### PR TITLE
feat(widgets): add custom widget

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,24 @@ background_opacity = 1.0
 #   [widgets.battery]
 #   disabled = true
 #
+# Custom widgets use the "custom-" prefix for user-defined buttons:
+#   right = ["custom-power", "tray", "clock"]
+#
+#   [widgets.custom-power]
+#   icon = "system-shutdown-symbolic"
+#   label = "Power"
+#   tooltip = "Power menu"
+#   on_click = "wlogout"
+#   on_click_right = "systemctl suspend"
+#
+#   [widgets.custom-weather]
+#   exec = "curl -s 'wttr.in/?format=1'"
+#   template = " {output}"
+#   interval = 600
+#   on_click = "xdg-open https://wttr.in"
+#   tooltip = "Weather"
+#   max_chars = 30
+#
 # See documentation for all widget options.
 
 [theme]

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -2084,4 +2084,48 @@ mod tests {
             warnings
         );
     }
+
+    // --- Custom widget show_if config tests ---
+
+    #[test]
+    fn test_show_if_on_custom_widget_parsed() {
+        let toml = r#"
+            [widgets]
+            right = ["custom-power"]
+
+            [widgets.custom-power]
+            icon = "system-shutdown-symbolic"
+            show_if = "command -v wlogout"
+        "#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        let opts = config.widgets.get_options("custom-power").unwrap();
+        assert_eq!(opts.show_if, Some("command -v wlogout".to_string()));
+    }
+
+    #[test]
+    fn test_show_if_with_interval_on_custom_widget() {
+        let toml = r#"
+            [widgets]
+            right = ["custom-weather"]
+
+            [widgets.custom-weather]
+            exec = "curl -s wttr.in"
+            interval = 600
+            show_if = "ping -c1 -W1 1.1.1.1"
+            show_if_interval = 60
+        "#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        let opts = config.widgets.get_options("custom-weather").unwrap();
+        assert_eq!(opts.show_if, Some("ping -c1 -W1 1.1.1.1".to_string()));
+        assert_eq!(opts.show_if_interval, Some(60));
+        // show_if_interval without show_if warning should NOT fire here
+        let warnings = config.warnings();
+        assert!(
+            !warnings.iter().any(|w| w.contains("show_if_interval")),
+            "unexpected warning: {:?}",
+            warnings
+        );
+    }
 }

--- a/crates/vibepanel/src/services/icons.rs
+++ b/crates/vibepanel/src/services/icons.rs
@@ -99,8 +99,9 @@ fn register_font_with_pango(font_path: &std::path::Path) -> bool {
 
 /// Maps logical icon names to Material Symbols glyph names.
 ///
-/// `scripts/subset-font.sh` extracts glyph names from match arms in this
-/// function. Keep the structure as flat `"key" => "value"` arms.
+/// Delegates to `material_symbol_lookup()` for the actual mapping table.
+/// `scripts/subset-font.sh` extracts glyph names from match arms in
+/// `material_symbol_lookup()`. Keep the structure as flat `"key" => "value"` arms.
 ///
 /// Material Symbols uses ligatures: setting the label text to "battery_full"
 /// renders the battery_full glyph. This mapping converts our canonical names
@@ -112,7 +113,24 @@ fn register_font_with_pango(font_path: &std::path::Path) -> bool {
 ///   - Plus "-charging" variants for each level
 ///   - battery-missing for unknown state
 pub fn material_symbol_name(icon_name: &str) -> &str {
-    match icon_name {
+    if let Some(mapped) = material_symbol_lookup(icon_name) {
+        return mapped;
+    }
+
+    // Fallback: pass through unchanged (warns since unmapped names won't render in subset font)
+    warn!("No Material Symbol mapping for '{icon_name}'; icon may not render (font is subset)");
+    icon_name
+}
+
+/// Look up the Material Symbol glyph name for a logical icon name.
+///
+/// Returns `Some(glyph_name)` if a mapping exists, `None` if the icon name
+/// has no known Material Symbol equivalent.
+///
+/// This is the single source of truth for the icon mapping table.
+/// `material_symbol_name()` wraps this with a fallback + warning for unmapped names.
+fn material_symbol_lookup(icon_name: &str) -> Option<&'static str> {
+    let result = match icon_name {
         // Battery (discharging) - 8 levels for granular display
         "battery-full" => "battery_full",
         "battery-high" => "battery_6_bar",
@@ -294,14 +312,16 @@ pub fn material_symbol_name(icon_name: &str) -> &str {
         // Loading / progress spinner
         "process-working-symbolic" => "progress_activity",
 
-        // Fallback: pass through unchanged (warns since unmapped names won't render in subset font)
-        _ => {
-            warn!(
-                "No Material Symbol mapping for '{icon_name}'; icon may not render (font is subset)"
-            );
-            icon_name
-        }
-    }
+        // No mapping found
+        _ => return None,
+    };
+    Some(result)
+}
+
+/// Returns whether `icon_name` has a Material Symbol mapping.
+/// Unlike `material_symbol_name()`, does not log a warning for unmapped names.
+pub(crate) fn has_material_mapping(icon_name: &str) -> bool {
+    material_symbol_lookup(icon_name).is_some()
 }
 
 /// Maps logical icon names to a list of GTK icon name candidates.

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -561,6 +561,11 @@ pub mod widget {
 
     /// Memory high usage state (`.memory-high`).
     pub const MEMORY_HIGH: &str = "memory-high";
+
+    // Custom
+    /// Custom widget prefix (`.custom-<name>`).
+    /// Each instance gets a dynamic `custom-{id}` class built from this prefix.
+    pub const CUSTOM_PREFIX: &str = "custom-";
 }
 
 /// Surface and popover classes.

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -223,8 +223,27 @@ impl Dismissible for MenuHandle {
     }
 }
 
+/// Describe a process exit status in human-readable form.
+///
+/// Translates well-known shell exit codes (127 = command not found,
+/// 126 = permission denied) into actionable messages.
+pub(super) fn describe_exit_status(status: std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(127) => "command not found".to_string(),
+        Some(126) => "permission denied (not executable)".to_string(),
+        Some(code) => format!("exit code {code}"),
+        None => {
+            use std::os::unix::process::ExitStatusExt;
+            match status.signal() {
+                Some(sig) => format!("killed by signal {sig}"),
+                None => "unknown exit status".to_string(),
+            }
+        }
+    }
+}
+
 /// Spawn a shell command, reaping the child process in a background thread.
-fn spawn_click_command(cmd: &str) {
+fn spawn_click_command(widget_name: &str, cmd: &str) {
     match Command::new("sh")
         .args(["-c", cmd])
         .stdin(Stdio::null())
@@ -233,13 +252,36 @@ fn spawn_click_command(cmd: &str) {
         .spawn()
     {
         Ok(mut child) => {
+            let widget_name = widget_name.to_string();
+            let cmd = cmd.to_string();
             // Reap the child in a background thread to avoid zombie processes
-            std::thread::spawn(move || {
-                let _ = child.wait();
+            std::thread::spawn(move || match child.wait() {
+                Ok(status) if !status.success() => {
+                    tracing::warn!(
+                        "'{}' click command '{}' failed: {}",
+                        widget_name,
+                        cmd,
+                        describe_exit_status(status)
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "'{}' click command '{}' wait failed: {}",
+                        widget_name,
+                        cmd,
+                        e
+                    );
+                }
+                _ => {}
             });
         }
         Err(e) => {
-            tracing::warn!("Failed to spawn click command '{}': {}", cmd, e);
+            tracing::warn!(
+                "'{}' failed to spawn click command '{}': {}",
+                widget_name,
+                cmd,
+                e
+            );
         }
     }
 }
@@ -314,6 +356,7 @@ impl BaseWidget {
         gesture_click.set_button(0);
         {
             let menu_for_cb = menu.clone();
+            let widget_name_for_cb = widget_name.clone();
             // Use connect_released for immediate response without double-click detection delay
             gesture_click.connect_released(move |gesture, n_press, x, y| {
                 debug!(
@@ -374,13 +417,13 @@ impl BaseWidget {
                     gdk::BUTTON_MIDDLE => {
                         if let Some(ref cmd) = on_click_middle {
                             debug!("BaseWidget middle-click: sh -c {}", cmd);
-                            spawn_click_command(cmd);
+                            spawn_click_command(&widget_name_for_cb, cmd);
                         }
                     }
                     gdk::BUTTON_SECONDARY => {
                         if let Some(ref cmd) = on_click_right {
                             debug!("BaseWidget right-click: sh -c {}", cmd);
-                            spawn_click_command(cmd);
+                            spawn_click_command(&widget_name_for_cb, cmd);
                         }
                     }
                     _ => {}
@@ -529,6 +572,16 @@ impl BaseWidget {
         Some(source_id)
     }
 
+    /// Cancel the periodic `show_if` timer, if any.
+    ///
+    /// Used by widgets that handle `show_if` themselves (e.g., custom widgets
+    /// piggyback on their exec polling cycle instead of running a separate timer).
+    pub(super) fn cancel_show_if_timer(&mut self) {
+        if let Some(source_id) = self._show_if_timer.take() {
+            source_id.remove();
+        }
+    }
+
     /// Run a `show_if` shell command synchronously with a timeout.
     /// Returns `(visible, stderr)` where visible = exit 0.
     /// Commands exceeding `SHOW_IF_TIMEOUT_SECS` are killed and treated as hidden.
@@ -579,6 +632,21 @@ impl BaseWidget {
             }
             Err(_) => (false, String::new()),
         }
+    }
+
+    /// Run a `show_if` shell command synchronously (no timeout).
+    /// Returns `(visible, stderr)` where visible = exit 0.
+    pub(super) fn run_show_if_command(cmd: &str) -> (bool, String) {
+        Command::new("sh")
+            .args(["-c", cmd])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .output()
+            .map(|o| {
+                let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
+                (o.status.success(), stderr)
+            })
+            .unwrap_or((false, String::new()))
     }
 
     /// Get the root GTK container for this widget.

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -1,0 +1,714 @@
+//! Custom widget - user-defined icon/label with optional script polling and click actions.
+//!
+//! Supports multiple instances via the `custom-` naming prefix.
+//! Each `custom-<name>` entry becomes its own widget with a unique CSS class.
+//!
+//! `on_click` is custom-widget-specific (runs the command, then refreshes `exec`
+//! output). `on_click_right` and `on_click_middle` are handled by BaseWidget and
+//! available on all widgets.
+//!
+//! Configuration example:
+//! ```toml
+//! [widgets]
+//! right = ["custom-power", "custom-weather", "clock"]
+//!
+//! [widgets.custom-power]
+//! icon = "system-shutdown-symbolic"
+//! label = "Power"
+//! tooltip = "Power menu"
+//! on_click = "wlogout"
+//! # on_click_right and on_click_middle are available on all widgets
+//! on_click_right = "systemctl suspend"
+//!
+//! [widgets.custom-weather]
+//! exec = "curl -s 'wttr.in/?format=1'"
+//! template = " {output}"
+//! interval = 600
+//! on_click = "xdg-open https://wttr.in"
+//! tooltip = "Weather"
+//! max_chars = 30
+//! ```
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::gio;
+use gtk4::glib::{self, SourceId};
+use gtk4::prelude::*;
+use gtk4::{GestureClick, Label, gdk};
+use tracing::{debug, warn};
+use vibepanel_core::config::WidgetEntry;
+
+use crate::services::config_manager::ConfigManager;
+use crate::services::icons::{IconHandle, has_material_mapping};
+use crate::styles::{state, widget as wgt};
+use crate::widgets::base::{BaseWidget, describe_exit_status};
+use crate::widgets::{WidgetConfig, warn_unknown_options};
+
+/// Known config keys for the custom widget.
+const KNOWN_OPTIONS: &[&str] = &[
+    "icon",
+    "label",
+    "exec",
+    "template",
+    "interval",
+    "on_click",
+    "tooltip",
+    "max_chars",
+];
+
+/// Default exec timeout in seconds.
+const EXEC_TIMEOUT_SECS: u64 = 10;
+
+/// Configuration for a custom widget instance.
+#[derive(Debug, Clone, Default)]
+pub struct CustomConfig {
+    /// Logical icon name via `IconsService` (e.g., "system-shutdown-symbolic").
+    pub icon: Option<String>,
+    /// Static/fallback label text. Supports emoji, Nerd Font glyphs, Unicode.
+    pub label: String,
+    /// Shell command whose first line of stdout replaces the label text.
+    pub exec: Option<String>,
+    /// Template for formatting exec output. `{output}` is replaced by the
+    /// first line of exec stdout. When absent, exec output replaces the
+    /// label wholesale.
+    pub template: Option<String>,
+    /// Polling interval in seconds. 0 = run once at startup.
+    pub interval: u64,
+    /// Shell command to execute on left click.
+    pub on_click: Option<String>,
+    /// Static tooltip text.
+    pub tooltip: Option<String>,
+    /// Truncate label to N characters with ellipsis.
+    pub max_chars: Option<i32>,
+}
+
+impl WidgetConfig for CustomConfig {
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        warn_unknown_options(&entry.name, entry, KNOWN_OPTIONS);
+
+        let icon = entry
+            .options
+            .get("icon")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let label = entry
+            .options
+            .get("label")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let exec = entry
+            .options
+            .get("exec")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let template = entry
+            .options
+            .get("template")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let interval = entry
+            .options
+            .get("interval")
+            .and_then(toml::Value::as_integer)
+            .map_or(0, |v| u64::try_from(v.max(0)).unwrap_or(0));
+
+        let on_click = entry
+            .options
+            .get("on_click")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let tooltip = entry
+            .options
+            .get("tooltip")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let max_chars = entry
+            .options
+            .get("max_chars")
+            .and_then(toml::Value::as_integer)
+            .map(|v| i32::try_from(v.max(1)).unwrap_or(i32::MAX));
+
+        Self {
+            icon,
+            label,
+            exec,
+            template,
+            interval,
+            on_click,
+            tooltip,
+            max_chars,
+        }
+    }
+}
+
+/// State shared between timer and click-handler closures for exec polling.
+#[derive(Clone)]
+struct ExecState {
+    cmd: String,
+    label: Option<Label>,
+    fallback_text: String,
+    template: Option<String>,
+    custom_id: String,
+    widget: gtk4::Box,
+}
+
+/// Pre-exec show_if gate: when present, the show_if command is evaluated
+/// before each exec cycle. Non-zero exit hides the widget and skips exec.
+#[derive(Clone)]
+struct ShowIfGate {
+    cmd: String,
+}
+
+/// Custom widget that displays a user-configured icon/label with optional
+/// script polling and click handlers.
+pub struct CustomWidget {
+    /// Shared base widget container.
+    base: BaseWidget,
+    /// Keeps the label GTK widget alive (needed when exec updates it).
+    #[allow(dead_code)]
+    label: Option<Label>,
+    /// Keeps the icon GTK widget alive for the lifetime of this widget.
+    #[allow(dead_code)]
+    icon_handle: Option<IconHandle>,
+    /// Active timer source ID for cancellation on drop.
+    timer_source: Rc<RefCell<Option<SourceId>>>,
+}
+
+impl CustomWidget {
+    /// Create a new custom widget.
+    ///
+    /// `custom_id` is the part after "custom-" (e.g., "power" from "custom-power").
+    /// It's used as the primary CSS class for the widget.
+    pub fn new(custom_id: &str, config: CustomConfig) -> Self {
+        if config.interval > 0 && config.exec.is_none() {
+            warn!(
+                "Custom widget '{}': interval is set but no exec command configured",
+                custom_id
+            );
+        }
+
+        let css_class_name = format!("{}{custom_id}", wgt::CUSTOM_PREFIX);
+        let mut base = BaseWidget::new(&[&css_class_name]);
+
+        // Retrieve show_if config from WidgetOptions (not CustomConfig — these
+        // are cross-cutting fields parsed at the WidgetOptions level).
+        let (show_if_cmd, show_if_interval) = ConfigManager::global().get_show_if(&css_class_name);
+
+        // When exec + interval is active, show_if piggybacks on the exec cycle
+        // instead of running a separate timer. Cancel BaseWidget's show_if timer.
+        let piggyback = config.exec.is_some() && config.interval > 0 && show_if_cmd.is_some();
+        if piggyback {
+            base.cancel_show_if_timer();
+
+            if show_if_interval.is_some() {
+                warn!(
+                    "Custom widget '{}': show_if_interval is ignored when exec + interval \
+                     is set (show_if piggybacks on the exec cycle)",
+                    custom_id
+                );
+            }
+        }
+
+        // Enables hover styling for left-click action.
+        // BaseWidget handles CLICKABLE for on_click_right / on_click_middle.
+        if config.on_click.is_some() {
+            base.widget().add_css_class(state::CLICKABLE);
+        }
+
+        if let Some(ref tip) = config.tooltip {
+            base.set_tooltip(tip);
+        }
+
+        let icon_handle = config.icon.as_ref().map(|icon_name| {
+            if !has_material_mapping(icon_name) {
+                warn!(
+                    "Custom widget '{}': icon '{}' has no Material Symbol mapping. \
+                     Use theme.icons.theme = \"gtk\" or a Nerd Font glyph in the label field.",
+                    custom_id, icon_name
+                );
+            }
+            base.add_icon(icon_name, &[])
+        });
+
+        let label = if !config.label.is_empty() || config.exec.is_some() {
+            let initial_text = if config.label.is_empty() {
+                None
+            } else {
+                Some(config.label.as_str())
+            };
+            let lbl = base.add_label(initial_text, &[]);
+
+            if let Some(max_chars) = config.max_chars {
+                lbl.set_max_width_chars(max_chars);
+                lbl.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+            }
+
+            Some(lbl)
+        } else {
+            None
+        };
+
+        let timer_source = Rc::new(RefCell::new(None));
+
+        let exec_show_if = if piggyback {
+            show_if_cmd.map(|cmd| ShowIfGate { cmd })
+        } else {
+            None
+        };
+
+        // Must be set up before click handlers to share exec_state
+        let exec_state = if let Some(exec_cmd) = config.exec {
+            let state = ExecState {
+                cmd: exec_cmd,
+                label: label.clone(),
+                fallback_text: config.label,
+                template: config.template,
+                custom_id: custom_id.to_string(),
+                widget: base.widget().clone(),
+            };
+
+            // Run the exec command once immediately (with show_if gate if piggybacking)
+            run_exec(
+                &state.cmd,
+                state.label.as_ref(),
+                &state.fallback_text,
+                state.template.as_deref(),
+                &state.custom_id,
+                &state.widget,
+                exec_show_if.as_ref(),
+            );
+
+            if config.interval > 0 {
+                let state_for_timer = state.clone();
+                let show_if_for_timer = exec_show_if.clone();
+
+                let source_id = glib::timeout_add_seconds_local(
+                    u32::try_from(config.interval).unwrap_or(u32::MAX),
+                    move || {
+                        run_exec(
+                            &state_for_timer.cmd,
+                            state_for_timer.label.as_ref(),
+                            &state_for_timer.fallback_text,
+                            state_for_timer.template.as_deref(),
+                            &state_for_timer.custom_id,
+                            &state_for_timer.widget,
+                            show_if_for_timer.as_ref(),
+                        );
+                        glib::ControlFlow::Continue
+                    },
+                );
+
+                *timer_source.borrow_mut() = Some(source_id);
+            }
+
+            Some(state)
+        } else {
+            None
+        };
+
+        if let Some(on_click) = config.on_click {
+            // Custom widget's own left-click handler. Runs the command, then
+            // re-runs exec to refresh the label immediately.
+            // Right-click and middle-click are handled by BaseWidget via
+            // on_click_right / on_click_middle in the widget config.
+            let click = GestureClick::new();
+            let click_widget_name = css_class_name.clone();
+            click.set_button(gdk::BUTTON_PRIMARY);
+            click.connect_released(move |_gesture, _n_press, _x, _y| {
+                let cmd = on_click.to_string();
+                let exec_state = exec_state.clone();
+                let widget_name = click_widget_name.clone();
+                debug!("Custom widget executing: sh -c {}", cmd);
+
+                glib::spawn_future_local(async move {
+                    let _ = gio::spawn_blocking(move || {
+                        use std::process::{Command, Stdio};
+                        match Command::new("sh")
+                            .args(["-c", &cmd])
+                            .stdin(Stdio::null())
+                            .stdout(Stdio::null())
+                            .stderr(Stdio::null())
+                            .spawn()
+                        {
+                            Ok(mut child) => match child.wait() {
+                                Ok(status) if !status.success() => {
+                                    warn!(
+                                        "'{}' click command '{}' failed: {}",
+                                        widget_name,
+                                        cmd,
+                                        describe_exit_status(status)
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "'{}' click command '{}' wait failed: {}",
+                                        widget_name, cmd, e
+                                    );
+                                }
+                                _ => {}
+                            },
+                            Err(e) => {
+                                warn!(
+                                    "'{}' failed to spawn click command '{}': {}",
+                                    widget_name, cmd, e
+                                );
+                            }
+                        }
+                    })
+                    .await;
+
+                    // Re-run exec after the click command finishes so the
+                    // label reflects the new state immediately.
+                    // No show_if gate — the user explicitly clicked.
+                    if let Some(ref state) = exec_state {
+                        run_exec(
+                            &state.cmd,
+                            state.label.as_ref(),
+                            &state.fallback_text,
+                            state.template.as_deref(),
+                            &state.custom_id,
+                            &state.widget,
+                            None,
+                        );
+                    }
+                });
+            });
+            base.widget().add_controller(click);
+        }
+
+        Self {
+            base,
+            label,
+            icon_handle,
+            timer_source,
+        }
+    }
+
+    /// Get the root GTK widget for embedding in the bar.
+    pub fn widget(&self) -> &gtk4::Box {
+        self.base.widget()
+    }
+}
+
+impl Drop for CustomWidget {
+    fn drop(&mut self) {
+        // In-flight run_exec futures are safe: cloned GTK refs keep widgets alive,
+        // and set_label/set_visible on a detached widget is a harmless no-op.
+        if let Some(source_id) = self.timer_source.borrow_mut().take() {
+            source_id.remove();
+            debug!("Custom widget timer cancelled on drop");
+        }
+    }
+}
+
+/// Run an exec command asynchronously and update the label with its output.
+///
+/// Uses `glib::spawn_future_local` + `gio::spawn_blocking` to avoid blocking
+/// the GTK event loop. The command is run via `sh -c` with a 10-second timeout.
+///
+/// Auto-hides the widget when exec returns empty output and no fallback label
+/// is configured. Shows the widget again when exec returns non-empty output.
+///
+/// When `show_if` is set, the show_if command is evaluated first as a gate:
+/// non-zero exit hides the widget and skips exec entirely.
+fn run_exec(
+    exec_cmd: &str,
+    label: Option<&Label>,
+    fallback_text: &str,
+    template: Option<&str>,
+    custom_id: &str,
+    widget: &gtk4::Box,
+    show_if: Option<&ShowIfGate>,
+) {
+    let Some(label) = label else { return };
+
+    let label = label.clone();
+    let exec_cmd = exec_cmd.to_string();
+    let fallback_text = fallback_text.to_string();
+    let template = template.map(String::from);
+    let custom_id = custom_id.to_string();
+    let widget = widget.clone();
+    let show_if_cmd = show_if.map(|g| g.cmd.clone());
+
+    glib::spawn_future_local(async move {
+        // Pre-exec show_if gate: if the command exits non-zero, hide and skip exec.
+        if let Some(ref cmd) = show_if_cmd {
+            let cmd = cmd.clone();
+            let custom_id_for_check = custom_id.clone();
+            let result = gio::spawn_blocking(move || BaseWidget::run_show_if_command(&cmd)).await;
+
+            let (visible, stderr) = match result {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        widget = %custom_id_for_check,
+                        error = ?e,
+                        "show_if spawn_blocking failed"
+                    );
+                    (false, String::new())
+                }
+            };
+
+            widget.set_visible(visible);
+            if !stderr.is_empty() {
+                debug!(
+                    widget = %custom_id,
+                    visible,
+                    stderr = %stderr.trim(),
+                    "show_if check"
+                );
+            }
+
+            if !visible {
+                return;
+            }
+        }
+
+        let result = gio::spawn_blocking(move || {
+            use std::os::unix::process::ExitStatusExt;
+            use std::process::{Command, Stdio};
+            use std::time::Duration;
+
+            let child = match Command::new("sh")
+                .args(["-c", &exec_cmd])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(e) => return Err(format!("Failed to spawn: {e}")),
+            };
+
+            // Spawn a watchdog thread that kills the child after the timeout.
+            // Uses an mpsc channel so the main thread can cancel the watchdog
+            // early when the command finishes, avoiding a leaked sleeping thread.
+            // We extract the PID here because wait_with_output() consumes the
+            // Child, so we can't call child.kill() from the watchdog thread.
+            let pid = child.id() as libc::pid_t;
+            let (tx, rx) = std::sync::mpsc::channel::<()>();
+
+            std::thread::spawn(move || {
+                if rx
+                    .recv_timeout(Duration::from_secs(EXEC_TIMEOUT_SECS))
+                    .is_err()
+                {
+                    // Timeout expired and sender didn't signal — kill the child.
+                    // SAFETY: Sending SIGKILL to a process. If the process already
+                    // exited and was reaped, kill() returns ESRCH which is harmless.
+                    // Theoretical PID reuse: if the child exits and its PID is
+                    // recycled before the timeout fires, we'd kill an unrelated
+                    // process. In practice this can't happen here because
+                    // wait_with_output() below is the only call that reaps the
+                    // child — if it completes before the timeout, tx.send(())
+                    // cancels the watchdog. If it hasn't completed, the child is
+                    // still alive and owns the PID.
+                    unsafe {
+                        libc::kill(pid, libc::SIGKILL);
+                    }
+                }
+            });
+
+            let output = child
+                .wait_with_output()
+                .map_err(|e| format!("Wait failed: {e}"))?;
+
+            // Cancel the watchdog (no-op if it already fired).
+            let _ = tx.send(());
+
+            if !output.status.success() && output.status.signal() == Some(libc::SIGKILL) {
+                return Err(format!("Command timed out after {EXEC_TIMEOUT_SECS}s"));
+            }
+
+            if !output.status.success() {
+                return Err(describe_exit_status(output.status));
+            }
+
+            // Extract only the first line from the captured output.
+            use std::io::BufRead;
+            let mut line = String::new();
+            let mut reader = std::io::BufReader::new(&output.stdout[..]);
+            let _ = reader.read_line(&mut line);
+            Ok(line)
+        })
+        .await;
+
+        match result {
+            Ok(Ok(output)) => {
+                // Trim whitespace (including the trailing newline from read_line)
+                let text = output.trim();
+                if text.is_empty() {
+                    label.set_label(&fallback_text);
+                    // Auto-hide when exec returns empty and no fallback is configured
+                    if fallback_text.is_empty() {
+                        widget.set_visible(false);
+                    }
+                } else {
+                    let display = if let Some(ref tmpl) = template {
+                        tmpl.replace("{output}", text)
+                    } else {
+                        text.to_string()
+                    };
+                    label.set_label(&display);
+                    widget.set_visible(true);
+                }
+            }
+            Ok(Err(err)) => {
+                warn!("'custom-{}' exec failed: {}", custom_id, err);
+                // Keep previous label text and visibility on error
+            }
+            Err(err) => {
+                warn!("'custom-{}' exec task failed: {:?}", custom_id, err);
+                // Keep previous label text and visibility on error
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use toml::Value;
+
+    fn make_entry(options: HashMap<String, Value>) -> WidgetEntry {
+        WidgetEntry {
+            name: "custom-test".to_string(),
+            options,
+        }
+    }
+
+    #[test]
+    fn test_custom_config_defaults() {
+        let entry = make_entry(HashMap::new());
+        let config = CustomConfig::from_entry(&entry);
+
+        assert!(config.icon.is_none());
+        assert_eq!(config.label, "");
+        assert!(config.exec.is_none());
+        assert!(config.template.is_none());
+        assert_eq!(config.interval, 0);
+        assert!(config.on_click.is_none());
+        assert!(config.tooltip.is_none());
+        assert!(config.max_chars.is_none());
+    }
+
+    #[test]
+    fn test_custom_config_full() {
+        let mut options = HashMap::new();
+        options.insert(
+            "icon".to_string(),
+            Value::String("system-shutdown-symbolic".to_string()),
+        );
+        options.insert("label".to_string(), Value::String("Power".to_string()));
+        options.insert("exec".to_string(), Value::String("echo hello".to_string()));
+        options.insert(
+            "template".to_string(),
+            Value::String(" {output}".to_string()),
+        );
+        options.insert("interval".to_string(), Value::Integer(600));
+        options.insert("on_click".to_string(), Value::String("wlogout".to_string()));
+        options.insert(
+            "tooltip".to_string(),
+            Value::String("Power menu".to_string()),
+        );
+        options.insert("max_chars".to_string(), Value::Integer(30));
+
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+
+        assert_eq!(config.icon, Some("system-shutdown-symbolic".to_string()));
+        assert_eq!(config.label, "Power");
+        assert_eq!(config.exec, Some("echo hello".to_string()));
+        assert_eq!(config.template, Some(" {output}".to_string()));
+        assert_eq!(config.interval, 600);
+        assert_eq!(config.on_click, Some("wlogout".to_string()));
+        assert_eq!(config.tooltip, Some("Power menu".to_string()));
+        assert_eq!(config.max_chars, Some(30));
+    }
+
+    #[test]
+    fn test_custom_config_negative_interval_clamped() {
+        let mut options = HashMap::new();
+        options.insert("interval".to_string(), Value::Integer(-5));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert_eq!(config.interval, 0);
+    }
+
+    #[test]
+    fn test_custom_config_max_chars_min_one() {
+        let mut options = HashMap::new();
+        options.insert("max_chars".to_string(), Value::Integer(0));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert_eq!(config.max_chars, Some(1));
+    }
+
+    #[test]
+    fn test_custom_config_ignores_non_string_icon() {
+        let mut options = HashMap::new();
+        options.insert("icon".to_string(), Value::Integer(42));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.icon.is_none());
+    }
+
+    #[test]
+    fn test_custom_config_template_parsed() {
+        let mut options = HashMap::new();
+        options.insert(
+            "template".to_string(),
+            Value::String(" {output}".to_string()),
+        );
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert_eq!(config.template, Some(" {output}".to_string()));
+    }
+
+    #[test]
+    fn test_custom_config_template_ignores_non_string() {
+        let mut options = HashMap::new();
+        options.insert("template".to_string(), Value::Integer(42));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.template.is_none());
+    }
+
+    // --- show_if piggyback tests ---
+
+    #[test]
+    fn test_run_show_if_command_true() {
+        let (visible, stderr) = BaseWidget::run_show_if_command("true");
+        assert!(visible);
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn test_run_show_if_command_false() {
+        let (visible, stderr) = BaseWidget::run_show_if_command("false");
+        assert!(!visible);
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn test_run_show_if_command_captures_stderr() {
+        let (visible, stderr) = BaseWidget::run_show_if_command("echo err >&2");
+        assert!(visible);
+        assert!(stderr.trim() == "err");
+    }
+
+    #[test]
+    fn test_run_show_if_command_nonexistent_binary() {
+        let (visible, _stderr) =
+            BaseWidget::run_show_if_command("/nonexistent/binary/that/does/not/exist");
+        assert!(!visible);
+    }
+}

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -19,6 +19,7 @@ mod battery_popover;
 mod calendar_popover;
 mod clock;
 mod cpu;
+mod custom;
 pub mod layer_shell_popover;
 mod marquee_label;
 mod media;
@@ -59,6 +60,7 @@ pub use window_title::{WindowTitleConfig, WindowTitleWidget};
 pub use workspaces::{WorkspacesConfig, WorkspacesWidget};
 
 pub use cpu::{CpuConfig, CpuWidget};
+pub use custom::{CustomConfig, CustomWidget};
 pub use memory::{MemoryConfig, MemoryWidget};
 
 use gtk4::Widget;
@@ -279,6 +281,22 @@ impl WidgetFactory {
                 Some(BuiltWidget {
                     widget: root,
                     handle: Box::new(spacer),
+                })
+            }
+            name if name.starts_with("custom-") => {
+                let custom_id = &name["custom-".len()..];
+                if custom_id.is_empty() {
+                    warn!(
+                        "Custom widget name must have an ID after 'custom-', e.g., 'custom-power'"
+                    );
+                    return None;
+                }
+                let cfg = CustomConfig::from_entry(entry);
+                let widget = CustomWidget::new(custom_id, cfg);
+                let root = widget.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(widget),
                 })
             }
             name => {

--- a/scripts/subset-font.sh
+++ b/scripts/subset-font.sh
@@ -26,9 +26,9 @@ FONT_URL="https://raw.githubusercontent.com/google/material-design-icons/master/
 PYTHON="${PYTHON:-python3}"
 
 # Extract unique Material Symbol glyph names from the RHS of match arms
-# in material_symbol_name().
+# in material_symbol_lookup() (the inner lookup table used by material_symbol_name).
 extract_glyphs() {
-    sed -n '/^pub fn material_symbol_name/,/^}/p' "$ICONS_RS" \
+    sed -n '/^fn material_symbol_lookup/,/^}/p' "$ICONS_RS" \
         | sed -n 's/.*=> "\([a-z_0-9]*\)".*/\1/p' \
         | sort -u
 }


### PR DESCRIPTION
Adds custom widgets with user-defined icons, labels, script output, and click actions. Closes #57.
Custom widgets use the `custom-` prefix. Add them to your bar layout and configure each one under `[widgets]`:
```toml
[widgets]
right = ["custom-power", "custom-weather", "tray", "clock"]

# Simple button with icon and click action
[widgets.custom-power]
icon = "system-shutdown-symbolic"
tooltip = "Power menu"
on_click = "wlogout"

# Script output that updates every 10 minutes
[widgets.custom-weather]
exec = "curl -s 'wttr.in/?format=1'"
interval = 600
on_click = "xdg-open https://wttr.in"
tooltip = "Weather"
max_chars = 20
```
### How it works
- **Static widget:** Set `label` and/or `icon` for a fixed widget.
- **Script output:** Set `exec` to run a shell command. The first line of stdout becomes the label. If the output is empty, `label` is used as fallback. If both are empty, the widget hides automatically.
- **Template:** Set `template` to combine static text with script output. `{output}` is replaced by exec stdout (e.g. `template = "🌤 {output}"` prepends a glyph).
- **Click actions:** `on_click` / `on_click_right` run a command when clicked. If `exec` is also set, it re-runs after the click command finishes so the label updates immediately.
### All options
| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `icon` | string | — | Icon name (Material Symbol or GTK icon) |
| `label` | string | `""` | Static label text (fallback when exec returns empty) |
| `exec` | string | — | Shell command; first line of stdout becomes the label |
| `template` | string | — | Format string with `{output}` placeholder for exec output |
| `interval` | integer | `0` | Re-run exec every N seconds. `0` = run once at startup |
| `on_click` | string | — | Command to run on left click |
| `on_click_right` | string | — | Command to run on right click |
| `tooltip` | string | — | Tooltip text |
| `max_chars` | integer | — | Truncate label to N characters |