### PR TITLE
feat: simplify section configuration and add spacer widget

### DIFF
--- a/crates/vibepanel-core/tests/config_integration.rs
+++ b/crates/vibepanel-core/tests/config_integration.rs
@@ -265,31 +265,6 @@ fn test_validation_rejects_notch_enabled_with_center_widgets() {
 }
 
 #[test]
-fn test_validation_rejects_notch_disabled_with_center_split_widgets() {
-    // When notch_enabled=false, using widgets.center_left/center_right should be rejected
-    let toml = r#"
-        [bar]
-        notch_enabled = false
-        
-        [widgets]
-        center_left = ["clock"]
-    "#;
-
-    let config: Config = toml::from_str(toml).unwrap();
-    let result = config.validate();
-
-    assert!(
-        result.is_err(),
-        "notch_enabled=false with widgets.center_left should fail"
-    );
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("center_left") || err.contains("center_right"),
-        "Error should mention center_left/center_right"
-    );
-}
-
-#[test]
 fn test_validation_accepts_valid_enum_values() {
     // Test all valid enum combinations
     let toml = r#"
@@ -314,7 +289,7 @@ fn test_validation_accepts_valid_enum_values() {
         .validate()
         .expect("Valid config should pass validation");
 
-    // Also test other valid values
+    // Also test other valid values (notch mode with left/right sections)
     let toml2 = r#"
         [bar]
         notch_enabled = true
@@ -329,7 +304,8 @@ fn test_validation_accepts_valid_enum_values() {
         position = "top"
         
         [widgets]
-        center_left = ["clock"]
+        left = ["clock"]
+        right = ["battery"]
     "#;
 
     let config2: Config = toml::from_str(toml2).unwrap();

--- a/crates/vibepanel/src/sectioned_bar.rs
+++ b/crates/vibepanel/src/sectioned_bar.rs
@@ -24,6 +24,8 @@ mod imp {
     pub struct CenterPriorityLayout {
         pub spacing: Cell<i32>,
         pub edge_margin: Cell<i32>,
+        pub left_expand: Cell<bool>,
+        pub right_expand: Cell<bool>,
         // Last allocation positions and widths for snapshot/clipping
         pub last_left_x: Cell<i32>,
         pub last_left_width: Cell<i32>,
@@ -188,8 +190,10 @@ mod imp {
                 interior,
                 spacing,
                 left_sizes,
+                self.left_expand.get(),
                 center_sizes,
                 right_sizes,
+                self.right_expand.get(),
             );
 
             // Record last allocation for snapshot/clipping
@@ -242,10 +246,12 @@ glib::wrapper! {
 }
 
 impl CenterPriorityLayout {
-    pub fn new(spacing: i32, edge_margin: i32) -> Self {
+    pub fn new(spacing: i32, edge_margin: i32, left_expand: bool, right_expand: bool) -> Self {
         let obj: Self = glib::Object::builder().build();
         obj.imp().spacing.set(spacing);
         obj.imp().edge_margin.set(edge_margin);
+        obj.imp().left_expand.set(left_expand);
+        obj.imp().right_expand.set(right_expand);
         obj
     }
 
@@ -256,11 +262,19 @@ impl CenterPriorityLayout {
     pub fn set_edge_margin(&self, edge_margin: i32) {
         self.imp().edge_margin.set(edge_margin);
     }
+
+    pub fn set_left_expand(&self, expand: bool) {
+        self.imp().left_expand.set(expand);
+    }
+
+    pub fn set_right_expand(&self, expand: bool) {
+        self.imp().right_expand.set(expand);
+    }
 }
 
 impl Default for CenterPriorityLayout {
     fn default() -> Self {
-        Self::new(8, 12)
+        Self::new(8, 12, false, false)
     }
 }
 
@@ -334,9 +348,9 @@ glib::wrapper! {
 }
 
 impl SectionedBar {
-    pub fn new(spacing: i32, edge_margin: i32) -> Self {
+    pub fn new(spacing: i32, edge_margin: i32, left_expand: bool, right_expand: bool) -> Self {
         let obj: Self = glib::Object::builder().build();
-        let layout = CenterPriorityLayout::new(spacing, edge_margin);
+        let layout = CenterPriorityLayout::new(spacing, edge_margin, left_expand, right_expand);
         obj.set_layout_manager(Some(layout));
         obj
     }
@@ -389,6 +403,6 @@ impl SectionedBar {
 
 impl Default for SectionedBar {
     fn default() -> Self {
-        Self::new(8, 12)
+        Self::new(8, 12, false, false)
     }
 }

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -483,12 +483,6 @@ fn widget_names(config: &Config) -> Vec<String> {
     for w in &config.widgets.center {
         names.extend(format_item("center", w));
     }
-    for w in &config.widgets.center_left {
-        names.extend(format_item("center_left", w));
-    }
-    for w in &config.widgets.center_right {
-        names.extend(format_item("center_right", w));
-    }
     for w in &config.widgets.right {
         names.extend(format_item("right", w));
     }

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -58,15 +58,6 @@ pub mod class {
 
     /// Bar section center (`.bar-section--center`).
     pub const BAR_SECTION_CENTER: &str = "bar-section--center";
-
-    /// Bar section center-left (`.bar-section--center-left`).
-    pub const BAR_SECTION_CENTER_LEFT: &str = "bar-section--center-left";
-
-    /// Bar section center-right (`.bar-section--center-right`).
-    pub const BAR_SECTION_CENTER_RIGHT: &str = "bar-section--center-right";
-
-    /// Notch spacer (`.notch-spacer`).
-    pub const NOTCH_SPACER: &str = "notch-spacer";
 }
 
 /// Foreground/text color classes.
@@ -319,6 +310,10 @@ pub mod qs {
 
 /// Widget-specific CSS classes.
 pub mod widget {
+    // Spacer
+    /// Spacer widget (`.spacer`).
+    pub const SPACER: &str = "spacer";
+
     // Clock
     /// Clock widget (`.clock`).
     pub const CLOCK: &str = "clock";

--- a/crates/vibepanel/src/widgets/css.rs
+++ b/crates/vibepanel/src/widgets/css.rs
@@ -190,6 +190,7 @@ popover.widget-menu.background > contents {
 /// Generate all widget CSS.
 pub fn widget_css(config: &Config) -> String {
     let outer_margin = config.bar.outer_margin;
+    let widget_spacing = config.bar.widget_spacing;
 
     format!(
         r#"
@@ -234,6 +235,17 @@ sectioned-bar.bar {{
 .widget > .content > *:not(:last-child),
 .widget-group > .content .content > *:not(:last-child) {{
     margin-right: var(--spacing-widget-gap);
+}}
+
+/* Section widget spacing via margins (Box spacing=0 to allow spacer to have no gaps) */
+.bar-section--left > *:not(:last-child):not(.spacer),
+.bar-section--right > *:not(:last-child):not(.spacer) {{
+    margin-right: {widget_spacing}px;
+}}
+
+/* Spacer widget - no margins so it doesn't create extra gaps */
+.spacer {{
+    min-width: 0;
 }}
 
 /* ===== WORKSPACE ===== */

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -66,6 +66,7 @@ mod notification_common;
 mod notification_popover;
 mod notification_toast;
 mod osd;
+mod spacer;
 mod system_popover;
 mod system_tray;
 mod updates;
@@ -85,6 +86,7 @@ pub use notification::{NotificationConfig, NotificationWidget};
 pub use osd::OsdOverlay;
 pub use quick_settings::QuickSettingsWindowHandle;
 pub use quick_settings::{QuickSettingsConfig, QuickSettingsWidget};
+pub use spacer::{SpacerConfig, SpacerWidget};
 pub use system_tray::{SystemTrayConfig, SystemTrayWidget};
 pub use updates::{UpdatesConfig, UpdatesWidget};
 pub use window_title::{WindowTitleConfig, WindowTitleWidget};
@@ -302,6 +304,15 @@ impl WidgetFactory {
                 Some(BuiltWidget {
                     widget: root,
                     handle: Box::new(memory),
+                })
+            }
+            "spacer" => {
+                let cfg = SpacerConfig::from_entry(entry);
+                let spacer = SpacerWidget::new(cfg);
+                let root = spacer.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(spacer),
                 })
             }
             name => {

--- a/crates/vibepanel/src/widgets/spacer.rs
+++ b/crates/vibepanel/src/widgets/spacer.rs
@@ -1,0 +1,122 @@
+//! Spacer widget - a flexible or fixed-width empty space.
+//!
+//! The spacer widget is used to push other widgets apart in a section.
+//! It can either expand to fill available space (default) or have a fixed width.
+//!
+//! # Configuration
+//!
+//! The spacer supports inline width syntax:
+//! - `"spacer"` - expands to fill available space
+//! - `"spacer:50"` - fixed 50px width
+//!
+//! Or via options section:
+//! ```toml
+//! [widgets.spacer]
+//! width = 50
+//! ```
+//!
+//! # Example Usage
+//!
+//! Push a widget to the edge of the notch:
+//! ```toml
+//! [widgets]
+//! left = ["workspaces", "spacer", "clock"]  # clock ends up at right edge of left section
+//! ```
+
+use gtk4::prelude::*;
+use vibepanel_core::config::WidgetEntry;
+
+use crate::styles::widget as wgt;
+use crate::widgets::{WidgetConfig, warn_unknown_options};
+
+/// Configuration for the spacer widget.
+///
+/// Note: Unlike other widgets, SpacerConfig intentionally omits the `color` field
+/// since the spacer is invisible by design and cannot be styled.
+#[derive(Debug, Clone, Default)]
+pub struct SpacerConfig {
+    /// Fixed width in pixels, or None for flexible (expand to fill).
+    pub width: Option<u32>,
+}
+
+impl WidgetConfig for SpacerConfig {
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        warn_unknown_options("spacer", entry, &["width"]);
+
+        let width = entry
+            .options
+            .get("width")
+            .and_then(|v| v.as_integer())
+            .and_then(|n| u32::try_from(n).ok());
+
+        SpacerConfig { width }
+    }
+}
+
+/// Spacer widget - either expands to fill space or has a fixed width.
+///
+/// Note: This widget intentionally does not use `BaseWidget` because it has no
+/// visible content, styling, tooltips, or click interactions - it's purely a
+/// layout primitive.
+pub struct SpacerWidget {
+    widget: gtk4::Box,
+}
+
+impl SpacerWidget {
+    /// Create a new spacer widget with the given configuration.
+    pub fn new(config: SpacerConfig) -> Self {
+        let widget = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+        widget.add_css_class(wgt::SPACER);
+
+        match config.width {
+            Some(fixed_width) => {
+                // Fixed width: set exact size, no expansion
+                widget.set_size_request(fixed_width as i32, -1);
+                widget.set_hexpand(false);
+            }
+            None => {
+                // Flexible: expand to fill available space
+                widget.set_hexpand(true);
+                // Minimum width of 0 so it can shrink completely if needed
+                widget.set_size_request(0, -1);
+            }
+        }
+
+        SpacerWidget { widget }
+    }
+
+    /// Get the GTK widget.
+    pub fn widget(&self) -> &gtk4::Box {
+        &self.widget
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_entry(options: HashMap<String, toml::Value>) -> WidgetEntry {
+        WidgetEntry {
+            name: "spacer".to_string(),
+            options,
+            color: None,
+        }
+    }
+
+    #[test]
+    fn test_spacer_config_default() {
+        let entry = make_entry(HashMap::new());
+        let config = SpacerConfig::from_entry(&entry);
+        assert_eq!(config.width, None);
+    }
+
+    #[test]
+    fn test_spacer_config_options() {
+        let mut options = HashMap::new();
+        options.insert("width".to_string(), toml::Value::Integer(100));
+        let entry = make_entry(options);
+        let config = SpacerConfig::from_entry(&entry);
+        assert_eq!(config.width, Some(100));
+    }
+}

--- a/crates/vibepanel/src/widgets/window_title.rs
+++ b/crates/vibepanel/src/widgets/window_title.rs
@@ -175,7 +175,6 @@ impl WindowTitleWidget {
         let label = Label::new(Some(&config.empty_text));
         label.add_css_class(wgt::WINDOW_TITLE_LABEL);
         label.set_xalign(0.0);
-        label.set_hexpand(true);
         // Always use ellipsization at the end so long titles
         // show "…" instead of being hard-clipped by section bounds.
         label.set_ellipsize(gtk4::pango::EllipsizeMode::End);

--- a/crates/vibepanel/src/widgets/workspace.rs
+++ b/crates/vibepanel/src/widgets/workspace.rs
@@ -191,7 +191,6 @@ fn create_indicators(
         label.add_css_class(widget::WORKSPACE_INDICATOR);
         label.add_css_class(state::CLICKABLE);
         label.set_valign(Align::Center);
-        label.set_hexpand(true);
         label.set_xalign(0.5);
         label.set_ellipsize(EllipsizeMode::End);
         label.set_single_line_mode(true);


### PR DESCRIPTION
Replace center_left/center_right sections with a universal spacer widget that can be placed anywhere to control layout. This simplifies notch mode configuration from 5 sections to 3 (left, center, right).

- Add spacer widget with flexible (expand) or fixed width modes
- Support inline width syntax (e.g., "spacer:50")
- Remove center_left/center_right config sections
- Move widget spacing from GTK Box to CSS margins (enables spacer exclusion)
- Update layout manager to respect section expander state