### PR TITLE
refactor(config): remove notch mode in favor of spacer

### DIFF
--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -259,18 +259,6 @@ impl Config {
             ));
         }
 
-        // Validate center widget configuration based on notch mode
-        let has_center = !self.widgets.center.is_empty();
-
-        if self.bar.notch_enabled && has_center {
-            // In notch mode, center section is reserved for the notch spacer
-            errors.push(
-                "widgets.center: cannot be used when notch_enabled=true; \
-                 use spacer widget in left/right sections to place widgets near the notch"
-                    .to_string(),
-            );
-        }
-
         if errors.is_empty() {
             Ok(())
         } else {
@@ -321,15 +309,6 @@ impl Config {
         lines.push(format!("  spacing: {}px", self.bar.spacing));
         lines.push(format!("  screen_margin: {}px", self.bar.screen_margin));
         lines.push(format!(
-            "  notch: {} (width: {}px)",
-            if self.bar.notch_enabled {
-                "enabled"
-            } else {
-                "disabled"
-            },
-            self.bar.notch_width
-        ));
-        lines.push(format!(
             "  background_opacity: {}",
             self.bar.background_opacity
         ));
@@ -349,19 +328,12 @@ impl Config {
             lines.push(format!("    - {}", name));
         }
 
-        if self.bar.notch_enabled {
-            lines.push(format!(
-                "  center: notch spacer ({}px)",
-                self.bar.notch_width
-            ));
-        } else {
-            lines.push(format!(
-                "  center: {} widget(s)",
-                count_widgets(&self.widgets.center)
-            ));
-            for name in format_widget_section(&self.widgets.center) {
-                lines.push(format!("    - {}", name));
-            }
+        lines.push(format!(
+            "  center: {} widget(s)",
+            count_widgets(&self.widgets.center)
+        ));
+        for name in format_widget_section(&self.widgets.center) {
+            lines.push(format!("    - {}", name));
         }
 
         lines.push(format!(
@@ -437,13 +409,6 @@ pub struct BarConfig {
     /// Distance from bar edge to first/last section in pixels.
     pub inset: u32,
 
-    /// Whether notch mode is enabled.
-    pub notch_enabled: bool,
-
-    /// Width of the notch spacer in pixels.
-    /// Default: 200
-    pub notch_width: u32,
-
     /// Border radius (percentage of bar height).
     pub border_radius: u32,
 
@@ -473,8 +438,6 @@ impl Default for BarConfig {
             spacing: 8,
             screen_margin: 4,
             inset: 8,
-            notch_enabled: false,
-            notch_width: 200,
             border_radius: 30,
             popover_offset: 1,
             outputs: Vec::new(),
@@ -515,7 +478,6 @@ pub struct WidgetsConfig {
 
     /// Widgets in the center section.
     /// Each entry is a widget name string or a group of widget names.
-    /// Note: Cannot be used when notch_enabled = true (center is reserved for notch spacer).
     pub center: Vec<WidgetPlacement>,
 
     /// Widgets in the right section.
@@ -1466,9 +1428,8 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_center_without_notch_ok() {
+    fn test_validate_center_widgets_ok() {
         let mut config = Config::default();
-        config.bar.notch_enabled = false;
         config
             .widgets
             .center
@@ -1478,45 +1439,9 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_center_with_notch_error() {
-        let mut config = Config::default();
-        config.bar.notch_enabled = true;
-        config
-            .widgets
-            .center
-            .push(WidgetPlacement::Single("clock".to_string()));
-
-        let result = config.validate();
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("widgets.center"));
-        assert!(msg.contains("notch_enabled=true"));
-    }
-
-    #[test]
-    fn test_validate_notch_mode_empty_center_ok() {
-        // Notch mode with empty center section is valid
-        let mut config = Config::default();
-        config.bar.notch_enabled = true;
-        // No widgets in center - this is correct for notch mode
-        config
-            .widgets
-            .left
-            .push(WidgetPlacement::Single("clock".to_string()));
-
-        assert!(config.validate().is_ok());
-    }
-
-    #[test]
-    fn test_validate_empty_center_sections_ok() {
-        // Empty center sections should be valid in either mode
-        let mut config = Config::default();
-        config.bar.notch_enabled = false;
-        assert!(config.validate().is_ok());
-
-        config.bar.notch_enabled = true;
+    fn test_validate_empty_center_ok() {
+        // Empty center section should be valid
+        let config = Config::default();
         assert!(config.validate().is_ok());
     }
 

--- a/crates/vibepanel-core/tests/config_integration.rs
+++ b/crates/vibepanel-core/tests/config_integration.rs
@@ -236,41 +236,9 @@ fn test_validation_rejects_invalid_osd_position() {
 }
 
 #[test]
-fn test_validation_rejects_notch_enabled_with_center_widgets() {
-    // When notch_enabled=true, using widgets.center should be rejected
-    let toml = r#"
-        [bar]
-        notch_enabled = true
-        
-        [widgets]
-        center = ["clock"]
-    "#;
-
-    let config: Config = toml::from_str(toml).unwrap();
-    let result = config.validate();
-
-    assert!(
-        result.is_err(),
-        "notch_enabled=true with widgets.center should fail"
-    );
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("widgets.center"),
-        "Error should mention widgets.center"
-    );
-    assert!(
-        err.contains("notch_enabled"),
-        "Error should mention notch_enabled"
-    );
-}
-
-#[test]
 fn test_validation_accepts_valid_enum_values() {
     // Test all valid enum combinations
     let toml = r#"
-        [bar]
-        notch_enabled = false
-        
         [theme]
         mode = "dark"
         
@@ -289,11 +257,8 @@ fn test_validation_accepts_valid_enum_values() {
         .validate()
         .expect("Valid config should pass validation");
 
-    // Also test other valid values (notch mode with left/right sections)
+    // Also test other valid values
     let toml2 = r#"
-        [bar]
-        notch_enabled = true
-        
         [theme]
         mode = "light"
         

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -124,10 +124,9 @@ pub fn create_bar_window(
     let left_section = create_section("left", config, state, &qs_handle, Some(output_id));
     bar_box.set_start_widget(Some(&left_section));
 
-    // Create center section only if notch is enabled or there are center widgets
+    // Create center section only if there are center widgets
     // Without a center widget, the layout manager uses linear allocation
-    let has_center_content =
-        config.bar.notch_enabled || !config.widgets.resolved_center().is_empty();
+    let has_center_content = !config.widgets.resolved_center().is_empty();
     if has_center_content {
         let center_section = create_center_section(config, state, &qs_handle, Some(output_id));
         bar_box.set_center_widget(Some(&center_section));
@@ -273,7 +272,7 @@ fn create_section(
     section
 }
 
-/// Create the center section, optionally with notch spacer.
+/// Create the center section with widgets.
 fn create_center_section(
     config: &Config,
     state: &mut BarState,
@@ -283,23 +282,12 @@ fn create_center_section(
     let section = gtk4::Box::new(gtk4::Orientation::Horizontal, config.bar.spacing as i32);
     section.add_css_class(class::BAR_SECTION_CENTER);
 
-    if config.bar.notch_enabled {
-        // Notch mode: center section is just a fixed-width empty spacer for the notch.
-        // Users place widgets adjacent to the notch using the spacer widget in left/right sections.
-        let notch_width = config.bar.notch_width;
-        section.set_size_request(notch_width as i32, -1);
-
-        debug!("Notch mode: {}px center spacer", notch_width);
-    } else {
-        // Non-notch mode: simple centered section with widgets
-        let mut widget_count = 0;
-        for item in &config.widgets.resolved_center() {
-            widget_count += build_widget_or_group(item, &section, state, qs_handle, output_id);
-        }
-
-        debug!("Created center section with {} widget(s)", widget_count);
+    let mut widget_count = 0;
+    for item in &config.widgets.resolved_center() {
+        widget_count += build_widget_or_group(item, &section, state, qs_handle, output_id);
     }
 
+    debug!("Created center section with {} widget(s)", widget_count);
     section
 }
 

--- a/crates/vibepanel/src/services/bar_manager.rs
+++ b/crates/vibepanel/src/services/bar_manager.rs
@@ -17,7 +17,6 @@
 //! This allows live reload of structural changes like:
 //! - Bar size, layout, margins
 //! - Widget list changes
-//! - Notch settings
 //! - Output allow-list changes
 
 use std::cell::RefCell;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -14,8 +14,8 @@
 //!
 //! - `icons.*`: Switches icon backend (Material ↔ GTK themes) and weight
 //! - `theme.*`: Updates colors, palette, CSS variables
-//! - Structural changes (widget list, layout, bar size, margins, notch settings)
-//!   trigger a full bar rebuild with a brief visual flicker.
+//! - Structural changes (widget list, layout, bar size, margins) trigger a full
+//!   bar rebuild with a brief visual flicker.
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -419,19 +419,6 @@ fn config_structure_changed(old: &Config, new: &Config) -> bool {
 
     if old.bar.inset != new.bar.inset {
         debug!("bar.inset changed ({} -> {})", old.bar.inset, new.bar.inset);
-        return true;
-    }
-
-    if old.bar.notch_enabled != new.bar.notch_enabled {
-        debug!("bar.notch_enabled changed");
-        return true;
-    }
-
-    if old.bar.notch_width != new.bar.notch_width {
-        debug!(
-            "bar.notch_width changed ({} -> {})",
-            old.bar.notch_width, new.bar.notch_width
-        );
         return true;
     }
 

--- a/crates/vibepanel/src/widgets/spacer.rs
+++ b/crates/vibepanel/src/widgets/spacer.rs
@@ -17,10 +17,16 @@
 //!
 //! # Example Usage
 //!
-//! Push a widget to the edge of the notch:
+//! Push a widget to the right edge of a section:
 //! ```toml
 //! [widgets]
 //! left = ["workspaces", "spacer", "clock"]  # clock ends up at right edge of left section
+//! ```
+//!
+//! Create a gap in the center (e.g., for a display notch):
+//! ```toml
+//! [widgets]
+//! center = ["spacer:200"]  # 200px fixed-width spacer in center
 //! ```
 
 use gtk4::prelude::*;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,7 @@ crates/vibepanel/src/
   main.rs           # Entry point, CLI, GTK app setup
   bar.rs            # Bar window creation, CSS loading
   sectioned_bar.rs  # Layout widget for left/center/right sections
-  layout_math.rs    # Notch/island layout calculations
+  layout_math.rs    # Layout calculations for sections/islands
   styles.rs         # CSS class name constants
   services.rs       # Service module exports
   services/


### PR DESCRIPTION
The dedicated notch mode added complexity without providing benefits over
the more flexible spacer widget approach. Users can achieve the same layout
by placing a fixed-width spacer in the center section (e.g., `center = ["spacer:200"]`).
BREAKING CHANGE: `notch_enabled` and `notch_width` options have been removed
from [bar] config. Remove these fields and use `center = ["spacer:WIDTH"]` instead