### PR TITLE
fix(workspace): multi-tag view in Mango/DWL workspace widget

### DIFF
--- a/crates/vibepanel/src/services/compositor/niri.rs
+++ b/crates/vibepanel/src/services/compositor/niri.rs
@@ -161,7 +161,7 @@ impl NiriBackend {
         snapshot.occupied_workspaces.clear();
         snapshot.urgent_workspaces.clear();
         snapshot.window_counts.clear();
-        snapshot.active_workspace = None;
+        snapshot.active_workspace.clear();
         snapshot.per_output.clear();
 
         for ws in workspaces {
@@ -207,7 +207,7 @@ impl NiriBackend {
                 .unwrap_or(false);
 
             if is_focused {
-                snapshot.active_workspace = Some(idx);
+                snapshot.active_workspace.insert(idx);
             }
 
             if ws
@@ -228,7 +228,7 @@ impl NiriBackend {
 
                 // is_active means visible on this output, is_focused means globally focused
                 if is_active {
-                    per_out.active_workspace = Some(idx);
+                    per_out.active_workspace.insert(idx);
                 }
             }
         }
@@ -449,8 +449,9 @@ impl NiriBackend {
                     let mut snapshot = shared.workspace_snapshot.write();
 
                     // Update global active workspace if this is the focused one
-                    if is_focused && snapshot.active_workspace != Some(idx) {
-                        snapshot.active_workspace = Some(idx);
+                    if is_focused && !snapshot.active_workspace.contains(&idx) {
+                        snapshot.active_workspace.clear();
+                        snapshot.active_workspace.insert(idx);
                         workspace_changed = true;
                     }
 
@@ -458,9 +459,10 @@ impl NiriBackend {
                     // WorkspaceActivated fires when a workspace becomes visible on its output
                     if let Some(out_name) = id_to_output.get(&ws_id)
                         && let Some(per_out) = snapshot.per_output.get_mut(out_name)
-                        && per_out.active_workspace != Some(idx)
+                        && !per_out.active_workspace.contains(&idx)
                     {
-                        per_out.active_workspace = Some(idx);
+                        per_out.active_workspace.clear();
+                        per_out.active_workspace.insert(idx);
                         workspace_changed = true;
                     }
                 }


### PR DESCRIPTION
Previously, only one tag was marked active in the workspace widget when viewing multiple tags simultaneously in Mango/DWL. This was because the data model used Option<i32> for active_workspace, which could only store a single workspace ID.

Changed active_workspace from Option<i32> to HashSet<i32> in:
- PerOutputState and WorkspaceSnapshot (types.rs)
- PerOutputWorkspaces and WorkspaceServiceSnapshot (workspace.rs service)

Updated all backends (mango.rs, niri.rs, hyprland.rs) to use the new HashSet type. For Niri and Hyprland, this is functionally equivalent since they only have one active workspace at a time.

Added 12 new tests covering active workspace functionality for single, multiple, and no active workspace scenarios.