### PR TITLE
feat: add per-widget background color configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibepanel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "vibepanel-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "thiserror",

--- a/crates/vibepanel-core/src/lib.rs
+++ b/crates/vibepanel-core/src/lib.rs
@@ -13,4 +13,4 @@ pub mod theme;
 
 pub use config::{Config, ConfigLoadResult, DEFAULT_CONFIG_TOML};
 pub use error::{Error, Result};
-pub use theme::{AccentSource, SurfaceStyles, ThemePalette, ThemeSizes};
+pub use theme::{AccentSource, SurfaceStyles, ThemePalette, ThemeSizes, parse_hex_color};

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -141,6 +141,11 @@ impl ConfigManager {
         self.config.borrow().bar.popover_offset
     }
 
+    /// Get the widget opacity from the current theme configuration.
+    pub fn widget_opacity(&self) -> f64 {
+        self.config.borrow().theme.widget_opacity
+    }
+
     /// Start watching the config file for changes.
     ///
     /// This spawns a background thread that monitors the config file. When changes

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -292,7 +292,17 @@ impl SurfaceStyleManager {
     ///
     /// The styles are applied with high priority to override GTK themes
     /// (like Tokyo Night) that may interfere with custom styling.
-    pub fn apply_surface_styles(&self, widget: &impl IsA<gtk4::Widget>, with_padding: bool) {
+    ///
+    /// # Arguments
+    /// * `widget` - The widget to style
+    /// * `with_padding` - Whether to apply padding to the widget
+    /// * `color_override` - Optional background color override (e.g., from parent widget)
+    pub fn apply_surface_styles(
+        &self,
+        widget: &impl IsA<gtk4::Widget>,
+        with_padding: bool,
+        color_override: Option<&str>,
+    ) {
         let widget = widget.as_ref();
 
         let styles = self.styles.borrow();
@@ -301,6 +311,9 @@ impl SurfaceStyleManager {
         } else {
             String::new()
         };
+
+        // Use color override if provided, otherwise use theme default
+        let bg = color_override.unwrap_or(&styles.background_color);
 
         // Build CSS targeting the widget's CSS name
         // For Popover, we need to target both the popover and its contents
@@ -345,9 +358,10 @@ popover.widget-menu.background > arrow {{
 popover.widget-menu *,
 popover.widget-menu.background * {{
     font-family: inherit;
+    color: inherit;
 }}
 "#,
-                bg = styles.background_color,
+                bg = bg,
                 radius = styles.border_radius,
                 font = styles.font_family,
                 fg = styles.text_color,
@@ -380,10 +394,11 @@ popover.widget-menu.background * {{
 
 {selector} * {{
     font-family: inherit;
+    color: inherit;
 }}
 "#,
                 selector = selector,
-                bg = styles.background_color,
+                bg = bg,
                 radius = styles.border_radius,
                 font = styles.font_family,
                 fg = styles.text_color,

--- a/crates/vibepanel/src/widgets/battery.rs
+++ b/crates/vibepanel/src/widgets/battery.rs
@@ -40,6 +40,8 @@ pub struct BatteryConfig {
     pub show_percentage: bool,
     /// Whether to show an icon.
     pub show_icon: bool,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for BatteryConfig {
@@ -61,6 +63,7 @@ impl WidgetConfig for BatteryConfig {
         Self {
             show_percentage,
             show_icon,
+            color: entry.color.clone(),
         }
     }
 }
@@ -70,6 +73,7 @@ impl Default for BatteryConfig {
         Self {
             show_percentage: DEFAULT_SHOW_PERCENTAGE,
             show_icon: DEFAULT_SHOW_ICON,
+            color: None,
         }
     }
 }
@@ -93,7 +97,7 @@ pub struct BatteryWidget {
 impl BatteryWidget {
     /// Create a new battery widget with the given configuration.
     pub fn new(config: BatteryConfig) -> Self {
-        let base = BaseWidget::new(&[widget::BATTERY]);
+        let base = BaseWidget::new(&[widget::BATTERY], config.color);
 
         // Initial tooltip until the first snapshot arrives.
         base.set_tooltip("Battery: unknown");
@@ -406,6 +410,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "battery".to_string(),
             options: Default::default(),
+            color: None,
         };
         let config = BatteryConfig::from_entry(&entry);
         assert!(config.show_percentage);

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -28,6 +28,8 @@ pub struct ClockConfig {
     pub format: String,
     /// Whether to show week numbers in the calendar popover.
     pub show_week_numbers: bool,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for ClockConfig {
@@ -50,6 +52,7 @@ impl WidgetConfig for ClockConfig {
         Self {
             format,
             show_week_numbers,
+            color: entry.color.clone(),
         }
     }
 }
@@ -59,6 +62,7 @@ impl Default for ClockConfig {
         Self {
             format: DEFAULT_FORMAT.to_string(),
             show_week_numbers: true,
+            color: None,
         }
     }
 }
@@ -80,7 +84,7 @@ pub struct ClockWidget {
 impl ClockWidget {
     /// Create a new clock widget with the given configuration.
     pub fn new(config: ClockConfig) -> Self {
-        let base = BaseWidget::new(&[wgt::CLOCK]);
+        let base = BaseWidget::new(&[wgt::CLOCK], config.color);
 
         let label = base.add_label(Some("--:--"), &[wgt::CLOCK_LABEL]);
 
@@ -170,6 +174,7 @@ mod tests {
         WidgetEntry {
             name: name.to_string(),
             options,
+            color: None,
         }
     }
 

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -32,6 +32,8 @@ pub struct CpuConfig {
     pub show_icon: bool,
     /// Whether to show the CPU usage percentage.
     pub show_percentage: bool,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for CpuConfig {
@@ -53,6 +55,7 @@ impl WidgetConfig for CpuConfig {
         Self {
             show_icon,
             show_percentage,
+            color: entry.color.clone(),
         }
     }
 }
@@ -62,6 +65,7 @@ impl Default for CpuConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             show_percentage: DEFAULT_SHOW_PERCENTAGE,
+            color: None,
         }
     }
 }
@@ -84,7 +88,7 @@ pub struct CpuWidget {
 impl CpuWidget {
     /// Create a new CPU widget with the given configuration.
     pub fn new(config: CpuConfig) -> Self {
-        let base = BaseWidget::new(&[widget::CPU]);
+        let base = BaseWidget::new(&[widget::CPU], config.color.clone());
 
         base.set_tooltip("CPU: unknown");
 
@@ -205,6 +209,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "cpu".to_string(),
             options: Default::default(),
+            color: None,
         };
         let config = CpuConfig::from_entry(&entry);
         assert!(config.show_icon);
@@ -220,6 +225,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "cpu".to_string(),
             options,
+            color: None,
         };
         let config = CpuConfig::from_entry(&entry);
         assert!(!config.show_icon);

--- a/crates/vibepanel/src/widgets/css.rs
+++ b/crates/vibepanel/src/widgets/css.rs
@@ -44,6 +44,7 @@ label link:active {
     padding: 4px;
     margin-top: -8px;
     border-radius: 50%;
+    color: var(--color-foreground-primary);
 }
 
 .vp-popover-icon-btn:hover {
@@ -381,6 +382,7 @@ button.vp-btn-link:hover,
 calendar.view {{
     background: transparent;
     border: none;
+    color: var(--color-foreground-primary);
 }}
 
 calendar.view grid {{

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -54,6 +54,8 @@ pub struct MemoryConfig {
     pub show_icon: bool,
     /// Display format for memory usage.
     pub format: MemoryFormat,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for MemoryConfig {
@@ -73,7 +75,11 @@ impl WidgetConfig for MemoryConfig {
             .map(MemoryFormat::from_str)
             .unwrap_or_default();
 
-        Self { show_icon, format }
+        Self {
+            show_icon,
+            format,
+            color: entry.color.clone(),
+        }
     }
 }
 
@@ -82,6 +88,7 @@ impl Default for MemoryConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             format: MemoryFormat::default(),
+            color: None,
         }
     }
 }
@@ -104,7 +111,7 @@ pub struct MemoryWidget {
 impl MemoryWidget {
     /// Create a new Memory widget with the given configuration.
     pub fn new(config: MemoryConfig) -> Self {
-        let base = BaseWidget::new(&[widget::MEMORY]);
+        let base = BaseWidget::new(&[widget::MEMORY], config.color.clone());
 
         base.set_tooltip("Memory: unknown");
 
@@ -231,6 +238,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "memory".to_string(),
             options: Default::default(),
+            color: None,
         };
         let config = MemoryConfig::from_entry(&entry);
         assert!(config.show_icon);
@@ -249,6 +257,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "memory".to_string(),
             options,
+            color: None,
         };
         let config = MemoryConfig::from_entry(&entry);
         assert!(!config.show_icon);

--- a/crates/vibepanel/src/widgets/notification.rs
+++ b/crates/vibepanel/src/widgets/notification.rs
@@ -20,16 +20,32 @@ use std::collections::HashSet;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
+use vibepanel_core::config::WidgetEntry;
 
 use crate::services::icons::IconHandle;
 use crate::services::notification::{NotificationService, URGENCY_CRITICAL};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::widget;
-use crate::widgets::BaseWidget;
 use crate::widgets::base::MenuHandle;
+use crate::widgets::{BaseWidget, WidgetConfig};
 
 use super::notification_popover::{ClosePopoverCallback, build_popover_content};
 use super::notification_toast::NotificationToastManager;
+
+/// Configuration for the notification widget.
+#[derive(Debug, Clone, Default)]
+pub struct NotificationConfig {
+    /// Custom background color for this widget.
+    pub color: Option<String>,
+}
+
+impl WidgetConfig for NotificationConfig {
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        Self {
+            color: entry.color.clone(),
+        }
+    }
+}
 
 /// Shared inner state for the notification widget.
 ///
@@ -261,8 +277,8 @@ pub struct NotificationWidget {
 
 impl NotificationWidget {
     /// Create a new notification widget.
-    pub fn new() -> Self {
-        let base = BaseWidget::new(&[widget::NOTIFICATION]);
+    pub fn new(config: NotificationConfig) -> Self {
+        let base = BaseWidget::new(&[widget::NOTIFICATION], config.color);
 
         // Create an overlay for badge on top of icon
         let overlay = Overlay::new();
@@ -390,6 +406,6 @@ impl NotificationWidget {
 
 impl Default for NotificationWidget {
     fn default() -> Self {
-        Self::new()
+        Self::new(NotificationConfig::default())
     }
 }

--- a/crates/vibepanel/src/widgets/notification_toast.rs
+++ b/crates/vibepanel/src/widgets/notification_toast.rs
@@ -146,7 +146,7 @@ impl NotificationToast {
         outer.add_css_class(notif::TOAST_CONTAINER);
 
         // Apply surface styling
-        SurfaceStyleManager::global().apply_surface_styles(&outer, false);
+        SurfaceStyleManager::global().apply_surface_styles(&outer, false, None);
 
         // Add urgency styling
         if notification.urgency == URGENCY_CRITICAL {

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -224,7 +224,7 @@ impl OsdOverlay {
         }
 
         // Apply theme surface styles for consistent popover appearance.
-        SurfaceStyleManager::global().apply_surface_styles(&container, true);
+        SurfaceStyleManager::global().apply_surface_styles(&container, true, None);
 
         // Child OSD widget.
         let osd_widget = OsdWidget::new(orientation, 24);

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -72,6 +72,8 @@ impl Default for QuickSettingsCardsConfig {
 pub struct QuickSettingsConfig {
     /// Which cards to show in the Quick Settings panel.
     pub cards: QuickSettingsCardsConfig,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for QuickSettingsConfig {
@@ -109,6 +111,7 @@ impl WidgetConfig for QuickSettingsConfig {
                 brightness: get_bool("brightness"),
                 power: get_bool("power"),
             },
+            color: entry.color.clone(),
         }
     }
 }
@@ -121,7 +124,7 @@ pub struct QuickSettingsWidget {
 impl QuickSettingsWidget {
     pub fn new(cfg: QuickSettingsConfig, qs_window: QuickSettingsWindowHandle) -> Self {
         let cards = &cfg.cards;
-        let base = BaseWidget::new(&[widget::QUICK_SETTINGS]);
+        let base = BaseWidget::new(&[widget::QUICK_SETTINGS], cfg.color);
 
         // Build icons only for enabled cards (order: Audio, Bluetooth, Wi-Fi, VPN)
         // Audio icon

--- a/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
@@ -273,7 +273,7 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice) -> gtk4::Widget {
         content_box.append(&action);
 
         panel.append(&content_box);
-        SurfaceStyleManager::global().apply_surface_styles(&panel, true);
+        SurfaceStyleManager::global().apply_surface_styles(&panel, true, None);
 
         popover.set_child(Some(&panel));
         popover.set_parent(btn);

--- a/crates/vibepanel/src/widgets/quick_settings/wifi_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/wifi_card.rs
@@ -579,7 +579,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
 
         panel.append(&content_box);
         let style_mgr = SurfaceStyleManager::global();
-        style_mgr.apply_surface_styles(&panel, true);
+        style_mgr.apply_surface_styles(&panel, true, None);
         style_mgr.apply_pango_attrs_all(&content_box);
 
         popover.set_child(Some(&panel));

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -321,7 +321,7 @@ impl QuickSettingsWindow {
         outer.set_margin_bottom(4);
         outer.set_margin_start(4);
         outer.set_margin_end(4);
-        SurfaceStyleManager::global().apply_surface_styles(&outer, true);
+        SurfaceStyleManager::global().apply_surface_styles(&outer, true, None);
 
         let content = GtkBox::new(Orientation::Vertical, 0);
         content.add_css_class(qs::CONTROL_CENTER);

--- a/crates/vibepanel/src/widgets/system_tray.rs
+++ b/crates/vibepanel/src/widgets/system_tray.rs
@@ -35,6 +35,8 @@ pub struct SystemTrayConfig {
     pub max_icons: usize,
     /// Icon size for pixmap icons (in pixels).
     pub pixmap_icon_size: i32,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl Default for SystemTrayConfig {
@@ -48,6 +50,7 @@ impl Default for SystemTrayConfig {
         Self {
             max_icons: DEFAULT_MAX_ICONS,
             pixmap_icon_size,
+            color: None,
         }
     }
 }
@@ -75,6 +78,7 @@ impl WidgetConfig for SystemTrayConfig {
         Self {
             max_icons,
             pixmap_icon_size,
+            color: entry.color.clone(),
         }
     }
 }
@@ -102,7 +106,7 @@ pub struct SystemTrayWidget {
 impl SystemTrayWidget {
     /// Create a new system tray widget.
     pub fn new(config: SystemTrayConfig) -> Self {
-        let base = BaseWidget::new(&[widget::TRAY]);
+        let base = BaseWidget::new(&[widget::TRAY], config.color.clone());
 
         let state = Rc::new(RefCell::new(WidgetState {
             config,
@@ -519,6 +523,15 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
         container.add_css_class(widget::TRAY_MENU);
         container.add_css_class(surface::POPOVER);
         container.add_css_class(surface::WIDGET_MENU_CONTENT);
+
+        // Apply surface styling with color override from widget config
+        let color_override = state_clone.borrow().config.color.clone();
+        SurfaceStyleManager::global().apply_surface_styles(
+            &container,
+            true,
+            color_override.as_deref(),
+        );
+
         popover.set_child(Some(&container));
 
         // Set up menu state

--- a/crates/vibepanel/src/widgets/updates.rs
+++ b/crates/vibepanel/src/widgets/updates.rs
@@ -32,6 +32,8 @@ pub struct UpdatesConfig {
     pub check_interval: u64,
     /// Override terminal emulator detection.
     pub terminal: Option<String>,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for UpdatesConfig {
@@ -54,6 +56,7 @@ impl WidgetConfig for UpdatesConfig {
         Self {
             check_interval,
             terminal,
+            color: entry.color.clone(),
         }
     }
 }
@@ -63,6 +66,7 @@ impl Default for UpdatesConfig {
         Self {
             check_interval: DEFAULT_CHECK_INTERVAL,
             terminal: None,
+            color: None,
         }
     }
 }
@@ -82,7 +86,7 @@ pub struct UpdatesWidget {
 impl UpdatesWidget {
     /// Create a new updates widget with the given configuration.
     pub fn new(config: UpdatesConfig) -> Self {
-        let base = BaseWidget::new(&[widget::UPDATES]);
+        let base = BaseWidget::new(&[widget::UPDATES], config.color);
         base.set_tooltip("Updates: checking...");
 
         let icon_handle = base.add_icon("software-update-available", &[widget::UPDATES_ICON]);
@@ -197,6 +201,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "updates".to_string(),
             options: Default::default(),
+            color: None,
         };
         let config = UpdatesConfig::from_entry(&entry);
 
@@ -216,6 +221,7 @@ mod tests {
         let entry = WidgetEntry {
             name: "updates".to_string(),
             options,
+            color: None,
         };
         let config = UpdatesConfig::from_entry(&entry);
 

--- a/crates/vibepanel/src/widgets/window_title.rs
+++ b/crates/vibepanel/src/widgets/window_title.rs
@@ -43,6 +43,8 @@ pub struct WindowTitleConfig {
     pub show_icon: bool,
     /// Whether to uppercase the title.
     pub uppercase: bool,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for WindowTitleConfig {
@@ -110,6 +112,7 @@ impl WidgetConfig for WindowTitleConfig {
             max_chars,
             show_icon,
             uppercase,
+            color: entry.color.clone(),
         }
     }
 }
@@ -123,6 +126,7 @@ impl Default for WindowTitleConfig {
             max_chars: DEFAULT_MAX_CHARS,
             show_icon: DEFAULT_SHOW_ICON,
             uppercase: DEFAULT_UPPERCASE,
+            color: None,
         }
     }
 }
@@ -140,7 +144,7 @@ impl WindowTitleWidget {
     /// used to filter window title updates to only show windows on this monitor.
     /// If `None`, the widget shows the globally focused window regardless of monitor.
     pub fn new(config: WindowTitleConfig, output_id: Option<String>) -> Self {
-        let base = BaseWidget::new(&[wgt::WINDOW_TITLE]);
+        let base = BaseWidget::new(&[wgt::WINDOW_TITLE], config.color.clone());
 
         // Use the content box provided by BaseWidget (has .content CSS class)
         let content = base.content();
@@ -503,6 +507,7 @@ mod tests {
         WidgetEntry {
             name: name.to_string(),
             options,
+            color: None,
         }
     }
 

--- a/crates/vibepanel/src/widgets/workspace.rs
+++ b/crates/vibepanel/src/widgets/workspace.rs
@@ -53,6 +53,8 @@ pub struct WorkspaceConfig {
     pub label_type: LabelType,
     /// Separator string between workspace indicators.
     pub separator: String,
+    /// Custom background color for this widget.
+    pub color: Option<String>,
 }
 
 impl WidgetConfig for WorkspaceConfig {
@@ -76,6 +78,7 @@ impl WidgetConfig for WorkspaceConfig {
         Self {
             label_type,
             separator,
+            color: entry.color.clone(),
         }
     }
 }
@@ -85,6 +88,7 @@ impl Default for WorkspaceConfig {
         Self {
             label_type: DEFAULT_LABEL_TYPE,
             separator: DEFAULT_SEPARATOR.to_string(),
+            color: None,
         }
     }
 }
@@ -106,7 +110,7 @@ impl WorkspaceWidget {
     ///   - For MangoWC: show all workspaces but with per-output window counts.
     ///   - For Hyprland: ignored (global workspace view).
     pub fn new(config: WorkspaceConfig, output_id: Option<String>) -> Self {
-        let base = BaseWidget::new(&[widget::WORKSPACE]);
+        let base = BaseWidget::new(&[widget::WORKSPACE], config.color);
 
         // Use the content box provided by BaseWidget
         let workspace_container = base.content().clone();
@@ -417,6 +421,7 @@ mod tests {
         WidgetEntry {
             name: name.to_string(),
             options,
+            color: None,
         }
     }
 


### PR DESCRIPTION
Allow setting custom background colors on individual widgets via the color option in [widgets.<name>] config sections. Colors inherit to widget popovers but not tooltips. Invalid hex colors trigger a warning at config load time.

Example:
  [widgets.clock]
  color = "#f5c2e7"