### PR TITLE
fix(media): debounce hide and album art to prevent flicker

### DIFF
--- a/crates/vibepanel/src/services/media.rs
+++ b/crates/vibepanel/src/services/media.rs
@@ -173,9 +173,12 @@ impl Default for MediaSnapshot {
 }
 
 impl MediaSnapshot {
-    /// Create an empty snapshot (no player available).
-    pub fn empty() -> Self {
-        Self::default()
+    /// Whether the snapshot contains meaningful track metadata (i.e. a non-empty title).
+    pub fn has_metadata(&self) -> bool {
+        self.metadata
+            .title
+            .as_ref()
+            .is_some_and(|t| !t.trim().is_empty())
     }
 }
 


### PR DESCRIPTION
Add a 500ms grace period before hiding the media widget and a 200ms debounce on album art loading. Some MPRIS players briefly report intermediate states during track switches, causing the widget to flicker off/on and flash wrong album art.

- Extract `perform_hide` to share hide logic between startup and timer
- Add `prepare_art_load` / `debounced_load` to ArtState with proper cancellation and Drop cleanup
- Skip text/art updates when metadata is momentarily empty, keeping stale-but-recent track info visible during transitions
- Add unit tests for art load state transitions