### PR TITLE
Popover animation and lifecycle rework

### DIFF
--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -20,13 +20,13 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
 use gtk4::glib;
-use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use tracing::{debug, error, info, warn};
 
 use vibepanel_core::{Config, ThemePalette, ThemeSizes};
@@ -129,6 +129,13 @@ impl ConfigManager {
         let config = self.config.borrow();
         let palette = ThemePalette::from_config(&config);
         palette.sizes.clone()
+    }
+
+    /// Get the computed surface border radius in pixels.
+    pub fn surface_border_radius(&self) -> u32 {
+        let config = self.config.borrow();
+        let palette = ThemePalette::from_config(&config);
+        palette.surface_border_radius
     }
 
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -20,13 +20,13 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
 use gtk4::glib;
-use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
+use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
 use tracing::{debug, error, info, warn};
 
 use vibepanel_core::{Config, ThemePalette, ThemeSizes};

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -652,17 +652,6 @@ pub mod surface {
     ///
     /// Transparent fullscreen overlay for click-outside-to-close behavior.
     pub const LAYER_SHELL_CLICK_CATCHER: &str = "layer-shell-click-catcher";
-
-    /// Popover content with open/close animation (`.popover-animate`).
-    ///
-    /// Enables CSS transition-based scale + fade on the popover content widget.
-    pub const POPOVER_ANIMATE: &str = "popover-animate";
-
-    /// Popover hidden state for animation (`.popover-hidden`).
-    ///
-    /// Combined with `POPOVER_ANIMATE`, sets the scaled-down + transparent state.
-    /// Removing this class triggers the open animation; adding it triggers close.
-    pub const POPOVER_HIDDEN: &str = "popover-hidden";
 }
 
 /// Icon-related classes.

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -82,6 +82,14 @@ pub struct MenuHandle {
     on_close: RefCell<Option<Rc<dyn Fn()>>>,
 }
 
+impl Drop for MenuHandle {
+    fn drop(&mut self) {
+        if let Some(id) = self.tracker_id.take() {
+            PopoverTracker::global().clear_if_active(id);
+        }
+    }
+}
+
 impl MenuHandle {
     fn new<F>(widget_name: String, builder: F, parent: GtkBox) -> Rc<Self>
     where
@@ -227,10 +235,9 @@ impl MenuHandle {
 
     /// Refresh the popover content if it's currently visible.
     ///
-    /// For layer-shell popovers, this hides and re-shows the popover
-    /// to rebuild its content. This may cause a brief visual flash,
-    /// but is necessary because layer-shell windows are recreated fresh
-    /// each time (to avoid stale state issues with layer-shell surfaces).
+    /// Rebuilds the popover content in-place by calling the builder closure
+    /// and swapping the animation shell's child. No animation is triggered —
+    /// the popover stays fully open at its current position.
     ///
     /// Used by widgets like Notifications that need to update their
     /// popover content dynamically while the popover is open.
@@ -239,9 +246,11 @@ impl MenuHandle {
             let Some(popover) = self.ensure_popover() else {
                 return;
             };
-            let (anchor_x, monitor) = self.get_anchor_info();
-            popover.hide();
-            popover.show_at(anchor_x, monitor);
+            popover.rebuild_content();
+        } else if let Some(ref popover) = *self.popover.borrow() {
+            // Popover is mid-close (or fully closed). Mark content dirty so
+            // a mid-close reversal rebuilds before the user sees stale content.
+            popover.mark_content_dirty();
         }
     }
 }

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -80,6 +80,10 @@ pub struct MenuHandle {
     tracker_id: Cell<Option<PopoverId>>,
     /// Stored on_close callback, forwarded to the LayerShellPopover on lazy init.
     on_close: RefCell<Option<Rc<dyn Fn()>>>,
+    /// Stored on_show callback, forwarded to the LayerShellPopover on lazy init.
+    on_show: RefCell<Option<Rc<dyn Fn()>>>,
+    /// Whether to enable content reuse mode on the popover.
+    reuse_content: Cell<bool>,
 }
 
 impl Drop for MenuHandle {
@@ -102,6 +106,8 @@ impl MenuHandle {
             parent,
             tracker_id: Cell::new(None),
             on_close: RefCell::new(None),
+            on_show: RefCell::new(None),
+            reuse_content: Cell::new(false),
         })
     }
 
@@ -141,6 +147,17 @@ impl MenuHandle {
             popover.set_on_close(move || cb());
         }
 
+        // Forward any stored on_show callback
+        if let Some(ref cb) = *self.on_show.borrow() {
+            let cb = cb.clone();
+            popover.set_on_show(move || cb());
+        }
+
+        // Forward reuse mode
+        if self.reuse_content.get() {
+            popover.set_reuse_content(true);
+        }
+
         *popover_opt = Some(popover.clone());
         Some(popover)
     }
@@ -157,6 +174,33 @@ impl MenuHandle {
         if let Some(ref popover) = *self.popover.borrow() {
             let cb = cb.clone();
             popover.set_on_close(move || cb());
+        }
+    }
+
+    /// Set a callback to be invoked every time the popover is shown.
+    ///
+    /// If the popover hasn't been created yet (lazy init), the callback is
+    /// stored and forwarded when `ensure_popover()` creates it.
+    pub fn set_on_show<F: Fn() + 'static>(&self, callback: F) {
+        let cb = Rc::new(callback);
+        *self.on_show.borrow_mut() = Some(cb.clone());
+
+        if let Some(ref popover) = *self.popover.borrow() {
+            let cb = cb.clone();
+            popover.set_on_show(move || cb());
+        }
+    }
+
+    /// Enable content reuse mode.
+    ///
+    /// When enabled, the builder is called only once and the resulting widget
+    /// is cached across open/close cycles. Use `set_on_show()` to refresh
+    /// data on each open.
+    pub fn set_reuse_content(&self, reuse: bool) {
+        self.reuse_content.set(reuse);
+
+        if let Some(ref popover) = *self.popover.borrow() {
+            popover.set_reuse_content(reuse);
         }
     }
 

--- a/crates/vibepanel/src/widgets/battery.rs
+++ b/crates/vibepanel/src/widgets/battery.rs
@@ -105,8 +105,6 @@ impl BatteryWidget {
         let controller_for_builder = controller_cell.clone();
 
         // Create a popover menu for detailed battery info.
-        // Reuse the widget across open/close cycles to avoid per-cycle
-        // widget allocation. See GTK issue #7758.
         let menu_handle = base.create_menu(move || {
             let (widget, controller) = build_battery_popover_with_controller();
             *controller_for_builder.borrow_mut() = Some(controller);

--- a/crates/vibepanel/src/widgets/battery.rs
+++ b/crates/vibepanel/src/widgets/battery.rs
@@ -105,10 +105,23 @@ impl BatteryWidget {
         let controller_for_builder = controller_cell.clone();
 
         // Create a popover menu for detailed battery info.
-        base.create_menu(move || {
+        // Reuse the widget across open/close cycles to avoid per-cycle
+        // widget allocation. See GTK issue #7758.
+        let menu_handle = base.create_menu(move || {
             let (widget, controller) = build_battery_popover_with_controller();
             *controller_for_builder.borrow_mut() = Some(controller);
             widget
+        });
+        menu_handle.set_reuse_content(true);
+
+        // Push fresh snapshots each time the popover opens so values are current.
+        let controller_for_show = controller_cell.clone();
+        menu_handle.set_on_show(move || {
+            if let Some(ctrl) = controller_for_show.borrow().as_ref() {
+                let battery_snapshot = BatteryService::global().snapshot();
+                let power_snapshot = PowerProfileService::global().snapshot();
+                ctrl.update_from_snapshots(&battery_snapshot, &power_snapshot);
+            }
         });
 
         // Initial neutral state until the first snapshot arrives.

--- a/crates/vibepanel/src/widgets/calendar_popover.rs
+++ b/crates/vibepanel/src/widgets/calendar_popover.rs
@@ -13,11 +13,15 @@ use crate::styles::{calendar as cal, icon, surface};
 /// Shows a month view calendar with custom previous/next navigation, a
 /// "go to today" button, and a header label. Toggles a `show-today` CSS class
 /// when the currently viewed month matches the real current month.
-pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
-    // Today and tracked month/year (always using day = 1 so that
-    // month arithmetic is simpler and avoids invalid dates like 31 Feb).
-    let today: NaiveDate = Local::now().date_naive();
-    let current_date = Rc::new(RefCell::new(today));
+///
+/// Returns the widget and a refresh callback. The refresh callback navigates
+/// the calendar to the real current date — call it on each open so the user
+/// always sees today's month, even when the widget is reused across cycles.
+pub fn build_clock_calendar_popover(show_week_numbers: bool) -> (Widget, Rc<dyn Fn()>) {
+    // "Today" is stored in a Cell so the on_show refresh callback can update
+    // it when the popover is reused across midnight boundaries.
+    let today = Rc::new(Cell::new(Local::now().date_naive()));
+    let current_date = Rc::new(RefCell::new(today.get()));
     // Flag to prevent signal handler from interfering during programmatic updates
     let updating = Rc::new(Cell::new(false));
 
@@ -122,7 +126,9 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
     let update_calendar = {
         let calendar = calendar.clone();
         let updating = updating.clone();
-        move |today: NaiveDate, date: NaiveDate| {
+        let today = today.clone();
+        move |date: NaiveDate| {
+            let today = today.get();
             let is_current_month = date.month() == today.month() && date.year() == today.year();
 
             // Set flag to prevent signal handler from interfering
@@ -153,7 +159,7 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
     {
         let date = *current_date.borrow();
         update_header(date);
-        update_calendar(today, date);
+        update_calendar(date);
     }
 
     // Navigation button handlers ---------------------------------------------
@@ -178,7 +184,7 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
             if let Some(new_date) = new_date {
                 *current_date.borrow_mut() = new_date;
                 update_header(new_date);
-                update_calendar(today, new_date);
+                update_calendar(new_date);
             }
         });
     }
@@ -187,12 +193,14 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
         let current_date = current_date.clone();
         let update_header = update_header.clone();
         let update_calendar = update_calendar.clone();
+        let today = today.clone();
         today_button.connect_clicked(move |_| {
+            let today = today.get();
             let today_month = NaiveDate::from_ymd_opt(today.year(), today.month(), 1);
             if let Some(new_date) = today_month {
                 *current_date.borrow_mut() = new_date;
                 update_header(new_date);
-                update_calendar(today, new_date);
+                update_calendar(new_date);
             }
         });
     }
@@ -217,7 +225,7 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
             if let Some(new_date) = new_date {
                 *current_date.borrow_mut() = new_date;
                 update_header(new_date);
-                update_calendar(today, new_date);
+                update_calendar(new_date);
             }
         });
     }
@@ -247,10 +255,23 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> Widget {
             {
                 *current_date.borrow_mut() = date;
                 update_header(date);
-                update_calendar(today, date);
+                update_calendar(date);
             }
         });
     }
 
-    container.upcast::<Widget>()
+    // Refresh callback — navigates calendar to the real current date.
+    // Called by on_show when the popover is reused across open/close cycles.
+    let refresh: Rc<dyn Fn()> = {
+        Rc::new(move || {
+            let new_today = Local::now().date_naive();
+            today.set(new_today);
+            let new_date = NaiveDate::from_ymd_opt(new_today.year(), new_today.month(), 1).unwrap();
+            *current_date.borrow_mut() = new_date;
+            update_header(new_date);
+            update_calendar(new_date);
+        })
+    };
+
+    (container.upcast::<Widget>(), refresh)
 }

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -85,7 +85,28 @@ impl ClockWidget {
         let label = base.add_label(Some("--:--"), &[wgt::CLOCK_LABEL]);
 
         let show_week_numbers = config.show_week_numbers;
-        base.create_menu(move || build_clock_calendar_popover(show_week_numbers));
+
+        // Shared slot for the calendar refresh callback. Populated by the
+        // builder on first open, invoked by on_show on every subsequent open.
+        type RefreshSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+        let refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
+
+        let refresh_for_builder = refresh_slot.clone();
+        let menu_handle = base.create_menu(move || {
+            let (widget, refresh) = build_clock_calendar_popover(show_week_numbers);
+            *refresh_for_builder.borrow_mut() = Some(refresh);
+            widget
+        });
+
+        // Reuse the calendar widget across open/close cycles to avoid
+        // unbounded memory growth from GTK4's Calendar internal widget tree.
+        // See GTK issue #7758.
+        menu_handle.set_reuse_content(true);
+        menu_handle.set_on_show(move || {
+            if let Some(ref cb) = *refresh_slot.borrow() {
+                cb();
+            }
+        });
 
         let timer_source = Rc::new(RefCell::new(None));
 

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -99,8 +99,7 @@ impl ClockWidget {
         });
 
         // Reuse the calendar widget across open/close cycles to avoid
-        // unbounded memory growth from GTK4's Calendar internal widget tree.
-        // See GTK issue #7758.
+        // unbounded memory growth from GTK4.
         menu_handle.set_reuse_content(true);
         menu_handle.set_on_show(move || {
             if let Some(ref cb) = *refresh_slot.borrow() {

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -8,11 +8,11 @@ use super::POPOVER_BG_WITH_OPACITY;
 /// Return shared utility CSS.
 pub fn css(animations: bool) -> String {
     let popover_bg = POPOVER_BG_WITH_OPACITY;
-    // Hover transitions are intentionally disabled (always `transition: none;`).
-    // Interrupted CSS transitions are observed to cause unbounded memory growth
-    // (e.g. spam-clicking a bar widget to toggle its popover).
-    // The 100ms background-color hover transition is barely perceptible and not
-    // worth the risk. Background-color changes still apply instantly.
+    // Hover background-color transitions are disabled unconditionally.
+    // CSS transitions on widgets with nested child widgets (e.g. Box > Label,
+    // Box > Image) are observed to cause unbounded memory growth in GTK4.
+    // Background-color changes still apply instantly on hover.
+    // Possibly related: https://gitlab.gnome.org/GNOME/gtk/-/issues/7758
     let hover_transition = "transition: none;";
     let slider_transition = if animations {
         "transition: transform 100ms ease-out;"

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -3,28 +3,21 @@
 //! These are truly shared styles that apply across multiple surfaces
 //! (bar, popovers, quick settings, etc).
 
-use super::{POPOVER_ANIMATION_MS, POPOVER_BG_WITH_OPACITY};
+use super::POPOVER_BG_WITH_OPACITY;
 
 /// Return shared utility CSS.
 pub fn css(animations: bool) -> String {
     let popover_bg = POPOVER_BG_WITH_OPACITY;
-    let hover_transition = if animations {
-        "transition: background-color 100ms ease;"
-    } else {
-        "transition: none;"
-    };
+    // Hover transitions are intentionally disabled (always `transition: none;`).
+    // Interrupted CSS transitions are observed to cause unbounded memory growth
+    // (e.g. spam-clicking a bar widget to toggle its popover).
+    // The 100ms background-color hover transition is barely perceptible and not
+    // worth the risk. Background-color changes still apply instantly.
+    let hover_transition = "transition: none;";
     let slider_transition = if animations {
         "transition: transform 100ms ease-out;"
     } else {
         "transition: none;"
-    };
-    let popover_transition = if animations {
-        format!(
-            "transition: opacity {ms}ms cubic-bezier(0.2, 0, 0, 1),\n                transform {ms}ms cubic-bezier(0.2, 0, 0, 1);",
-            ms = POPOVER_ANIMATION_MS,
-        )
-    } else {
-        "transition: none;".to_string()
     };
     format!(
         r#"
@@ -301,19 +294,6 @@ button:hover {{
 }}
 .slider-row .qs-toggle-more:hover {{
     background: var(--color-card-overlay-hover);
-}}
-
-/* ===== POPOVER OPEN/CLOSE ANIMATION ===== */
-
-.popover-animate {{
-    {popover_transition}
-    opacity: 1;
-    transform: scale(1);
-}}
-
-.popover-animate.popover-hidden {{
-    opacity: 0;
-    transform: scale(0.95);
 }}
 "#
     )

--- a/crates/vibepanel/src/widgets/css/mod.rs
+++ b/crates/vibepanel/src/widgets/css/mod.rs
@@ -29,9 +29,9 @@ pub const WIDGET_BG_HOVER: &str = "color-mix(in srgb, color-mix(in srgb, var(--w
 
 /// Popover open/close animation duration in milliseconds.
 ///
-/// Single source of truth for both CSS transitions and Rust timeout durations.
-/// Used by `base.rs` for the `.popover-animate` CSS rule and by
-/// `layer_shell_popover.rs` / `quick_settings/window.rs` for close-animation timeouts.
+/// Single source of truth for tick-callback animation durations.
+/// Used by `layer_shell_popover.rs` and `quick_settings/window.rs` for
+/// open/close animations driven by frame-clock tick callbacks.
 pub const POPOVER_ANIMATION_MS: u64 = 150;
 
 /// Dismiss animation duration in milliseconds (matches quick settings revealers).

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -387,6 +387,10 @@ pub struct LayerShellPopover {
     /// Optional callback invoked when the popover is fully hidden (after close
     /// animation completes). NOT fired at the start of hide().
     on_close: RefCell<Option<Rc<dyn Fn()>>>,
+    /// Optional callback invoked every time the popover is shown (after content
+    /// is parented but before the animation starts). Use this to refresh data
+    /// in reuse mode — e.g. updating the calendar to today's date.
+    on_show: RefCell<Option<Rc<dyn Fn()>>>,
     /// Shared animation state driven by the tick callback.
     anim_state: Rc<RefCell<AnimState>>,
     /// Generation counter incremented on every show/hide to cancel stale
@@ -400,6 +404,16 @@ pub struct LayerShellPopover {
     /// logically open (e.g. a notification arrives during the close animation).
     /// Checked and cleared on mid-close reversal so the content gets rebuilt.
     content_dirty: Cell<bool>,
+    /// When true, the builder is called only once and the content widget is
+    /// cached across open/close cycles. On subsequent opens the cached widget
+    /// is re-parented into the anim shell instead of calling the builder again.
+    ///
+    /// This avoids per-cycle widget allocation which is observed to leak memory
+    /// in GTK4 for widgets with complex internal trees (e.g. Calendar).
+    reuse_content: Cell<bool>,
+    /// Cached content widget for reuse mode. Kept alive across close cycles
+    /// so it can be re-parented on the next open.
+    cached_content: RefCell<Option<gtk4::Widget>>,
 }
 
 impl LayerShellPopover {
@@ -424,10 +438,13 @@ impl LayerShellPopover {
             anchor_x: Cell::new(0),
             anchor_monitor: RefCell::new(None),
             on_close: RefCell::new(None),
+            on_show: RefCell::new(None),
             anim_state: Rc::new(RefCell::new(AnimState::new_idle())),
             anim_generation: Rc::new(Cell::new(0)),
             logically_open: Cell::new(false),
             content_dirty: Cell::new(false),
+            reuse_content: Cell::new(false),
+            cached_content: RefCell::new(None),
         })
     }
 
@@ -444,6 +461,27 @@ impl LayerShellPopover {
     /// Set a callback to be invoked when the popover is hidden.
     pub fn set_on_close<F: Fn() + 'static>(&self, callback: F) {
         *self.on_close.borrow_mut() = Some(Rc::new(callback));
+    }
+
+    /// Set a callback to be invoked every time the popover is shown.
+    ///
+    /// In reuse mode this is called after the cached content is re-parented,
+    /// allowing consumers to refresh data (e.g. update calendar to today).
+    pub fn set_on_show<F: Fn() + 'static>(&self, callback: F) {
+        *self.on_show.borrow_mut() = Some(Rc::new(callback));
+    }
+
+    /// Enable content reuse mode.
+    ///
+    /// When enabled, the builder is called only once and the resulting widget
+    /// is cached. On subsequent opens the cached widget is re-parented into
+    /// the anim shell instead of calling the builder again.
+    ///
+    /// This avoids per-cycle widget allocation which is observed to cause
+    /// unbounded memory growth in GTK4 for widgets with complex internal
+    /// trees (e.g. gtk4::Calendar). See GTK issue #7758.
+    pub fn set_reuse_content(&self, reuse: bool) {
+        self.reuse_content.set(reuse);
     }
 
     /// Mark the popover content as needing a rebuild.
@@ -538,10 +576,18 @@ impl LayerShellPopover {
 
         anim_shell.remove_child();
 
+        // Invalidate cache so the builder runs fresh.
+        *self.cached_content.borrow_mut() = None;
+
         let content = (self.builder)();
         content.add_css_class(surface::POPOVER);
         let popover_class = format!("{}-popover", self.widget_name);
         content.add_css_class(&popover_class);
+
+        // Re-cache if in reuse mode.
+        if self.reuse_content.get() {
+            *self.cached_content.borrow_mut() = Some(content.clone());
+        }
 
         anim_shell.set_child(&content);
 
@@ -625,13 +671,34 @@ impl LayerShellPopover {
 
         anim_shell.remove_child();
 
-        // Build fresh content from the builder closure.
-        let content = (self.builder)();
-        content.add_css_class(surface::POPOVER);
-        let popover_class = format!("{}-popover", self.widget_name);
-        content.add_css_class(&popover_class);
+        // Get or build content. In reuse mode, the builder is called only once
+        // and the widget is cached for subsequent opens. This avoids per-cycle
+        // widget allocation which leaks memory in GTK4 for complex widgets.
+        let content = if self.reuse_content.get() {
+            if let Some(ref cached) = *self.cached_content.borrow() {
+                cached.clone()
+            } else {
+                let fresh = (self.builder)();
+                fresh.add_css_class(surface::POPOVER);
+                let popover_class = format!("{}-popover", self.widget_name);
+                fresh.add_css_class(&popover_class);
+                *self.cached_content.borrow_mut() = Some(fresh.clone());
+                fresh
+            }
+        } else {
+            let fresh = (self.builder)();
+            fresh.add_css_class(surface::POPOVER);
+            let popover_class = format!("{}-popover", self.widget_name);
+            fresh.add_css_class(&popover_class);
+            fresh
+        };
 
         anim_shell.set_child(&content);
+
+        // Fire on_show callback (e.g. to refresh calendar to today's date).
+        if let Some(ref cb) = *self.on_show.borrow() {
+            cb();
+        }
 
         SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
 

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -18,6 +18,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
 
+use super::scale_box::ScaleBox;
 use crate::services::compositor::CompositorManager;
 use crate::services::config_manager::ConfigManager;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -37,7 +38,7 @@ const POPOVER_DEFAULT_WIDTH_ESTIMATE: i32 = 320;
 
 const POPOVER_MIN_VALID_WIDTH: i32 = 20;
 
-/// Duration of the popover open/close CSS transition.
+/// Duration of the popover open/close animation.
 /// Derived from the single source of truth in `css::POPOVER_ANIMATION_MS`.
 pub const POPOVER_ANIMATION_DURATION: Duration =
     Duration::from_millis(super::css::POPOVER_ANIMATION_MS);
@@ -243,26 +244,40 @@ where
 
 /// A layer-shell popover for widget menus.
 ///
-/// Creates fresh windows on each `show()` call and destroys them on `hide()`,
-/// ensuring clean state without remembered scroll positions or expanded sections.
+/// The window shell (`ApplicationWindow` with layer-shell configuration) is
+/// created lazily on first show and **reused** across open/close cycles.
+/// Content is built fresh on each `show()` via the builder closure, placed
+/// inside a persistent `ScaleBox` animation shell.
 ///
-/// Supports animated open/close via CSS transitions (scale + fade). On hide,
-/// the window is taken out of the struct (so `is_visible()` returns false
-/// immediately) and the close animation plays on the orphaned window before
-/// it is destroyed.
+/// Open/close animation is a simple opacity snap + timeout: the `ScaleBox`
+/// opacity is set to 0 immediately on hide, then the window is hidden and
+/// `on_close` fires after `POPOVER_ANIMATION_DURATION`.
 pub struct LayerShellPopover {
     app: Application,
     widget_name: String,
     builder: Rc<dyn Fn() -> gtk4::Widget>,
     window: RefCell<Option<ApplicationWindow>>,
     click_catcher: RefCell<Option<ApplicationWindow>>,
-    /// Reference to the popover content widget for animation class toggling.
-    content_widget: RefCell<Option<gtk4::Widget>>,
+    /// Persistent animation shell. Never destroyed. Builder content is placed
+    /// inside this as a child and swapped on each show.
+    anim_shell: RefCell<Option<ScaleBox>>,
     /// Anchor X coordinate (widget center) in monitor coordinates.
     anchor_x: Cell<i32>,
     anchor_monitor: RefCell<Option<Monitor>>,
-    /// Optional callback invoked when the popover is hidden.
+    /// Optional callback invoked when the popover is fully hidden (after close
+    /// animation completes). NOT fired at the start of hide().
     on_close: RefCell<Option<Rc<dyn Fn()>>>,
+    /// Generation counter incremented on every show/hide to cancel stale
+    /// idle callbacks and timeout callbacks.
+    generation: Rc<Cell<u32>>,
+    /// Logical open state. True from the moment show() is called until
+    /// hide() is called. Used by is_visible() so the toggle logic in BaseWidget works correctly
+    /// even while a close animation is in flight.
+    logically_open: Cell<bool>,
+    /// Set when `mark_content_dirty()` is called while the popover is not
+    /// logically open (e.g. a notification arrives during the close animation).
+    /// Checked and cleared on the next show so the content gets rebuilt.
+    content_dirty: Cell<bool>,
 }
 
 impl LayerShellPopover {
@@ -283,19 +298,24 @@ impl LayerShellPopover {
             builder: Rc::new(builder),
             window: RefCell::new(None),
             click_catcher: RefCell::new(None),
-            content_widget: RefCell::new(None),
+            anim_shell: RefCell::new(None),
             anchor_x: Cell::new(0),
             anchor_monitor: RefCell::new(None),
             on_close: RefCell::new(None),
+            generation: Rc::new(Cell::new(0)),
+            logically_open: Cell::new(false),
+            content_dirty: Cell::new(false),
         })
     }
 
-    /// Check if the popover is currently visible.
+    /// Check if the popover is logically open.
+    ///
+    /// Returns `true` from the moment `show_at()` is called until `hide()`
+    /// is called, even though the window may still be visible during the close
+    /// animation. This is critical for the toggle logic in `BaseWidget` to
+    /// work correctly during rapid clicking.
     pub fn is_visible(&self) -> bool {
-        self.window
-            .borrow()
-            .as_ref()
-            .is_some_and(|w| w.is_visible())
+        self.logically_open.get()
     }
 
     /// Set a callback to be invoked when the popover is hidden.
@@ -303,114 +323,220 @@ impl LayerShellPopover {
         *self.on_close.borrow_mut() = Some(Rc::new(callback));
     }
 
+    /// Mark the popover content as needing a rebuild.
+    ///
+    /// Called by `MenuHandle::refresh_if_visible()` when the popover is not
+    /// logically open (e.g. a notification arrives during the close animation).
+    /// The flag is checked on the next show so the stale content gets
+    /// replaced before the user sees it again.
+    pub fn mark_content_dirty(&self) {
+        self.content_dirty.set(true);
+    }
+
     /// Show the popover at the given anchor position.
     ///
-    /// Creates fresh window and click-catcher instances.
+    /// Reuses all persistent shells (window, animation, click-catcher) and
+    /// builds fresh content.
     pub fn show_at(self: &Rc<Self>, x: i32, monitor: Option<Monitor>) {
         self.anchor_x.set(x);
         *self.anchor_monitor.borrow_mut() = monitor;
         self.show_internal();
     }
 
-    /// Hide the popover with a close animation.
+    /// Hide the popover, keeping the window shell alive.
     ///
-    /// The click-catcher is destroyed immediately so the bar is interactive
-    /// during the animation. The window is taken out of the struct (making
-    /// `is_visible()` return false) and moved into a timeout closure that
-    /// closes it after the CSS transition completes.
+    /// The click-catcher is hidden immediately so the bar is interactive
+    /// during the animation. The animation shell snaps to opacity 0,
+    /// then a timeout hides the window and fires `on_close`.
     pub fn hide(&self) {
-        // Destroy click-catcher immediately
-        if let Some(catcher) = self.click_catcher.borrow_mut().take() {
-            catcher.close();
+        // Mark as logically closed immediately — the toggle logic in BaseWidget
+        // checks this to decide show vs hide on the next click.
+        self.logically_open.set(false);
+
+        // Bump generation to cancel any pending idle callback from show_internal().
+        let generation = self.generation.get().wrapping_add(1);
+        self.generation.set(generation);
+
+        // Hide click-catcher immediately so bar is interactive during animation.
+        if let Some(ref catcher) = *self.click_catcher.borrow() {
+            catcher.set_visible(false);
         }
 
-        let content = self.content_widget.borrow_mut().take();
-        let window = self.window.borrow_mut().take();
+        let window = self.window.borrow().as_ref().cloned();
+        let anim_shell = self.anim_shell.borrow().as_ref().cloned();
 
         let Some(window) = window else {
             return;
         };
 
-        // Fire on_close callback only when actually closing a visible popover.
-        if let Some(ref cb) = *self.on_close.borrow() {
-            cb();
+        // Release keyboard grab while hiding.
+        window.set_keyboard_mode(KeyboardMode::None);
+
+        // Snap the animation shell to hidden state.
+        if let Some(ref shell) = anim_shell {
+            shell.set_opacity(0.0);
         }
 
-        // Start close animation on the content widget
-        if let Some(ref content) = content {
-            content.add_css_class(surface::POPOVER_HIDDEN);
+        // If animations are disabled, hide window immediately.
+        if !ConfigManager::global().animations_enabled() {
+            if let Some(ref shell) = anim_shell {
+                shell.remove_child();
+            }
+            window.set_visible(false);
+            if let Some(ref cb) = *self.on_close.borrow() {
+                cb();
+            }
+            return;
         }
 
-        // The orphaned window closes itself after the animation duration.
-        // If show_at() is called during this window, a new window is created
-        // independently — Rust ownership prevents conflicts.
-        let delay = if ConfigManager::global().animations_enabled() {
-            POPOVER_ANIMATION_DURATION
-        } else {
-            Duration::ZERO
-        };
-        glib::timeout_add_local_once(delay, move || {
-            // `window` and `content` are moved here and dropped after close
-            let _ = &content;
-            window.close();
+        // Hide the window and fire on_close after the animation duration.
+        let on_close = self.on_close.borrow().clone();
+        let gen_rc = Rc::clone(&self.generation);
+        glib::timeout_add_local_once(POPOVER_ANIMATION_DURATION, move || {
+            // Bail if a newer show/hide cycle started.
+            if gen_rc.get() != generation {
+                return;
+            }
+            if let Some(ref shell) = anim_shell {
+                shell.remove_child();
+            }
+            window.set_visible(false);
+            if let Some(ref cb) = on_close {
+                cb();
+            }
         });
     }
 
+    /// Rebuild the popover content in-place without any animation.
+    ///
+    /// Used by `MenuHandle::refresh_if_visible()` to hot-swap content while the
+    /// popover is already open (e.g. a new notification arrives). This avoids
+    /// the hide→show cycle which would trigger unnecessary animation.
+    pub fn rebuild_content(&self) {
+        let Some(anim_shell) = self.anim_shell.borrow().as_ref().cloned() else {
+            return;
+        };
+
+        anim_shell.remove_child();
+
+        let content = (self.builder)();
+        content.add_css_class(surface::POPOVER);
+        let popover_class = format!("{}-popover", self.widget_name);
+        content.add_css_class(&popover_class);
+
+        anim_shell.set_child(&content);
+
+        SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
+    }
+
     fn show_internal(self: &Rc<Self>) {
-        // Guard against re-entrancy: if already visible, hide first to avoid
-        // orphaning the old window/click-catcher
-        if self.is_visible() {
-            self.hide();
+        // Mark as logically open immediately.
+        self.logically_open.set(true);
+
+        // Fresh content will be built below, so clear any pending dirty flag.
+        self.content_dirty.set(false);
+
+        // Bump generation to cancel any stale timeout or idle callbacks.
+        let generation = self.generation.get().wrapping_add(1);
+        self.generation.set(generation);
+
+        // If the window is somehow still visible (shouldn't happen with
+        // logically_open guard, but be defensive), hide it synchronously.
+        if self
+            .window
+            .borrow()
+            .as_ref()
+            .is_some_and(|w| w.is_visible())
+        {
+            if let Some(ref shell) = *self.anim_shell.borrow() {
+                shell.set_opacity(0.0);
+                shell.remove_child();
+            }
+            if let Some(ref window) = *self.window.borrow() {
+                window.set_visible(false);
+            }
         }
 
-        // Create the main window
-        let window = self.create_window();
+        let window = self.ensure_window_shell();
 
-        // Set monitor if specified
+        let anim_shell = self.ensure_anim_shell();
+
+        anim_shell.remove_child();
+
+        // Build fresh content from the builder closure.
+        let content = (self.builder)();
+        content.add_css_class(surface::POPOVER);
+        let popover_class = format!("{}-popover", self.widget_name);
+        content.add_css_class(&popover_class);
+
+        anim_shell.set_child(&content);
+
+        SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
+
         if let Some(ref monitor) = *self.anchor_monitor.borrow() {
             window.set_monitor(Some(monitor));
         }
 
-        // Create and show click-catcher first
-        let bar_zone = calculate_bar_exclusive_zone();
-        let weak_self = Rc::downgrade(self);
-        let catcher = create_click_catcher(&self.app, bar_zone, move || {
-            if let Some(popover) = weak_self.upgrade() {
-                popover.hide();
-            }
-        });
+        // Set the shell to the hidden state (will be revealed after positioning).
+        anim_shell.set_opacity(0.0);
 
+        // Ensure the outer wrapper is set as the window's child (persists).
+        if window.child().is_none() {
+            let outer = GtkBox::new(Orientation::Vertical, 0);
+            outer.add_css_class(surface::WIDGET_MENU);
+            outer.add_css_class(surface::NO_FOCUS);
+            SurfaceStyleManager::global().apply_shadow_margins(&outer, POPOVER_SHADOW_MARGIN);
+            outer.append(&anim_shell);
+            window.set_child(Some(&outer));
+        }
+
+        // Restore keyboard mode (hide() sets it to None).
+        window.set_keyboard_mode(popover_keyboard_mode());
+
+        // Show click-catcher (persistent, created lazily).
+        let catcher = self.ensure_click_catcher();
         if let Some(ref monitor) = *self.anchor_monitor.borrow() {
             catcher.set_monitor(Some(monitor));
         }
-
+        catcher.set_margin(popover_bar_edge(), calculate_bar_exclusive_zone());
         catcher.set_visible(true);
-        *self.click_catcher.borrow_mut() = Some(catcher.clone());
 
-        // Show window with opacity trick to avoid flicker during positioning
+        // Show window with opacity trick to avoid flicker during positioning.
         window.set_opacity(0.0);
         window.set_visible(true);
         window.present();
 
-        *self.window.borrow_mut() = Some(window.clone());
-
-        // After window is mapped, update position and reveal with animation
+        // After window is mapped, update position and reveal.
         let weak_self = Rc::downgrade(self);
-        glib::idle_add_local(move || {
+        let gen_rc = Rc::clone(&self.generation);
+        glib::idle_add_local_once(move || {
+            // Bail if a newer show/hide cycle started before this idle fired.
+            if gen_rc.get() != generation {
+                return;
+            }
+
             if let Some(popover) = weak_self.upgrade() {
                 popover.update_position();
                 if let Some(ref window) = *popover.window.borrow() {
                     window.set_opacity(1.0);
                 }
-                if let Some(ref content) = *popover.content_widget.borrow() {
-                    content.remove_css_class(surface::POPOVER_HIDDEN);
+                if let Some(ref shell) = *popover.anim_shell.borrow() {
+                    shell.set_opacity(1.0);
                 }
             }
-            ControlFlow::Break
         });
     }
 
-    fn create_window(self: &Rc<Self>) -> ApplicationWindow {
+    /// Ensure the window shell exists, creating it lazily if needed.
+    ///
+    /// The shell includes the `ApplicationWindow`, layer-shell configuration,
+    /// and ESC key handler — but no content. Content is set by `show_internal()`
+    /// on each open.
+    fn ensure_window_shell(self: &Rc<Self>) -> ApplicationWindow {
+        if let Some(ref window) = *self.window.borrow() {
+            return window.clone();
+        }
+
         let window = ApplicationWindow::builder()
             .application(&self.app)
             .title(format!("vibepanel {} popover", self.widget_name))
@@ -434,36 +560,6 @@ impl LayerShellPopover {
         window.set_anchor(Edge::Left, false);
         window.set_keyboard_mode(popover_keyboard_mode());
 
-        // Build content
-        let content = (self.builder)();
-        content.add_css_class(surface::POPOVER);
-        let popover_class = format!("{}-popover", self.widget_name);
-        content.add_css_class(&popover_class);
-
-        // Start in hidden state for the open animation
-        content.add_css_class(surface::POPOVER_ANIMATE);
-        content.add_css_class(surface::POPOVER_HIDDEN);
-
-        *self.content_widget.borrow_mut() = Some(content.clone().upcast());
-
-        // Wrap in container with margins for shadow space.
-        // The bar-adjacent side gets 0 margin (tight against bar),
-        // the opposite side gets shadow margin for drop shadow rendering.
-        let outer = GtkBox::new(Orientation::Vertical, 0);
-        outer.add_css_class(surface::WIDGET_MENU);
-        outer.add_css_class(surface::NO_FOCUS);
-        SurfaceStyleManager::global().apply_shadow_margins(&outer, POPOVER_SHADOW_MARGIN);
-        outer.append(&content);
-
-        // Apply surface styles (background, shadow, font) to the content
-        // Note: content does NOT have WIDGET_MENU_CONTENT class, so it gets shadow
-        SurfaceStyleManager::global().apply_surface_styles(&content, true);
-
-        // Apply Pango font attributes
-        SurfaceStyleManager::global().apply_pango_attrs_all(&outer);
-
-        window.set_child(Some(&outer));
-
         // ESC key handler
         {
             let weak_self = Rc::downgrade(self);
@@ -474,7 +570,50 @@ impl LayerShellPopover {
             });
         }
 
+        *self.window.borrow_mut() = Some(window.clone());
         window
+    }
+
+    /// Ensure the persistent animation shell exists, creating it lazily.
+    ///
+    /// The animation shell is a `ScaleBox` whose child (builder content) is
+    /// swapped on each show. It is **never destroyed** and carries no styling —
+    /// it is a pure transparent animation wrapper. Visual styles (background,
+    /// padding, border-radius) live on the content widget via CSS classes
+    /// resolved by the global stylesheet.
+    fn ensure_anim_shell(&self) -> ScaleBox {
+        if let Some(ref shell) = *self.anim_shell.borrow() {
+            return shell.clone();
+        }
+
+        let shell = ScaleBox::new();
+
+        // Start fully hidden.
+        shell.set_opacity(0.0);
+
+        *self.anim_shell.borrow_mut() = Some(shell.clone());
+        shell
+    }
+
+    /// Ensure the persistent click-catcher exists, creating it lazily.
+    ///
+    /// The click-catcher is shown/hidden each cycle rather than created/destroyed
+    /// to avoid per-cycle allocation of an `ApplicationWindow` + layer-shell surface.
+    fn ensure_click_catcher(self: &Rc<Self>) -> ApplicationWindow {
+        if let Some(ref catcher) = *self.click_catcher.borrow() {
+            return catcher.clone();
+        }
+
+        let bar_zone = calculate_bar_exclusive_zone();
+        let weak_self = Rc::downgrade(self);
+        let catcher = create_click_catcher(&self.app, bar_zone, move || {
+            if let Some(popover) = weak_self.upgrade() {
+                popover.hide();
+            }
+        });
+
+        *self.click_catcher.borrow_mut() = Some(catcher.clone());
+        catcher
     }
 
     fn update_position(&self) {
@@ -533,6 +672,26 @@ impl LayerShellPopover {
 pub trait Dismissible {
     fn dismiss(&self);
     fn is_visible(&self) -> bool;
+}
+
+impl Drop for LayerShellPopover {
+    fn drop(&mut self) {
+        // If the popover was still open when destroyed, fire on_close
+        // synchronously so consumers can clean up resources
+        // (e.g. SystemPopoverBinding releases GPU polling).
+        if self.logically_open.get() {
+            if let Some(ref cb) = *self.on_close.borrow() {
+                cb();
+            }
+        }
+
+        if let Some(catcher) = self.click_catcher.borrow_mut().take() {
+            catcher.close();
+        }
+        if let Some(window) = self.window.borrow_mut().take() {
+            window.close();
+        }
+    }
 }
 
 impl Dismissible for LayerShellPopover {

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -476,10 +476,6 @@ impl LayerShellPopover {
     /// When enabled, the builder is called only once and the resulting widget
     /// is cached. On subsequent opens the cached widget is re-parented into
     /// the anim shell instead of calling the builder again.
-    ///
-    /// This avoids per-cycle widget allocation which is observed to cause
-    /// unbounded memory growth in GTK4 for widgets with complex internal
-    /// trees (e.g. gtk4::Calendar). See GTK issue #7758.
     pub fn set_reuse_content(&self, reuse: bool) {
         self.reuse_content.set(reuse);
     }

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -16,7 +16,6 @@ use gtk4::{
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
-use std::time::Duration;
 
 use super::scale_box::ScaleBox;
 use crate::services::compositor::CompositorManager;
@@ -38,10 +37,122 @@ const POPOVER_DEFAULT_WIDTH_ESTIMATE: i32 = 320;
 
 const POPOVER_MIN_VALID_WIDTH: i32 = 20;
 
-/// Duration of the popover open/close animation.
-/// Derived from the single source of truth in `css::POPOVER_ANIMATION_MS`.
-pub const POPOVER_ANIMATION_DURATION: Duration =
-    Duration::from_millis(super::css::POPOVER_ANIMATION_MS);
+/// Animation duration as f64 milliseconds for tick-callback math.
+pub(crate) const ANIM_DURATION_MS: f64 = super::css::POPOVER_ANIMATION_MS as f64;
+
+/// Starting scale for popover open/close animation.
+/// ScaleBox simulates this via symmetric center-clip (no actual scale transform).
+pub(crate) const ANIM_SCALE_FROM: f64 = 0.94;
+
+/// Direction of the popover animation.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum AnimDirection {
+    Opening,
+    Closing,
+}
+
+/// Shared animation state, passed to the tick callback via `Rc<RefCell<_>>`.
+///
+/// `progress` represents the current visual state:
+///   0.0 = fully hidden (opacity 0)
+///   1.0 = fully visible (opacity 1)
+pub(crate) struct AnimState {
+    /// Current direction of animation.
+    pub(crate) direction: AnimDirection,
+    /// Frame-clock time (microseconds) when this animation segment started.
+    pub(crate) start_time_us: i64,
+    /// Progress value at the start of this segment (for mid-flight reversal).
+    pub(crate) start_progress: f64,
+    /// Target progress (1.0 for opening, 0.0 for closing).
+    pub(crate) target_progress: f64,
+    /// Whether a tick callback is currently driving this state.
+    pub(crate) active: bool,
+    /// Generation counter that the current tick callback was started with.
+    /// Used to detect when an active tick has a stale generation and needs
+    /// to be replaced by a new one.
+    pub(crate) tick_generation: u32,
+}
+
+impl AnimState {
+    pub(crate) fn new_idle() -> Self {
+        Self {
+            direction: AnimDirection::Opening,
+            start_time_us: 0,
+            start_progress: 0.0,
+            target_progress: 0.0,
+            active: false,
+            tick_generation: 0,
+        }
+    }
+
+    /// Compute the current eased progress given the frame clock time.
+    pub(crate) fn current_progress(&self, now_us: i64) -> f64 {
+        let elapsed_ms = (now_us - self.start_time_us) as f64 / 1000.0;
+        let distance = (self.target_progress - self.start_progress).abs();
+        if distance < f64::EPSILON {
+            return self.target_progress;
+        }
+        // Duration is proportional to remaining distance — a half-done
+        // animation that reverses takes half the time.
+        let segment_duration_ms = ANIM_DURATION_MS * distance;
+        let t = (elapsed_ms / segment_duration_ms).clamp(0.0, 1.0);
+        // Quintic ease-out: snappy start, long gentle tail.
+        // Approximates the Material Design `cubic-bezier(0.2, 0, 0, 1)` curve
+        // used in the original CSS transitions.
+        let eased = 1.0 - (1.0 - t).powi(5);
+        self.start_progress + (self.target_progress - self.start_progress) * eased
+    }
+
+    /// Whether the animation has reached its target.
+    pub(crate) fn is_complete(&self, now_us: i64) -> bool {
+        let elapsed_ms = (now_us - self.start_time_us) as f64 / 1000.0;
+        let distance = (self.target_progress - self.start_progress).abs();
+        if distance < f64::EPSILON {
+            return true;
+        }
+        let segment_duration_ms = ANIM_DURATION_MS * distance;
+        elapsed_ms >= segment_duration_ms
+    }
+
+    /// Prepare an animation segment and determine if a new tick callback is needed.
+    ///
+    /// Captures the current progress (for mid-flight reversal), updates all state
+    /// fields, and returns `true` if a new tick callback must be registered. Returns
+    /// `false` if the existing tick callback will pick up the new direction.
+    ///
+    /// `current_opacity` is the shell's current opacity, used as the starting
+    /// progress when no animation is in flight.
+    pub(crate) fn prepare(
+        &mut self,
+        direction: AnimDirection,
+        generation: u32,
+        start_time_us: i64,
+        current_opacity: f64,
+    ) -> bool {
+        let target = match direction {
+            AnimDirection::Opening => 1.0,
+            AnimDirection::Closing => 0.0,
+        };
+
+        let start_progress = if self.active {
+            self.current_progress(start_time_us)
+        } else {
+            current_opacity
+        };
+
+        let was_active = self.active;
+        let tick_is_current = was_active && self.tick_generation == generation;
+        self.direction = direction;
+        self.start_time_us = start_time_us;
+        self.start_progress = start_progress;
+        self.target_progress = target;
+        self.active = true;
+        self.tick_generation = generation;
+        // Need a new tick callback if none is running, or the running one
+        // has a stale generation (it will self-cancel).
+        !tick_is_current
+    }
+}
 
 /// Calculate the margin for a popover on the bar-adjacent edge.
 ///
@@ -246,12 +357,20 @@ where
 ///
 /// The window shell (`ApplicationWindow` with layer-shell configuration) is
 /// created lazily on first show and **reused** across open/close cycles.
-/// Content is built fresh on each `show()` via the builder closure, placed
-/// inside a persistent `ScaleBox` animation shell.
 ///
-/// Open/close animation is a simple opacity snap + timeout: the `ScaleBox`
-/// opacity is set to 0 immediately on hide, then the window is hidden and
-/// `on_close` fires after `POPOVER_ANIMATION_DURATION`.
+/// ## Animation architecture
+///
+/// Open/close animations (opacity fade) are driven by a **tick callback**
+/// on the persistent animation shell, not by CSS `transition:` properties. This
+/// avoids unbounded memory growth observed when CSS transitions are interrupted.
+///
+/// The tick callback reads the frame clock each frame, computes eased progress
+/// from an `AnimState`, and applies opacity via `Widget::set_opacity()`. This gives:
+///
+/// - **No CSS transitions** (no `transition:` on any widget)
+/// - **Smooth mid-flight reversal** (clicking close during open reverses from
+///   the current position, proportional timing)
+/// - **No jank** (no snapping between states on rapid clicks)
 pub struct LayerShellPopover {
     app: Application,
     widget_name: String,
@@ -267,16 +386,18 @@ pub struct LayerShellPopover {
     /// Optional callback invoked when the popover is fully hidden (after close
     /// animation completes). NOT fired at the start of hide().
     on_close: RefCell<Option<Rc<dyn Fn()>>>,
+    /// Shared animation state driven by the tick callback.
+    anim_state: Rc<RefCell<AnimState>>,
     /// Generation counter incremented on every show/hide to cancel stale
-    /// idle callbacks and timeout callbacks.
-    generation: Rc<Cell<u32>>,
+    /// tick callbacks and idle callbacks.
+    anim_generation: Rc<Cell<u32>>,
     /// Logical open state. True from the moment show() is called until
     /// hide() is called. Used by is_visible() so the toggle logic in BaseWidget works correctly
     /// even while a close animation is in flight.
     logically_open: Cell<bool>,
     /// Set when `mark_content_dirty()` is called while the popover is not
     /// logically open (e.g. a notification arrives during the close animation).
-    /// Checked and cleared on the next show so the content gets rebuilt.
+    /// Checked and cleared on mid-close reversal so the content gets rebuilt.
     content_dirty: Cell<bool>,
 }
 
@@ -302,7 +423,8 @@ impl LayerShellPopover {
             anchor_x: Cell::new(0),
             anchor_monitor: RefCell::new(None),
             on_close: RefCell::new(None),
-            generation: Rc::new(Cell::new(0)),
+            anim_state: Rc::new(RefCell::new(AnimState::new_idle())),
+            anim_generation: Rc::new(Cell::new(0)),
             logically_open: Cell::new(false),
             content_dirty: Cell::new(false),
         })
@@ -327,7 +449,7 @@ impl LayerShellPopover {
     ///
     /// Called by `MenuHandle::refresh_if_visible()` when the popover is not
     /// logically open (e.g. a notification arrives during the close animation).
-    /// The flag is checked on the next show so the stale content gets
+    /// The flag is checked on mid-close reversal so the stale content gets
     /// replaced before the user sees it again.
     pub fn mark_content_dirty(&self) {
         self.content_dirty.set(true);
@@ -343,19 +465,25 @@ impl LayerShellPopover {
         self.show_internal();
     }
 
-    /// Hide the popover, keeping the window shell alive.
+    /// Hide the popover with a close animation, keeping the window shell alive.
     ///
     /// The click-catcher is hidden immediately so the bar is interactive
-    /// during the animation. The animation shell snaps to opacity 0,
-    /// then a timeout hides the window and fires `on_close`.
+    /// during the animation. The animation shell fades out via the tick
+    /// callback, then content is removed and the window is hidden.
+    ///
+    /// If the popover is currently opening, the animation smoothly reverses
+    /// from the current progress — no snapping.
+    ///
+    /// The `on_close` callback fires when the close animation **completes**,
+    /// not when `hide()` is called.
     pub fn hide(&self) {
         // Mark as logically closed immediately — the toggle logic in BaseWidget
         // checks this to decide show vs hide on the next click.
         self.logically_open.set(false);
 
         // Bump generation to cancel any pending idle callback from show_internal().
-        let generation = self.generation.get().wrapping_add(1);
-        self.generation.set(generation);
+        let generation = self.anim_generation.get().wrapping_add(1);
+        self.anim_generation.set(generation);
 
         // Hide click-catcher immediately so bar is interactive during animation.
         if let Some(ref catcher) = *self.click_catcher.borrow() {
@@ -372,46 +500,36 @@ impl LayerShellPopover {
         // Release keyboard grab while hiding.
         window.set_keyboard_mode(KeyboardMode::None);
 
-        // Snap the animation shell to hidden state.
-        if let Some(ref shell) = anim_shell {
-            shell.set_opacity(0.0);
-        }
-
-        // If animations are disabled, hide window immediately.
+        // If animations are disabled, snap closed immediately.
         if !ConfigManager::global().animations_enabled() {
             if let Some(ref shell) = anim_shell {
+                shell.set_opacity(0.0);
+                shell.set_scale(ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             window.set_visible(false);
+            // Fire on_close now since there's no animation to wait for.
             if let Some(ref cb) = *self.on_close.borrow() {
                 cb();
             }
             return;
         }
 
-        // Hide the window and fire on_close after the animation duration.
-        let on_close = self.on_close.borrow().clone();
-        let gen_rc = Rc::clone(&self.generation);
-        glib::timeout_add_local_once(POPOVER_ANIMATION_DURATION, move || {
-            // Bail if a newer show/hide cycle started.
-            if gen_rc.get() != generation {
-                return;
-            }
-            if let Some(ref shell) = anim_shell {
-                shell.remove_child();
-            }
-            window.set_visible(false);
-            if let Some(ref cb) = on_close {
-                cb();
-            }
-        });
+        // Ensure the window is fully visible (the idle callback from show_internal
+        // may not have fired yet, leaving window.opacity at 0.0).
+        window.set_opacity(1.0);
+
+        // Start (or reverse into) the close animation.
+        // on_close fires when the animation completes (in the tick callback).
+        self.start_animation(AnimDirection::Closing, generation);
     }
 
     /// Rebuild the popover content in-place without any animation.
     ///
     /// Used by `MenuHandle::refresh_if_visible()` to hot-swap content while the
     /// popover is already open (e.g. a new notification arrives). This avoids
-    /// the hide→show cycle which would trigger unnecessary animation.
+    /// the hide→show cycle which would trigger the mid-close reversal path and
+    /// skip the content rebuild.
     pub fn rebuild_content(&self) {
         let Some(anim_shell) = self.anim_shell.borrow().as_ref().cloned() else {
             return;
@@ -433,12 +551,53 @@ impl LayerShellPopover {
         // Mark as logically open immediately.
         self.logically_open.set(true);
 
+        // If we're currently animating a close, the window is still visible
+        // with content — just reverse the animation direction. No need to
+        // rebuild content, recreate click-catcher, etc.
+        let was_closing = {
+            let state = self.anim_state.borrow();
+            state.active && state.direction == AnimDirection::Closing
+        };
+
+        if was_closing {
+            // Content may have become stale during the close animation (e.g. a
+            // notification arrived while logically_open was false). Rebuild now
+            // so the user doesn't see outdated content when the reversal
+            // completes.
+            if self.content_dirty.take() {
+                self.rebuild_content();
+            }
+
+            // Use the CURRENT generation (set by hide()) so the existing tick
+            // callback stays valid — no new closure allocation needed.
+            let generation = self.anim_generation.get();
+            // Re-show click-catcher (hide() hid it).
+            let catcher = self.ensure_click_catcher();
+            if let Some(ref monitor) = *self.anchor_monitor.borrow() {
+                catcher.set_monitor(Some(monitor));
+            }
+            catcher.set_margin(popover_bar_edge(), calculate_bar_exclusive_zone());
+            catcher.set_visible(true);
+
+            // Restore keyboard mode (hide() set it to None).
+            if let Some(ref window) = *self.window.borrow() {
+                window.set_keyboard_mode(popover_keyboard_mode());
+            }
+
+            // Anchor may have changed since the original open.
+            self.update_position();
+
+            // Reverse into opening — tick callback picks up new direction.
+            self.start_animation(AnimDirection::Opening, generation);
+            return;
+        }
+
+        // Not mid-close — full open from scratch.
         // Fresh content will be built below, so clear any pending dirty flag.
         self.content_dirty.set(false);
-
-        // Bump generation to cancel any stale timeout or idle callbacks.
-        let generation = self.generation.get().wrapping_add(1);
-        self.generation.set(generation);
+        // Bump generation to cancel any stale tick callbacks or idle callbacks.
+        let generation = self.anim_generation.get().wrapping_add(1);
+        self.anim_generation.set(generation);
 
         // If the window is somehow still visible (shouldn't happen with
         // logically_open guard, but be defensive), hide it synchronously.
@@ -448,8 +607,10 @@ impl LayerShellPopover {
             .as_ref()
             .is_some_and(|w| w.is_visible())
         {
+            // Snap-close without animation to avoid recursion.
             if let Some(ref shell) = *self.anim_shell.borrow() {
                 shell.set_opacity(0.0);
+                shell.set_scale(ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             if let Some(ref window) = *self.window.borrow() {
@@ -477,8 +638,9 @@ impl LayerShellPopover {
             window.set_monitor(Some(monitor));
         }
 
-        // Set the shell to the hidden state (will be revealed after positioning).
+        // Set the shell to the hidden state (will be animated to visible).
         anim_shell.set_opacity(0.0);
+        anim_shell.set_scale(ANIM_SCALE_FROM);
 
         // Ensure the outer wrapper is set as the window's child (persists).
         if window.child().is_none() {
@@ -506,9 +668,9 @@ impl LayerShellPopover {
         window.set_visible(true);
         window.present();
 
-        // After window is mapped, update position and reveal.
+        // After window is mapped, update position and start the open animation.
         let weak_self = Rc::downgrade(self);
-        let gen_rc = Rc::clone(&self.generation);
+        let gen_rc = Rc::clone(&self.anim_generation);
         glib::idle_add_local_once(move || {
             // Bail if a newer show/hide cycle started before this idle fired.
             if gen_rc.get() != generation {
@@ -520,8 +682,15 @@ impl LayerShellPopover {
                 if let Some(ref window) = *popover.window.borrow() {
                     window.set_opacity(1.0);
                 }
-                if let Some(ref shell) = *popover.anim_shell.borrow() {
-                    shell.set_opacity(1.0);
+
+                if ConfigManager::global().animations_enabled() {
+                    popover.start_animation(AnimDirection::Opening, generation);
+                } else {
+                    // Animations disabled — snap open immediately.
+                    if let Some(ref shell) = *popover.anim_shell.borrow() {
+                        shell.set_opacity(1.0);
+                        shell.set_scale(1.0);
+                    }
                 }
             }
         });
@@ -588,8 +757,9 @@ impl LayerShellPopover {
 
         let shell = ScaleBox::new();
 
-        // Start fully hidden.
+        // Start fully hidden (opacity 0, scale at starting value).
         shell.set_opacity(0.0);
+        shell.set_scale(ANIM_SCALE_FROM);
 
         *self.anim_shell.borrow_mut() = Some(shell.clone());
         shell
@@ -614,6 +784,95 @@ impl LayerShellPopover {
 
         *self.click_catcher.borrow_mut() = Some(catcher.clone());
         catcher
+    }
+
+    /// Start or reverse the open/close animation via a tick callback.
+    ///
+    /// If an animation is already in flight (e.g., opening and user clicks to
+    /// close), the current progress is captured and the animation reverses from
+    /// that point with proportional timing — no snapping.
+    fn start_animation(&self, direction: AnimDirection, generation: u32) {
+        let anim_shell = self.anim_shell.borrow().as_ref().cloned();
+        let Some(anim_shell) = anim_shell else {
+            return;
+        };
+
+        // Cache the current border radius for the duration of this animation.
+        anim_shell.set_radius(ConfigManager::global().surface_border_radius() as f32);
+
+        let start_time_us = anim_shell
+            .frame_clock()
+            .map(|fc| fc.frame_time())
+            .unwrap_or(0);
+
+        let need_tick = self.anim_state.borrow_mut().prepare(
+            direction,
+            generation,
+            start_time_us,
+            anim_shell.opacity(),
+        );
+
+        if !need_tick {
+            return;
+        }
+
+        let anim_state = Rc::clone(&self.anim_state);
+        let anim_gen = Rc::clone(&self.anim_generation);
+        let window = self.window.borrow().as_ref().cloned();
+        let shell_for_scale = anim_shell.clone();
+        let on_close = self.on_close.borrow().clone();
+
+        anim_shell.add_tick_callback(move |shell, frame_clock| {
+            // Generation check — bail if a newer cycle started.
+            // Do NOT touch `active` — a newer tick callback owns that now.
+            if anim_gen.get() != generation {
+                return ControlFlow::Break;
+            }
+
+            let now_us = frame_clock.frame_time();
+            let (progress, complete, direction) = {
+                let state = anim_state.borrow();
+                if !state.active {
+                    return ControlFlow::Break;
+                }
+                (
+                    state.current_progress(now_us),
+                    state.is_complete(now_us),
+                    state.direction,
+                )
+            };
+
+            // Apply visual state — opacity and scale, no CSS involvement.
+            shell.set_opacity(progress);
+            // Interpolate scale: ANIM_SCALE_FROM at progress=0 → 1.0 at progress=1.
+            let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
+            shell_for_scale.set_scale(scale);
+
+            if complete {
+                anim_state.borrow_mut().active = false;
+
+                if direction == AnimDirection::Closing {
+                    // Close complete — remove content and hide window.
+                    shell.set_opacity(0.0);
+                    shell_for_scale.set_scale(ANIM_SCALE_FROM);
+                    shell_for_scale.remove_child();
+                    if let Some(ref w) = window {
+                        w.set_visible(false);
+                    }
+                    // Fire on_close now that the popover is fully hidden.
+                    if let Some(ref cb) = on_close {
+                        cb();
+                    }
+                } else {
+                    // Open complete — ensure we're at exactly 1.0.
+                    shell.set_opacity(1.0);
+                    shell_for_scale.set_scale(1.0);
+                }
+                return ControlFlow::Break;
+            }
+
+            ControlFlow::Continue
+        });
     }
 
     fn update_position(&self) {
@@ -676,13 +935,13 @@ pub trait Dismissible {
 
 impl Drop for LayerShellPopover {
     fn drop(&mut self) {
-        // If the popover was still open when destroyed, fire on_close
-        // synchronously so consumers can clean up resources
+        // If the popover was still open (or mid-animation) when destroyed,
+        // fire on_close synchronously so consumers can clean up resources
         // (e.g. SystemPopoverBinding releases GPU polling).
-        if self.logically_open.get() {
-            if let Some(ref cb) = *self.on_close.borrow() {
-                cb();
-            }
+        if (self.logically_open.get() || self.anim_state.borrow().active)
+            && let Some(ref cb) = *self.on_close.borrow()
+        {
+            cb();
         }
 
         if let Some(catcher) = self.click_catcher.borrow_mut().take() {

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -361,8 +361,9 @@ where
 /// ## Animation architecture
 ///
 /// Open/close animations (opacity fade) are driven by a **tick callback**
-/// on the persistent animation shell, not by CSS `transition:` properties. This
-/// avoids unbounded memory growth observed when CSS transitions are interrupted.
+/// on the persistent animation shell, not by CSS `transition:` properties.
+/// CSS `transform: scale()` transitions are observed to cause unbounded
+/// memory growth in GTK4.
 ///
 /// The tick callback reads the frame clock each frame, computes eased progress
 /// from an `AnimState`, and applies opacity via `Widget::set_opacity()`. This gives:

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -647,8 +647,10 @@ impl MediaWidget {
 
         // We need access to the menu handle to close the popover when popping out.
         // Use the same pattern as notifications: store it after create_menu returns.
+        // The on_popout closure captures a Weak to avoid a reference cycle:
+        //   menu_handle_cell → MenuHandle → builder closure → on_popout → menu_handle_cell
         let menu_handle_cell: Rc<RefCell<Option<Rc<MenuHandle>>>> = Rc::new(RefCell::new(None));
-        let menu_handle_for_builder = menu_handle_cell.clone();
+        let menu_handle_weak = Rc::downgrade(&menu_handle_cell);
 
         // Create the on_popout callback that will be called when the pop-out button is clicked.
         let on_popout = move || {
@@ -656,7 +658,9 @@ impl MediaWidget {
             TooltipManager::global().cancel_and_hide();
 
             // Close the popover first
-            if let Some(menu_handle) = menu_handle_for_builder.borrow().as_ref() {
+            if let Some(cell) = menu_handle_weak.upgrade()
+                && let Some(menu_handle) = cell.borrow().as_ref()
+            {
                 menu_handle.hide();
             }
 

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -727,16 +727,36 @@ impl MediaWidget {
         };
 
         let menu_handle = base.create_menu(move || {
-            // Drop old controller before building the new one so stale
-            // callbacks are cleaned up before new ones are registered.
-            controller_for_builder.borrow_mut().take();
-
             let on_popout_clone = on_popout.clone();
             let (widget, controller) = build_media_popover_with_controller(move || {
                 on_popout_clone();
             });
             *controller_for_builder.borrow_mut() = Some(controller);
             widget
+        });
+
+        // Reuse the media popover widget across open/close cycles to avoid
+        // per-cycle widget allocation. See GTK issue #7758.
+        menu_handle.set_reuse_content(true);
+
+        // Push a fresh snapshot each time the popover opens so values are current.
+        let controller_for_show = controller_cell.clone();
+        menu_handle.set_on_show(move || {
+            if let Some(ctrl) = controller_for_show.borrow().as_ref() {
+                let snapshot = MediaService::global().snapshot();
+                ctrl.update_from_snapshot(&snapshot);
+            }
+        });
+
+        // Pause the popover visualizer when closed so cava callbacks and
+        // tick-driven redraws don't run on an invisible widget.
+        let controller_for_close = controller_cell.clone();
+        menu_handle.set_on_close(move || {
+            if let Some(ctrl) = controller_for_close.borrow().as_ref()
+                && let Some(ref viz) = ctrl.visualizer
+            {
+                viz.pause();
+            }
         });
 
         *menu_handle_cell.borrow_mut() = Some(menu_handle);

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -735,8 +735,6 @@ impl MediaWidget {
             widget
         });
 
-        // Reuse the media popover widget across open/close cycles to avoid
-        // per-cycle widget allocation. See GTK issue #7758.
         menu_handle.set_reuse_content(true);
 
         // Push a fresh snapshot each time the popover opens so values are current.

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -37,6 +37,7 @@ mod notifications_toast;
 mod osd;
 pub(crate) mod ripple;
 mod rounded_picture;
+pub(crate) mod scale_box;
 mod spacer;
 mod system_popover;
 mod tray;

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -347,8 +347,10 @@ impl NotificationsWidget {
 
         // We need a reference to the menu handle inside the builder, but the handle
         // is created by create_menu. Use a RefCell to store it after creation.
+        // The builder captures a Weak to avoid a reference cycle:
+        //   menu_handle_cell → MenuHandle → builder closure → menu_handle_cell
         let menu_handle_cell: Rc<RefCell<Option<Rc<MenuHandle>>>> = Rc::new(RefCell::new(None));
-        let menu_handle_for_builder = Rc::clone(&menu_handle_cell);
+        let menu_handle_weak = Rc::downgrade(&menu_handle_cell);
 
         let menu_handle = self.base.create_menu(move || {
             // Mark as seen when popover opens
@@ -356,9 +358,11 @@ impl NotificationsWidget {
 
             // Create close callback that hides the popover
             let on_close: Option<ClosePopoverCallback> =
-                menu_handle_for_builder.borrow().as_ref().map(|handle| {
-                    let handle_clone = Rc::clone(handle);
-                    Rc::new(move || handle_clone.hide()) as ClosePopoverCallback
+                menu_handle_weak.upgrade().and_then(|cell| {
+                    cell.borrow().as_ref().map(|handle| {
+                        let handle_clone = Rc::clone(handle);
+                        Rc::new(move || handle_clone.hide()) as ClosePopoverCallback
+                    })
                 });
 
             build_popover_content(on_close, Rc::clone(&suppress_rebuild))

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -7,7 +7,7 @@
 //! while hidden. UI state is reset on close so it opens fresh.
 
 use gtk4::gdk::{self, Monitor};
-use gtk4::glib;
+use gtk4::glib::{self, ControlFlow};
 use gtk4::prelude::*;
 use gtk4::{
     Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation, PolicyType,
@@ -30,10 +30,11 @@ use crate::services::updates::UpdatesService;
 use crate::services::vpn::VpnService;
 use crate::styles::{qs, state, surface};
 use crate::widgets::layer_shell_popover::{
-    Dismissible, POPOVER_ANIMATION_DURATION, calculate_bar_exclusive_zone,
+    ANIM_SCALE_FROM, AnimDirection, AnimState, Dismissible, calculate_bar_exclusive_zone,
     calculate_popover_bar_margin, calculate_popover_right_margin, create_click_catcher,
     popover_bar_edge, popover_keyboard_mode, setup_esc_handler,
 };
+use crate::widgets::scale_box::ScaleBox;
 
 use super::audio_card::{
     self, AudioCardState, build_audio_details, build_audio_hint_label, build_audio_row,
@@ -114,19 +115,37 @@ const AUDIO_SECTION_TOP_MARGIN: i32 = 12;
 
 /// Full Quick Settings window.
 ///
+/// ## Animation architecture
+///
+/// Open/close animations are driven by a **tick callback** on the animation
+/// shell (`ScaleBox`), not by CSS `transition:` properties. This avoids
+/// unbounded memory growth observed when CSS transitions are interrupted.
+/// See `LayerShellPopover` for the same pattern.
 pub struct QuickSettingsWindow {
     window: ApplicationWindow,
     click_catcher: RefCell<Option<ApplicationWindow>>,
-    /// Outer container with animation classes, target for open/close animation.
+    /// Animation shell wrapping the outer container. Opacity and scale are
+    /// animated via tick callback — no CSS transitions involved.
+    anim_shell: ScaleBox,
+    /// Outer container (shadow margins, surface styles). Child of `anim_shell`.
     outer_container: RefCell<Option<GtkBox>>,
     /// Anchor X position in monitor coordinates.
     anchor_x: Cell<i32>,
-    anchor_monitor: RefCell<Option<Monitor>>,
+    anchor_monitor: RefCell<Option<gdk::Monitor>>,
     /// Whether the window has been mapped at least once (used to skip
     /// the opacity fade-in trick on subsequent shows).
     has_been_mapped: Cell<bool>,
     /// Whether a close animation is currently playing.
     is_animating_out: Cell<bool>,
+    /// Logical open state. True from show_panel() until hide_panel() is called.
+    /// Used by toggle_at() and Dismissible so clicks during close animation
+    /// re-open the panel instead of being silently swallowed.
+    logically_open: Cell<bool>,
+    /// Shared animation state driven by the tick callback.
+    anim_state: Rc<RefCell<AnimState>>,
+    /// Generation counter incremented on every show/hide to cancel stale
+    /// tick callbacks and idle callbacks.
+    anim_generation: Rc<Cell<u32>>,
     cards_config: QuickSettingsCardsConfig,
     audio_scroll_percentage: i32,
     scroll_container: ScrolledWindow,
@@ -191,15 +210,25 @@ impl QuickSettingsWindow {
         scroll_container.set_vscrollbar_policy(PolicyType::Automatic);
         scroll_container.set_propagate_natural_height(true);
 
+        // Create the animation shell — a ScaleBox that wraps the outer
+        // container. Opacity and scale are animated via tick callback.
+        let anim_shell = ScaleBox::new();
+        anim_shell.set_opacity(0.0);
+        anim_shell.set_scale(ANIM_SCALE_FROM);
+
         // Content is built after construction.
         let qs = Rc::new(Self {
             window: window.clone(),
             click_catcher: RefCell::new(None),
+            anim_shell: anim_shell.clone(),
             outer_container: RefCell::new(None),
             anchor_x: Cell::new(0),
             anchor_monitor: RefCell::new(None),
             has_been_mapped: Cell::new(false),
             is_animating_out: Cell::new(false),
+            logically_open: Cell::new(false),
+            anim_state: Rc::new(RefCell::new(AnimState::new_idle())),
+            anim_generation: Rc::new(Cell::new(0)),
             cards_config: config.cards,
             audio_scroll_percentage: config.audio_scroll_percentage,
             scroll_container,
@@ -224,9 +253,12 @@ impl QuickSettingsWindow {
         });
 
         let outer = Self::build_content(&qs);
-        window.set_child(Some(&outer));
 
-        // Store outer container for animation class toggling
+        // Hierarchy: window → anim_shell (ScaleBox) → outer (GtkBox)
+        anim_shell.set_child(&outer);
+        window.set_child(Some(&anim_shell));
+
+        // Store outer container reference.
         *qs.outer_container.borrow_mut() = Some(outer.clone());
 
         // Apply Pango font attributes to all labels if enabled in config.
@@ -367,7 +399,6 @@ impl QuickSettingsWindow {
         // Apply surface styles - background now controlled via CSS variables
         outer.add_css_class("quick-settings-popover");
         outer.add_css_class(surface::POPOVER);
-        outer.add_css_class(surface::POPOVER_ANIMATE);
         SurfaceStyleManager::global().apply_surface_styles(&outer, true);
 
         let content = GtkBox::new(Orientation::Vertical, 0);
@@ -1313,36 +1344,29 @@ impl QuickSettingsWindow {
     /// being made visible again). On re-show, the window is already mapped so
     /// we skip the opacity fade-in trick and go straight to positioning.
     fn show_panel(self: &Rc<Self>) {
-        // Cancel any in-progress close animation
+        // Mark as logically open immediately so toggle_at() works correctly
+        // even if a close animation is still in flight.
+        self.logically_open.set(true);
+
+        // Note: unlike LayerShellPopover, we don't attempt mid-close reversal
+        // here — not worth the complexity for a 150ms animation.
         self.is_animating_out.set(false);
+
+        // Bump generation to cancel stale tick callbacks and idle callbacks.
+        let generation = self.anim_generation.get().wrapping_add(1);
+        self.anim_generation.set(generation);
 
         if let Some(monitor) = self.anchor_monitor.borrow().as_ref() {
             self.window.set_monitor(Some(monitor));
         }
 
-        // Create click-catcher (fresh each time — trivial cost)
-        let app = self
-            .window
-            .application()
-            .expect("QuickSettingsWindow must have an associated Application");
-
-        let bar_zone = calculate_bar_exclusive_zone();
-        let qs_weak = Rc::downgrade(self);
-        let catcher = create_click_catcher(&app, bar_zone, move || {
-            if let Some(qs) = qs_weak.upgrade() {
-                qs.hide_panel();
-            }
-        });
-
-        // Add QS-specific CSS class
-        catcher.add_css_class(qs::CLICK_CATCHER);
-
-        // Set monitor and show click-catcher
+        // Show click-catcher (persistent, created lazily).
+        let catcher = self.ensure_click_catcher();
         if let Some(monitor) = self.anchor_monitor.borrow().as_ref() {
             catcher.set_monitor(Some(monitor));
         }
+        catcher.set_margin(popover_bar_edge(), calculate_bar_exclusive_zone());
         catcher.set_visible(true);
-        *self.click_catcher.borrow_mut() = Some(catcher.clone());
 
         // Restore keyboard mode
         self.window.set_keyboard_mode(popover_keyboard_mode());
@@ -1350,10 +1374,9 @@ impl QuickSettingsWindow {
         // Set the global current QS window reference
         set_current_qs_window(self);
 
-        // Start with content hidden for open animation
-        if let Some(ref outer) = *self.outer_container.borrow() {
-            outer.add_css_class(surface::POPOVER_HIDDEN);
-        }
+        // Set animation shell to hidden state for open animation.
+        self.anim_shell.set_opacity(0.0);
+        self.anim_shell.set_scale(ANIM_SCALE_FROM);
 
         if self.has_been_mapped.get() {
             // Re-show: window was previously mapped and hidden. The surface
@@ -1363,14 +1386,21 @@ impl QuickSettingsWindow {
             self.window.set_visible(true);
             self.window.present();
 
-            // Trigger open animation + re-deliver service snapshots
+            // Start open animation + re-deliver service snapshots.
             let window_weak = self.window.downgrade();
+            let gen_rc = Rc::clone(&self.anim_generation);
             glib::idle_add_local_once(move || {
+                if gen_rc.get() != generation {
+                    return;
+                }
                 if let Some(window) = window_weak.upgrade()
                     && let Some(qs) = get_qs_window_data(&window)
                 {
-                    if let Some(ref outer) = *qs.outer_container.borrow() {
-                        outer.remove_css_class(surface::POPOVER_HIDDEN);
+                    if ConfigManager::global().animations_enabled() {
+                        qs.start_animation(AnimDirection::Opening, generation);
+                    } else {
+                        qs.anim_shell.set_opacity(1.0);
+                        qs.anim_shell.set_scale(1.0);
                     }
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
@@ -1385,16 +1415,22 @@ impl QuickSettingsWindow {
             self.window.present();
 
             let window_weak = self.window.downgrade();
+            let gen_rc = Rc::clone(&self.anim_generation);
             glib::idle_add_local_once(move || {
+                if gen_rc.get() != generation {
+                    return;
+                }
                 if let Some(window) = window_weak.upgrade()
                     && let Some(qs) = get_qs_window_data(&window)
                 {
                     qs.update_position();
                     qs.window.set_opacity(1.0);
 
-                    // Trigger open animation
-                    if let Some(ref outer) = *qs.outer_container.borrow() {
-                        outer.remove_css_class(surface::POPOVER_HIDDEN);
+                    if ConfigManager::global().animations_enabled() {
+                        qs.start_animation(AnimDirection::Opening, generation);
+                    } else {
+                        qs.anim_shell.set_opacity(1.0);
+                        qs.anim_shell.set_scale(1.0);
                     }
 
                     let snapshot = NetworkService::global().snapshot();
@@ -1406,14 +1442,18 @@ impl QuickSettingsWindow {
 
     /// Hide the panel with a close animation, keeping the window alive.
     ///
-    /// The click-catcher is destroyed and keyboard grab released immediately
-    /// so the bar is interactive during the animation. UI state is reset and
-    /// the window hidden after the CSS transition completes.
+    /// The click-catcher is hidden and keyboard grab released immediately
+    /// so the bar is interactive during the animation. The animation shell
+    /// fades out via tick callback, then UI state is reset and the window hidden.
     /// Does NOT clear PopoverTracker — the caller is responsible for that.
     pub(super) fn hide_panel(&self) {
         if self.is_animating_out.get() {
             return;
         }
+
+        // Mark as logically closed immediately so toggle_at() can re-open
+        // during the close animation instead of swallowing the click.
+        self.logically_open.set(false);
 
         // Restore keyboard mode if it was released for VPN password dialogs
         vpn_card::restore_keyboard_if_released();
@@ -1425,42 +1465,141 @@ impl QuickSettingsWindow {
         // Release keyboard grab while hidden
         self.window.set_keyboard_mode(KeyboardMode::None);
 
-        // Destroy click-catcher immediately so bar is interactive
-        if let Some(catcher) = self.click_catcher.borrow_mut().take() {
-            catcher.close();
+        // Hide click-catcher immediately so bar is interactive during animation.
+        if let Some(ref catcher) = *self.click_catcher.borrow() {
+            catcher.set_visible(false);
         }
 
-        // Start close animation
-        if let Some(ref outer) = *self.outer_container.borrow() {
-            outer.add_css_class(surface::POPOVER_HIDDEN);
-        }
+        // Bump generation to cancel any pending idle callback from show_panel().
+        let generation = self.anim_generation.get().wrapping_add(1);
+        self.anim_generation.set(generation);
 
         self.is_animating_out.set(true);
 
-        // After animation completes, reset UI state and hide the window.
-        // If show_panel() was called during the animation, is_animating_out
-        // will have been cleared — the stale timeout becomes a no-op.
-        let window_weak = self.window.downgrade();
-        let delay = if ConfigManager::global().animations_enabled() {
-            POPOVER_ANIMATION_DURATION
-        } else {
-            std::time::Duration::ZERO
-        };
-        glib::timeout_add_local_once(delay, move || {
-            let Some(window) = window_weak.upgrade() else {
-                return;
-            };
-            let Some(qs) = get_qs_window_data(&window) else {
-                return;
-            };
-            if !qs.is_animating_out.get() {
-                return;
-            }
+        if !ConfigManager::global().animations_enabled() {
+            // Animations disabled — snap closed immediately.
+            self.anim_shell.set_opacity(0.0);
+            self.anim_shell.set_scale(ANIM_SCALE_FROM);
+            self.is_animating_out.set(false);
+            self.reset_ui_state();
+            self.window.set_visible(false);
+            return;
+        }
 
-            qs.is_animating_out.set(false);
-            qs.reset_ui_state();
-            qs.window.set_visible(false);
+        // Ensure the window is fully visible (the idle callback from show_panel
+        // may not have fired yet, leaving window.opacity at 0.0).
+        self.window.set_opacity(1.0);
+
+        // Start (or reverse into) the close animation.
+        self.start_animation(AnimDirection::Closing, generation);
+    }
+
+    /// Ensure the persistent click-catcher exists, creating it lazily.
+    ///
+    /// The click-catcher is shown/hidden each cycle rather than created/destroyed
+    /// to avoid per-cycle allocation of an `ApplicationWindow` + layer-shell surface.
+    fn ensure_click_catcher(self: &Rc<Self>) -> ApplicationWindow {
+        if let Some(ref catcher) = *self.click_catcher.borrow() {
+            return catcher.clone();
+        }
+
+        let app = self
+            .window
+            .application()
+            .expect("QuickSettingsWindow must have an associated Application");
+
+        let bar_zone = calculate_bar_exclusive_zone();
+        let qs_weak = Rc::downgrade(self);
+        let catcher = create_click_catcher(&app, bar_zone, move || {
+            if let Some(qs) = qs_weak.upgrade() {
+                qs.hide_panel();
+            }
         });
+
+        catcher.add_css_class(qs::CLICK_CATCHER);
+
+        *self.click_catcher.borrow_mut() = Some(catcher.clone());
+        catcher
+    }
+
+    /// Start or reverse the open/close animation via a tick callback.
+    ///
+    /// If an animation is already in flight (e.g., opening and user clicks to
+    /// close), the current progress is captured and the animation reverses from
+    /// that point with proportional timing — no snapping.
+    fn start_animation(&self, direction: AnimDirection, generation: u32) {
+        // Cache the current border radius for the duration of this animation.
+        self.anim_shell
+            .set_radius(ConfigManager::global().surface_border_radius() as f32);
+
+        let start_time_us = self
+            .anim_shell
+            .frame_clock()
+            .map(|fc| fc.frame_time())
+            .unwrap_or(0);
+
+        let need_tick = self.anim_state.borrow_mut().prepare(
+            direction,
+            generation,
+            start_time_us,
+            self.anim_shell.opacity(),
+        );
+
+        if !need_tick {
+            return;
+        }
+
+        let anim_state = Rc::clone(&self.anim_state);
+        let anim_gen = Rc::clone(&self.anim_generation);
+        let window_weak = self.window.downgrade();
+        let shell_clone = self.anim_shell.clone();
+
+        self.anim_shell
+            .add_tick_callback(move |shell, frame_clock| {
+                if anim_gen.get() != generation {
+                    return ControlFlow::Break;
+                }
+
+                let now_us = frame_clock.frame_time();
+                let (progress, complete, direction) = {
+                    let state = anim_state.borrow();
+                    if !state.active {
+                        return ControlFlow::Break;
+                    }
+                    (
+                        state.current_progress(now_us),
+                        state.is_complete(now_us),
+                        state.direction,
+                    )
+                };
+
+                // Apply visual state — opacity and scale, no CSS involvement.
+                shell.set_opacity(progress);
+                let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
+                shell_clone.set_scale(scale);
+
+                if complete {
+                    anim_state.borrow_mut().active = false;
+
+                    if direction == AnimDirection::Closing {
+                        shell.set_opacity(0.0);
+                        shell_clone.set_scale(ANIM_SCALE_FROM);
+                        if let Some(window) = window_weak.upgrade()
+                            && let Some(qs) = get_qs_window_data(&window)
+                        {
+                            qs.is_animating_out.set(false);
+                            qs.reset_ui_state();
+                            qs.window.set_visible(false);
+                        }
+                    } else {
+                        shell.set_opacity(1.0);
+                        shell_clone.set_scale(1.0);
+                    }
+                    return ControlFlow::Break;
+                }
+
+                ControlFlow::Continue
+            });
     }
 
     /// Temporarily release exclusive keyboard grab to allow external dialogs
@@ -1577,12 +1716,13 @@ impl QuickSettingsWindowHandle {
     }
 
     pub fn toggle_at(&self, x: i32, monitor: Option<Monitor>) {
-        // Check if window exists and is visible
+        // Check logical state, not window visibility — the window may still
+        // be visible during a close animation but logically_open is already false.
         let is_visible = self
             .window
             .borrow()
             .as_ref()
-            .is_some_and(|w| w.window.is_visible());
+            .is_some_and(|w| w.logically_open.get());
 
         if is_visible {
             // Window is visible — hide it (keep alive for instant re-show)
@@ -1645,6 +1785,6 @@ impl Dismissible for QuickSettingsDismissible {
         self.window
             .borrow()
             .as_ref()
-            .is_some_and(|w| w.window.is_visible())
+            .is_some_and(|w| w.logically_open.get())
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -118,9 +118,9 @@ const AUDIO_SECTION_TOP_MARGIN: i32 = 12;
 /// ## Animation architecture
 ///
 /// Open/close animations are driven by a **tick callback** on the animation
-/// shell (`ScaleBox`), not by CSS `transition:` properties. This avoids
-/// unbounded memory growth observed when CSS transitions are interrupted.
-/// See `LayerShellPopover` for the same pattern.
+/// shell (`ScaleBox`), not by CSS `transition:` properties. CSS `transform:
+/// scale()` transitions are observed to cause unbounded memory growth in
+/// GTK4. See `LayerShellPopover` for the same pattern.
 pub struct QuickSettingsWindow {
     window: ApplicationWindow,
     click_catcher: RefCell<Option<ApplicationWindow>>,

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -1,0 +1,174 @@
+//! A container that simulates scale animation via symmetric rounded clip.
+//!
+//! The child is always allocated at full size — the scale effect is achieved
+//! by clipping to a centered rect in `snapshot()` that grows from smaller to
+//! full size. Combined with opacity fade this approximates `transform: scale()`
+//! without any scale transforms in the render tree (which cause unbounded
+//! memory growth in GTK4).
+//!
+//! Only calls `queue_draw()` on scale changes — no layout or CSS resolution.
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use gtk4::subclass::prelude::*;
+use std::cell::Cell;
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct ScaleBox {
+        /// Current scale factor (1.0 = normal size).
+        pub(super) scale: Cell<f64>,
+        /// Border radius for the rounded clip (pixels).
+        pub(super) radius: Cell<f32>,
+        /// The single child widget.
+        pub(super) child: glib::WeakRef<gtk4::Widget>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ScaleBox {
+        const NAME: &'static str = "VibepanelScaleBox";
+        type Type = super::ScaleBox;
+        type ParentType = gtk4::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("scale-box");
+        }
+    }
+
+    impl ObjectImpl for ScaleBox {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.scale.set(1.0);
+        }
+
+        fn dispose(&self) {
+            if let Some(child) = self.child.upgrade() {
+                child.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for ScaleBox {
+        fn measure(&self, orientation: gtk4::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            if let Some(child) = self.child.upgrade() {
+                child.measure(orientation, for_size)
+            } else {
+                (0, 0, -1, -1)
+            }
+        }
+
+        fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
+            // Full allocation — scale effect is purely visual via snapshot() clipping.
+            if let Some(child) = self.child.upgrade() {
+                child.allocate(width, height, baseline, None);
+            }
+        }
+
+        fn snapshot(&self, snapshot: &gtk4::Snapshot) {
+            let Some(child) = self.child.upgrade() else {
+                return;
+            };
+
+            let s = self.scale.get();
+            let widget = self.obj();
+
+            if (s - 1.0).abs() < f64::EPSILON {
+                widget.snapshot_child(&child, snapshot);
+                return;
+            }
+            if s <= 0.0 {
+                return;
+            }
+
+            // Rounded center-clip: crop edges uniformly, matching surface border radius.
+            let w = widget.width() as f32;
+            let h = widget.height() as f32;
+            let cw = w * s as f32;
+            let ch = h * s as f32;
+            let dx = (w - cw) / 2.0;
+            let dy = (h - ch) / 2.0;
+
+            let radius = self.radius.get();
+            let rect = gtk4::graphene::Rect::new(dx, dy, cw, ch);
+            let rounded = gtk4::gsk::RoundedRect::new(
+                rect,
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+            );
+
+            snapshot.push_rounded_clip(&rounded);
+            widget.snapshot_child(&child, snapshot);
+            snapshot.pop();
+        }
+    }
+}
+
+glib::wrapper! {
+    /// A container that simulates scale via symmetric center-clip in `snapshot()`.
+    /// Child always gets full allocation. No scale transforms in the render tree.
+    pub struct ScaleBox(ObjectSubclass<imp::ScaleBox>)
+        @extends gtk4::Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl Default for ScaleBox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScaleBox {
+    /// Create a new ScaleBox with scale 1.0.
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    /// Get the current scale factor.
+    pub fn scale(&self) -> f64 {
+        self.imp().scale.get()
+    }
+
+    /// Set the border radius used for the rounded clip (pixels).
+    pub fn set_radius(&self, radius: f32) {
+        let imp = self.imp();
+        if (imp.radius.get() - radius).abs() < f32::EPSILON {
+            return;
+        }
+        imp.radius.set(radius);
+        self.queue_draw();
+    }
+
+    /// Set the scale factor and queue a repaint.
+    /// Values below 1.0 crop edges inward; only calls `queue_draw()`.
+    pub fn set_scale(&self, scale: f64) {
+        let imp = self.imp();
+        if (imp.scale.get() - scale).abs() < f64::EPSILON {
+            return;
+        }
+        imp.scale.set(scale.clamp(0.0, 1.0));
+        self.queue_draw();
+    }
+
+    /// Set the single child widget.
+    pub fn set_child(&self, child: &impl IsA<gtk4::Widget>) {
+        let imp = self.imp();
+        if let Some(old) = imp.child.upgrade() {
+            old.unparent();
+        }
+        let widget = child.as_ref();
+        widget.set_parent(self);
+        imp.child.set(Some(widget));
+    }
+
+    /// Remove the current child widget, if any.
+    pub fn remove_child(&self) {
+        if let Some(child) = self.imp().child.upgrade() {
+            child.unparent();
+        }
+        self.imp().child.set(None::<&gtk4::Widget>);
+    }
+}

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -3,8 +3,8 @@
 //! The child is always allocated at full size — the scale effect is achieved
 //! by clipping to a centered rect in `snapshot()` that grows from smaller to
 //! full size. Combined with opacity fade this approximates `transform: scale()`
-//! without any scale transforms in the render tree (which cause unbounded
-//! memory growth in GTK4).
+//! without any scale transforms in the render tree (which are observed to
+//! cause unbounded memory growth in GTK4).
 //!
 //! Only calls `queue_draw()` on scale changes — no layout or CSS resolution.
 

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -611,39 +611,49 @@ impl SystemPopoverBinding {
         let controller: Rc<RefCell<Option<SystemPopoverController>>> = Rc::new(RefCell::new(None));
         let gpu_callback_id: Rc<Cell<Option<CallbackId>>> = Rc::new(Cell::new(None));
         let controller_for_builder = controller.clone();
-        let gpu_cb_for_builder = gpu_callback_id.clone();
 
         let menu_handle = base.create_menu(move || {
-            // Builder runs each time the popover opens.
-            // Start GPU polling so the popover gets fresh data.
+            let (widget, ctrl) = build_system_popover_with_controller();
+            *controller_for_builder.borrow_mut() = Some(ctrl);
+            widget
+        });
+
+        // Reuse the system popover widget across open/close cycles to avoid
+        // per-cycle widget allocation. See GTK issue #7758.
+        menu_handle.set_reuse_content(true);
+
+        // Start GPU polling and subscribe to updates each time the popover opens.
+        let controller_for_show = controller.clone();
+        let gpu_cb_for_show = gpu_callback_id.clone();
+        menu_handle.set_on_show(move || {
             let gpu_service = GpuService::global();
             GpuService::request_polling(&gpu_service);
 
-            let (widget, ctrl) = build_system_popover_with_controller();
-            *controller_for_builder.borrow_mut() = Some(ctrl);
+            // Push fresh system + GPU snapshots so values are current on open.
+            if let Some(ctrl) = controller_for_show.borrow().as_ref() {
+                let sys_snapshot = SystemService::global().snapshot();
+                ctrl.update_from_snapshot(&sys_snapshot);
+                let gpu_snapshot = gpu_service.snapshot();
+                ctrl.update_from_gpu_snapshot(&gpu_snapshot);
+            }
 
-            // Subscribe to GPU snapshot updates so the popover refreshes while open.
-            let controller_for_gpu = controller_for_builder.clone();
+            // Subscribe to GPU snapshot updates so metrics refresh while open.
+            let controller_for_gpu = controller_for_show.clone();
             let cb_id = gpu_service.connect(move |snapshot: &GpuSnapshot| {
                 if let Some(ctrl) = controller_for_gpu.borrow().as_ref() {
                     ctrl.update_from_gpu_snapshot(snapshot);
                 }
             });
-            gpu_cb_for_builder.set(Some(cb_id));
-
-            widget
+            gpu_cb_for_show.set(Some(cb_id));
         });
 
-        // Stop GPU polling and drop the controller so we don't update invisible widgets.
-        let controller_for_close = controller.clone();
+        // Stop GPU polling when the popover closes.
         let gpu_cb_for_close = gpu_callback_id.clone();
         menu_handle.set_on_close(move || {
-            // Disconnect GPU callback before releasing polling.
             if let Some(cb_id) = gpu_cb_for_close.take() {
                 GpuService::global().disconnect(cb_id);
             }
             GpuService::global().release_polling();
-            *controller_for_close.borrow_mut() = None;
         });
 
         Self {

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -618,8 +618,6 @@ impl SystemPopoverBinding {
             widget
         });
 
-        // Reuse the system popover widget across open/close cycles to avoid
-        // per-cycle widget allocation. See GTK issue #7758.
         menu_handle.set_reuse_content(true);
 
         // Start GPU polling and subscribe to updates each time the popover opens.


### PR DESCRIPTION
Work around unbounded memory growth observed when using CSS transitions on GTK4 widgets with nested children. Fixes #80 

Changes:
- Replace CSS transition animations with tick-callback driven animations — Popover open/close animations now use frame-clock tick callbacks with opacity + a custom ScaleBox clip widget instead of CSS transition: scale()/opacity. 
- Persistent popover shells — Layer-shell windows, animation shells, and click-catchers are created lazily and reused across open/close cycles instead of being destroyed and recreated each time.
- Content reuse mode — Battery, calendar, media, and system popovers cache their widget tree across cycles.
- Remove CSS transitions — .popover-animate/.popover-hidden classes removed. Hover background-color transitions disabled unconditionally.
- Fix Rc reference cycles in media and notification builder closures.