### PR TITLE
feat(widgets): merge button for groups with widgets that share popover

### DIFF
--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -1,7 +1,7 @@
 //! Bar window implementation using GTK4 and layer-shell.
 
 use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow};
+use gtk4::{Application, ApplicationWindow, GestureClick, Overlay, gdk};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -10,9 +10,20 @@ use tracing::{debug, info, warn};
 use vibepanel_core::config::{WidgetEntry, WidgetOrGroup};
 use vibepanel_core::{Config, ThemePalette};
 
+/// Horizontal spacing (px) between widgets inside a merge group.
+/// Matches the `.content` horizontal padding in `css/bar.rs`.
+const MERGE_GROUP_SPACING: i32 = 10;
+
+use crate::popover_tracker::PopoverTracker;
 use crate::sectioned_bar::SectionedBar;
-use crate::styles::{class, widget as style_widget};
-use crate::widgets::{self, BarState, QuickSettingsConfig, WidgetConfig, WidgetFactory};
+use crate::services::config_manager::ConfigManager;
+use crate::services::tooltip::TooltipManager;
+use crate::styles::{class, state, widget as style_widget};
+use crate::widgets::{
+    self, BarState, MenuHandle, PopoverKind, QuickSettingsConfig, RippleHandle,
+    SystemPopoverBinding, WidgetConfig, WidgetFactory, popover_kind_for,
+    trigger_ripple_from_gesture,
+};
 
 /// Create and configure the bar window with layer-shell.
 ///
@@ -236,14 +247,54 @@ fn build_widget_or_group(
             surface.append(&content);
             island.append(&surface);
 
+            // Partition into runs of same-popover widgets for merge grouping.
+            // Widgets with custom click handlers stay unmergeable so their
+            // on_click_right / on_click_middle commands aren't silently lost.
+            let kinds: Vec<PopoverKind> = group
+                .iter()
+                .map(|e| {
+                    let (right, middle) = ConfigManager::global().get_click_handlers(&e.name);
+                    if right.is_some() || middle.is_some() {
+                        PopoverKind::Unmergeable
+                    } else {
+                        popover_kind_for(&e.name)
+                    }
+                })
+                .collect();
+            let runs = compute_merge_runs(&kinds);
+
             let mut count = 0;
-            for entry in group {
-                if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id) {
-                    // Remove the .widget class from this widget since it's inside a group
-                    built.widget.remove_css_class(class::WIDGET);
-                    content.append(&built.widget);
-                    state.add_handle(built.handle);
-                    count += 1;
+
+            // Build entries individually (used for singletons and merge fallback).
+            let build_individually =
+                |entries: &[WidgetEntry], content: &gtk4::Box, state: &mut BarState| -> usize {
+                    let mut n = 0;
+                    for entry in entries {
+                        if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id)
+                        {
+                            built.widget.remove_css_class(class::WIDGET);
+                            content.append(&built.widget);
+                            state.add_handle(built.handle);
+                            n += 1;
+                        }
+                    }
+                    n
+                };
+
+            for (kind, start, end) in &runs {
+                let run_entries = &group[*start..*end];
+                let run_len = end - start;
+
+                if run_len >= 2 && *kind != PopoverKind::Unmergeable {
+                    let merged = build_merge_group(run_entries, *kind, &content, state);
+                    if merged > 0 {
+                        count += merged;
+                    } else {
+                        // Merge unsupported for this kind — fall back
+                        count += build_individually(run_entries, &content, state);
+                    }
+                } else {
+                    count += build_individually(run_entries, &content, state);
                 }
             }
 
@@ -256,6 +307,133 @@ fn build_widget_or_group(
             count
         }
     }
+}
+
+/// Partition `PopoverKind` values into runs of adjacent equal values.
+/// `Unmergeable` entries are never grouped — each becomes its own singleton run.
+fn compute_merge_runs(kinds: &[PopoverKind]) -> Vec<(PopoverKind, usize, usize)> {
+    let mut runs = Vec::new();
+    if kinds.is_empty() {
+        return runs;
+    }
+
+    let mut start = 0;
+    while start < kinds.len() {
+        let kind = kinds[start];
+        if kind == PopoverKind::Unmergeable {
+            runs.push((kind, start, start + 1));
+            start += 1;
+        } else {
+            let mut end = start + 1;
+            while end < kinds.len() && kinds[end] == kind {
+                end += 1;
+            }
+            runs.push((kind, start, end));
+            start = end;
+        }
+    }
+    runs
+}
+
+/// Build a merge-group wrapper for adjacent same-popover widgets.
+/// Returns the number of widgets successfully built (0 if unsupported kind).
+fn build_merge_group(
+    entries: &[WidgetEntry],
+    kind: PopoverKind,
+    parent_content: &gtk4::Box,
+    state: &mut BarState,
+) -> usize {
+    // Overlay wrapper — ripple sits on top of the content box.
+    let wrapper = Overlay::new();
+    wrapper.add_css_class(class::WIDGET_MERGE_GROUP);
+    wrapper.add_css_class(state::CLICKABLE);
+    wrapper.set_overflow(gtk4::Overflow::Hidden);
+
+    let inner_content = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    inner_content.add_css_class(class::MERGE_GROUP_CONTENT);
+    inner_content.set_vexpand(true);
+    inner_content.set_valign(gtk4::Align::Fill);
+    inner_content.set_spacing(MERGE_GROUP_SPACING);
+    wrapper.set_child(Some(&inner_content));
+
+    let ripple_handle = RippleHandle::new();
+    wrapper.add_overlay(ripple_handle.widget());
+    wrapper.set_measure_overlay(ripple_handle.widget(), true);
+
+    let widget_name = entries[0].name.clone();
+    let menu_handle = MenuHandle::new_placeholder(widget_name, wrapper.clone());
+
+    let binding = match kind {
+        PopoverKind::System => Some(SystemPopoverBinding::new_for_menu(&menu_handle)),
+        _ => {
+            warn!("Merge group for {:?} popover not yet supported", kind);
+            None
+        }
+    };
+
+    let Some(binding) = binding else {
+        return 0;
+    };
+
+    // Primary click toggles the shared popover. Right/middle-click handlers
+    // are not forwarded — the merge group is a single button, and per-widget
+    // click commands don't have a meaningful target here.
+    let gesture_click = GestureClick::new();
+    gesture_click.set_button(0);
+
+    {
+        let menu_for_cb = menu_handle.clone();
+        let ripple_for_press = ripple_handle.clone();
+        gesture_click.connect_pressed(move |gesture, _n_press, x, y| {
+            let button = gesture.current_button();
+            if button == gdk::BUTTON_PRIMARY {
+                let my_menu_was_visible = menu_for_cb.is_visible();
+
+                TooltipManager::global().cancel_and_hide();
+                PopoverTracker::global().dismiss_active();
+
+                if !my_menu_was_visible {
+                    menu_for_cb.show();
+                }
+
+                trigger_ripple_from_gesture(gesture, x, y, &ripple_for_press);
+            }
+        });
+    }
+
+    wrapper.add_controller(gesture_click.clone());
+
+    let mut built_widgets: Vec<widgets::BuiltWidget> = Vec::new();
+    for entry in entries {
+        if let Some(built) = WidgetFactory::build_passive(entry, &binding) {
+            built_widgets.push(built);
+        }
+    }
+
+    // If only 0–1 widgets survived (e.g. GPU unavailable), don't wrap in a
+    // merge group — return 0 so the caller rebuilds via the normal active path.
+    // Dropped passive widgets clean up their service callbacks via Drop.
+    if built_widgets.len() <= 1 {
+        return 0;
+    }
+
+    let count = built_widgets.len();
+    for built in built_widgets {
+        inner_content.append(&built.widget);
+        state.add_handle(built.handle);
+    }
+
+    parent_content.append(&wrapper);
+    // Keep the menu handle, gesture, and ripple alive
+    state.add_handle(Box::new(menu_handle));
+    state.add_handle(Box::new(gesture_click));
+    state.add_handle(Box::new(ripple_handle));
+    debug!(
+        "Created merge group with {} widget(s) ({:?} popover)",
+        count, kind
+    );
+
+    count
 }
 
 fn create_section(
@@ -528,4 +706,44 @@ fn generate_css(config: &Config, palette: &ThemePalette) -> String {
         "{}\n{}\n{}\n{}",
         css_vars, per_widget_css, utility_css, widget_css
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widgets::PopoverKind::{System, Unmergeable};
+
+    #[test]
+    fn merge_runs_empty() {
+        assert_eq!(compute_merge_runs(&[]), vec![]);
+    }
+
+    #[test]
+    fn merge_runs_unmergeable_never_grouped() {
+        let runs = compute_merge_runs(&[Unmergeable, Unmergeable, Unmergeable]);
+        assert_eq!(
+            runs,
+            vec![
+                (Unmergeable, 0, 1),
+                (Unmergeable, 1, 2),
+                (Unmergeable, 2, 3),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_runs_system_grouping() {
+        // Consecutive System entries merge into one run
+        assert_eq!(
+            compute_merge_runs(&[System, System, System]),
+            vec![(System, 0, 3)]
+        );
+        // Unmergeable breaks a System run; singleton System stays singleton
+        assert_eq!(
+            compute_merge_runs(&[System, System, Unmergeable, System]),
+            vec![(System, 0, 2), (Unmergeable, 2, 3), (System, 3, 4)],
+        );
+        // Single System is its own run
+        assert_eq!(compute_merge_runs(&[System]), vec![(System, 0, 1)]);
+    }
 }

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -27,6 +27,16 @@ pub mod class {
     /// Applied to shared island containers that hold multiple grouped widgets.
     pub const WIDGET_GROUP: &str = "widget-group";
 
+    /// Merge group wrapper (`.widget-merge-group`).
+    /// Merges adjacent same-popover widgets into a single visual button.
+    pub const WIDGET_MERGE_GROUP: &str = "widget-merge-group";
+
+    /// Inner content box of a merge group (`.merge-group-content`).
+    pub const MERGE_GROUP_CONTENT: &str = "merge-group-content";
+
+    /// Passive widget marker (`.passive`).
+    pub const PASSIVE: &str = "passive";
+
     /// Widget visual surface class (`.widget-surface`).
     /// Applied to a GtkBox that carries the widget's background-color and
     /// border-radius. Separated from `.widget` so the click target remains

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -69,12 +69,12 @@ pub fn configure_popover(popover: &Popover) {
 pub struct MenuHandle {
     /// The lazily-initialized popover
     popover: RefCell<Option<Rc<LayerShellPopover>>>,
-    /// Builder function to create the popover content
-    builder: Rc<dyn Fn() -> gtk4::Widget>,
+    /// Builder for popover content. `RefCell` allows `set_builder()` replacement.
+    builder: RefCell<Rc<dyn Fn() -> gtk4::Widget>>,
     /// Widget name for CSS styling
     widget_name: String,
-    /// Parent widget container
-    parent: GtkBox,
+    /// Parent widget container (used for popover anchor positioning)
+    parent: gtk4::Widget,
     /// ID returned from PopoverTracker when this popover is active.
     /// Used to correctly clear ourselves from the tracker on hide.
     tracker_id: Cell<Option<PopoverId>>,
@@ -95,20 +95,51 @@ impl Drop for MenuHandle {
 }
 
 impl MenuHandle {
-    fn new<F>(widget_name: String, builder: F, parent: GtkBox) -> Rc<Self>
+    pub(crate) fn new<F>(
+        widget_name: String,
+        builder: F,
+        parent: impl IsA<gtk4::Widget>,
+    ) -> Rc<Self>
     where
         F: Fn() -> gtk4::Widget + 'static,
     {
         Rc::new(Self {
             popover: RefCell::new(None),
-            builder: Rc::new(builder),
+            builder: RefCell::new(Rc::new(builder)),
             widget_name,
-            parent,
+            parent: parent.upcast(),
             tracker_id: Cell::new(None),
             on_close: RefCell::new(None),
             on_show: RefCell::new(None),
             reuse_content: Cell::new(false),
         })
+    }
+
+    /// Create a menu handle with a placeholder builder, to be replaced via `set_builder()`.
+    pub(crate) fn new_placeholder(widget_name: String, parent: impl IsA<gtk4::Widget>) -> Rc<Self> {
+        Rc::new(Self {
+            popover: RefCell::new(None),
+            builder: RefCell::new(Rc::new(|| {
+                unreachable!(
+                    "placeholder builder called — set_builder() must be called before showing the popover"
+                )
+            })),
+            widget_name,
+            parent: parent.upcast(),
+            tracker_id: Cell::new(None),
+            on_close: RefCell::new(None),
+            on_show: RefCell::new(None),
+            reuse_content: Cell::new(false),
+        })
+    }
+
+    /// Replace the builder function.
+    ///
+    /// Must be called before the popover is first shown; calling it afterward
+    /// has no effect because the `LayerShellPopover` captures the builder at
+    /// creation time.
+    pub(crate) fn set_builder<F: Fn() -> gtk4::Widget + 'static>(&self, builder: F) {
+        *self.builder.borrow_mut() = Rc::new(builder);
     }
 
     /// Ensure the popover is created, creating it lazily if needed.
@@ -138,7 +169,7 @@ impl MenuHandle {
             return None;
         };
 
-        let builder = self.builder.clone();
+        let builder = self.builder.borrow().clone();
         let popover = LayerShellPopover::new(&app, &self.widget_name, move || builder());
 
         // Forward any stored on_close callback
@@ -405,19 +436,18 @@ fn click_target_matches(
 /// The BaseWidget automatically creates an inner `.content` box for consistent
 /// padding and theming across all widgets. Widgets should add their children to
 /// `content()` rather than `widget()` directly.
+///
+/// In **passive** mode (see [`new_passive`](Self::new_passive)), the overlay,
+/// ripple, menu, and gesture fields are `None` — the merge-group wrapper
+/// provides those instead.
 pub struct BaseWidget {
     container: GtkBox,
     content: GtkBox,
-    overlay: Overlay,
-    /// Cairo-based ripple overlay for click-origin Material Design ripple.
-    /// Sits on top of content inside an `Overlay`, draws a flat-opacity
-    /// circle expanding from the click point.
-    ripple_handle: RippleHandle,
-    /// The widget's menu popover, if any. Each BaseWidget supports at most one menu.
-    menu: Rc<RefCell<Option<Rc<MenuHandle>>>>,
-    /// Widget name for CSS class-based styling of popovers (e.g., "clock")
+    overlay: Option<Overlay>,
+    ripple_handle: Option<RippleHandle>,
+    menu: Option<Rc<RefCell<Option<Rc<MenuHandle>>>>>,
     widget_name: String,
-    _gesture_click: GestureClick,
+    _gesture_click: Option<GestureClick>,
     _show_if_timer: Option<glib::SourceId>,
 }
 
@@ -432,9 +462,26 @@ impl BaseWidget {
     /// - The first class in `extra_classes` is used as the widget name for
     ///   popover styling (e.g., "clock" -> popovers get "clock-popover" class).
     pub fn new(extra_classes: &[&str]) -> Self {
+        Self::new_inner(extra_classes, false)
+    }
+
+    /// Create a passive base widget — no GestureClick, no RippleHandle, no menu.
+    ///
+    /// Used by widgets that participate in a merge group, where the merge
+    /// wrapper owns click handling, ripple animation, and the shared popover.
+    /// The widget still builds its visual content (icon, label, tooltip) and
+    /// responds to data service updates.
+    pub(crate) fn new_passive(extra_classes: &[&str]) -> Self {
+        Self::new_inner(extra_classes, true)
+    }
+
+    fn new_inner(extra_classes: &[&str], passive: bool) -> Self {
         let container = GtkBox::new(Orientation::Horizontal, 0);
         container.add_css_class(class::WIDGET);
         container.add_css_class(class::WIDGET_ITEM);
+        if passive {
+            container.add_css_class(class::PASSIVE);
+        }
         container.set_hexpand(false);
         for cls in extra_classes {
             container.add_css_class(cls);
@@ -456,6 +503,22 @@ impl BaseWidget {
         // Disable baseline alignment - it can cause vertical offset issues with text
         content.set_baseline_position(gtk4::BaselinePosition::Center);
 
+        if passive {
+            container.append(&content);
+            let show_if_timer = Self::setup_show_if_timer(&widget_name, &container);
+
+            return Self {
+                container,
+                content,
+                overlay: None,
+                ripple_handle: None,
+                menu: None,
+                widget_name,
+                _gesture_click: None,
+                _show_if_timer: show_if_timer,
+            };
+        }
+
         // Visual surface: rounded background + overflow clipping.
         // Must be a GtkBox (not Overlay) — Overlay doesn't clip background to border-radius.
         let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
@@ -471,10 +534,8 @@ impl BaseWidget {
         overlay.set_hexpand(true);
         overlay.set_vexpand(true);
 
-        // Create Cairo-based ripple overlay for click-origin ripple effect
         let ripple_handle = RippleHandle::new();
         overlay.add_overlay(ripple_handle.widget());
-        // Tell the Overlay to measure this overlay so it fills the full area
         overlay.set_measure_overlay(ripple_handle.widget(), true);
 
         surface.append(&overlay);
@@ -573,11 +634,11 @@ impl BaseWidget {
         Self {
             container,
             content,
-            overlay,
-            ripple_handle,
-            menu,
+            overlay: Some(overlay),
+            ripple_handle: Some(ripple_handle),
+            menu: Some(menu),
             widget_name,
-            _gesture_click: gesture_click,
+            _gesture_click: Some(gesture_click),
             _show_if_timer: show_if_timer,
         }
     }
@@ -795,8 +856,8 @@ impl BaseWidget {
     }
 
     /// Get the ripple handle for triggering ripple animations.
-    pub fn ripple_handle(&self) -> &RippleHandle {
-        &self.ripple_handle
+    pub fn ripple_handle(&self) -> Option<&RippleHandle> {
+        self.ripple_handle.as_ref()
     }
 
     /// Get the inner `.content` box for adding widget children.
@@ -805,8 +866,8 @@ impl BaseWidget {
     }
 
     /// Get the overlay wrapping the content box.
-    pub fn overlay(&self) -> &Overlay {
-        &self.overlay
+    pub fn overlay(&self) -> Option<&Overlay> {
+        self.overlay.as_ref()
     }
 
     /// Create an icon using `IconsService`, apply CSS classes, pack it into the
@@ -859,6 +920,10 @@ impl BaseWidget {
     /// since at widget construction time the widget isn't yet attached to a window.
     ///
     /// Also adds the `clickable` CSS class to enable hover styling for interactive widgets.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a passive BaseWidget (which has no menu slot).
     pub fn create_menu<F>(&self, builder: F) -> Rc<MenuHandle>
     where
         F: Fn() -> gtk4::Widget + 'static,
@@ -867,7 +932,11 @@ impl BaseWidget {
         self.container.add_css_class(state::CLICKABLE);
 
         let handle = MenuHandle::new(self.widget_name.clone(), builder, self.container.clone());
-        *self.menu.borrow_mut() = Some(handle.clone());
+        let menu = self
+            .menu
+            .as_ref()
+            .expect("create_menu called on passive BaseWidget");
+        *menu.borrow_mut() = Some(handle.clone());
         handle
     }
 }

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -80,14 +80,23 @@ impl CpuWidget {
     /// Create a new CPU widget with the given configuration.
     pub fn new(config: CpuConfig) -> Self {
         let base = BaseWidget::new(&[widget::CPU]);
+        let popover_binding = SystemPopoverBinding::new(&base);
+        Self::build(config, base, popover_binding)
+    }
 
+    /// Create a passive CPU widget for use in a merge group.
+    pub fn new_passive(config: CpuConfig, shared_binding: SystemPopoverBinding) -> Self {
+        let base = BaseWidget::new_passive(&[widget::CPU]);
+        Self::build(config, base, shared_binding)
+    }
+
+    /// Shared construction for active and passive modes.
+    fn build(config: CpuConfig, base: BaseWidget, popover_binding: SystemPopoverBinding) -> Self {
         base.set_tooltip("CPU: unknown");
 
         let icon_handle = base.add_icon("cpu-symbolic", &[widget::CPU_ICON]);
 
         let percentage_label = base.add_label(None, &[widget::CPU_LABEL, class::VCENTER_CAPS]);
-
-        let popover_binding = SystemPopoverBinding::new(&base);
 
         icon_handle.widget().set_visible(config.show_icon);
         percentage_label.set_visible(config.show_percentage);

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -88,7 +88,7 @@ sectioned-bar.bar {{
     background-color: {widget_bg_hover};
 }}
 
-/* Pull non-first items left to overlap with previous item's right padding */
+/* Pull non-first items left to overlap adjacent .content padding (2 × 10px) */
 .widget-group .content > .widget-item:not(:first-child) {{
     margin-left: -20px;
 }}
@@ -111,6 +111,32 @@ sectioned-bar.bar {{
    parent .widget-group already provides the base widget background. */
 .widget-group .content > .widget-item.clickable:hover {{
     background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+}}
+
+/* ===== MERGE GROUP ===== */
+
+/* Merge group wrapper — acts as a single visual button for adjacent
+   same-popover widgets. Rounded corners clip the shared ripple effect.
+   overflow:hidden is set in Rust (not a valid GTK4 CSS property). */
+.widget-merge-group {{
+    border-radius: var(--radius-widget);
+}}
+
+/* Merge group hover — shared background for the entire merged button */
+.widget-merge-group.clickable:hover {{
+    background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+}}
+
+/* Passive widgets inside a merge group must not show their own
+   hover — the wrapper provides it. Background is already transparent
+   via .widget-group .widget-surface .widget-surface rule. */
+.merge-group-content > .widget-item.passive:hover {{
+    background-color: transparent;
+}}
+
+/* Pull non-first items left to overlap adjacent .content padding (2 × 10px) */
+.merge-group-content > .widget-item:not(:first-child) {{
+    margin-left: -20px;
 }}
 
 /* Spacing between items inside widgets */

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -100,14 +100,23 @@ impl GpuWidget {
     /// Create a new GPU widget with the given configuration.
     pub fn new(config: GpuConfig) -> Self {
         let base = BaseWidget::new(&[widget::GPU]);
+        let popover_binding = SystemPopoverBinding::new(&base);
+        Self::build(config, base, popover_binding)
+    }
 
+    /// Create a passive GPU widget for use in a merge group.
+    pub fn new_passive(config: GpuConfig, shared_binding: SystemPopoverBinding) -> Self {
+        let base = BaseWidget::new_passive(&[widget::GPU]);
+        Self::build(config, base, shared_binding)
+    }
+
+    /// Shared construction for active and passive modes.
+    fn build(config: GpuConfig, base: BaseWidget, popover_binding: SystemPopoverBinding) -> Self {
         base.set_tooltip("GPU: unknown");
 
         let icon_handle = base.add_icon("video-display-symbolic", &[widget::GPU_ICON]);
 
         let gpu_label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
-
-        let popover_binding = SystemPopoverBinding::new(&base);
 
         icon_handle.widget().set_visible(config.show_icon);
 

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -791,11 +791,11 @@ impl MediaWidget {
         // Use insert_before to place it behind the content box in paint order.
         // When disabled in config, skip creation entirely to avoid spawning cava.
         let bar_visualizer = if config.visualizer {
+            let overlay = base.overlay().expect("media uses active BaseWidget");
             let viz = BarVisualizer::new();
-            base.overlay().add_overlay(viz.widget());
-            base.overlay().set_measure_overlay(viz.widget(), false);
-            viz.widget()
-                .insert_before(base.overlay(), Some(base.content()));
+            overlay.add_overlay(viz.widget());
+            overlay.set_measure_overlay(viz.widget(), false);
+            viz.widget().insert_before(overlay, Some(base.content()));
             Some(viz)
         } else {
             None

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -100,14 +100,27 @@ impl MemoryWidget {
     /// Create a new Memory widget with the given configuration.
     pub fn new(config: MemoryConfig) -> Self {
         let base = BaseWidget::new(&[widget::MEMORY]);
+        let popover_binding = SystemPopoverBinding::new(&base);
+        Self::build(config, base, popover_binding)
+    }
 
+    /// Create a passive Memory widget for use in a merge group.
+    pub fn new_passive(config: MemoryConfig, shared_binding: SystemPopoverBinding) -> Self {
+        let base = BaseWidget::new_passive(&[widget::MEMORY]);
+        Self::build(config, base, shared_binding)
+    }
+
+    /// Shared construction for active and passive modes.
+    fn build(
+        config: MemoryConfig,
+        base: BaseWidget,
+        popover_binding: SystemPopoverBinding,
+    ) -> Self {
         base.set_tooltip("Memory: unknown");
 
         let icon_handle = base.add_icon("ram-symbolic", &[widget::MEMORY_ICON]);
 
         let memory_label = base.add_label(None, &[widget::MEMORY_LABEL, class::VCENTER_CAPS]);
-
-        let popover_binding = SystemPopoverBinding::new(&base);
 
         icon_handle.widget().set_visible(config.show_icon);
 

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -51,6 +51,7 @@ pub mod css;
 pub mod quick_settings;
 
 pub use base::BaseWidget;
+pub(crate) use base::{MenuHandle, RippleHandle, trigger_ripple_from_gesture};
 pub use battery::{BatteryConfig, BatteryWidget};
 pub use clock::{ClockConfig, ClockWidget};
 pub use media::{MediaConfig, MediaWidget};
@@ -70,11 +71,32 @@ pub use gpu::{GpuConfig, GpuWidget};
 pub use memory::{MemoryConfig, MemoryWidget};
 pub use network_speed::{NetworkSpeedConfig, NetworkSpeedWidget};
 
+pub(crate) use system_popover::SystemPopoverBinding;
+
 use gtk4::Widget;
 use gtk4::prelude::*;
 use std::any::Any;
 use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
+
+/// The kind of shared popover a widget opens when clicked.
+///
+/// Used by merge-group logic to identify adjacent widgets that can be
+/// visually merged into a single button with shared hover/ripple/popover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PopoverKind {
+    System,
+    /// Widget has no popover or its popover is not mergeable.
+    Unmergeable,
+}
+
+/// Return the popover kind for a given widget name.
+pub(crate) fn popover_kind_for(widget_name: &str) -> PopoverKind {
+    match widget_name {
+        "cpu" | "memory" | "gpu" | "network_speed" => PopoverKind::System,
+        _ => PopoverKind::Unmergeable,
+    }
+}
 
 use crate::services::battery::BatteryService;
 use crate::services::gpu::GpuService;
@@ -335,6 +357,65 @@ impl WidgetFactory {
             }
         }
     }
+
+    /// Build a widget in passive mode for a merge group.
+    ///
+    /// Returns `None` for unsupported widget types or if the widget should be
+    /// skipped (e.g., gpu when no GPU is detected).
+    pub(crate) fn build_passive(
+        entry: &WidgetEntry,
+        shared_binding: &SystemPopoverBinding,
+    ) -> Option<BuiltWidget> {
+        match entry.name.as_str() {
+            "cpu" => {
+                let cfg = CpuConfig::from_entry(entry);
+                let cpu = CpuWidget::new_passive(cfg, shared_binding.clone());
+                let root = cpu.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(cpu),
+                })
+            }
+            "memory" => {
+                let cfg = MemoryConfig::from_entry(entry);
+                let memory = MemoryWidget::new_passive(cfg, shared_binding.clone());
+                let root = memory.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(memory),
+                })
+            }
+            "gpu" => {
+                if !GpuService::global().snapshot().available {
+                    debug!("Skipping gpu widget: no supported GPU detected");
+                    return None;
+                }
+                let cfg = GpuConfig::from_entry(entry);
+                let gpu = GpuWidget::new_passive(cfg, shared_binding.clone());
+                let root = gpu.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(gpu),
+                })
+            }
+            "network_speed" => {
+                let cfg = NetworkSpeedConfig::from_entry(entry);
+                let network = NetworkSpeedWidget::new_passive(cfg, shared_binding.clone());
+                let root = network.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(network),
+                })
+            }
+            name => {
+                warn!(
+                    "build_passive called for unsupported widget type: '{}'",
+                    name
+                );
+                None
+            }
+        }
+    }
 }
 
 /// Holds widget handles to keep them alive for the lifetime of the bar.
@@ -368,5 +449,26 @@ impl BarState {
 impl Default for BarState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn popover_kind_system_widgets() {
+        assert_eq!(popover_kind_for("cpu"), PopoverKind::System);
+        assert_eq!(popover_kind_for("memory"), PopoverKind::System);
+        assert_eq!(popover_kind_for("gpu"), PopoverKind::System);
+        assert_eq!(popover_kind_for("network_speed"), PopoverKind::System);
+    }
+
+    #[test]
+    fn popover_kind_non_system_widgets() {
+        assert_eq!(popover_kind_for("clock"), PopoverKind::Unmergeable);
+        assert_eq!(popover_kind_for("battery"), PopoverKind::Unmergeable);
+        assert_eq!(popover_kind_for("media"), PopoverKind::Unmergeable);
+        assert_eq!(popover_kind_for("unknown"), PopoverKind::Unmergeable);
     }
 }

--- a/crates/vibepanel/src/widgets/network_speed.rs
+++ b/crates/vibepanel/src/widgets/network_speed.rs
@@ -125,7 +125,22 @@ impl NetworkSpeedWidget {
     /// Create a new Network widget with the given configuration.
     pub fn new(config: NetworkSpeedConfig) -> Self {
         let base = BaseWidget::new(&[widget::NETWORK_SPEED]);
+        let popover_binding = SystemPopoverBinding::new(&base);
+        Self::build(config, base, popover_binding)
+    }
 
+    /// Create a passive Network widget for use in a merge group.
+    pub fn new_passive(config: NetworkSpeedConfig, shared_binding: SystemPopoverBinding) -> Self {
+        let base = BaseWidget::new_passive(&[widget::NETWORK_SPEED]);
+        Self::build(config, base, shared_binding)
+    }
+
+    /// Shared construction for active and passive modes.
+    fn build(
+        config: NetworkSpeedConfig,
+        base: BaseWidget,
+        popover_binding: SystemPopoverBinding,
+    ) -> Self {
         base.set_tooltip("Network: unknown");
 
         let icon_handle = base.add_icon(
@@ -166,8 +181,6 @@ impl NetworkSpeedWidget {
         } else {
             (None, None)
         };
-
-        let popover_binding = SystemPopoverBinding::new(&base);
 
         icon_handle.widget().set_visible(config.show_icon);
 

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -535,7 +535,10 @@ impl QuickSettingsWidget {
         gesture.set_propagation_phase(gtk4::PropagationPhase::Capture);
 
         {
-            let ripple = base.ripple_handle().clone();
+            let ripple = base
+                .ripple_handle()
+                .expect("QuickSettings uses active BaseWidget")
+                .clone();
             let qs_window_handle = qs_window.clone();
             let root = base.widget().clone();
             gesture.connect_pressed(move |gesture, _n_press, x, y| {

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -608,11 +608,31 @@ impl SystemPopoverBinding {
     /// A GPU service callback is also registered while the popover is open so that
     /// GPU metrics update live (even when there is no GPU bar widget).
     pub fn new(base: &crate::widgets::base::BaseWidget) -> Self {
+        let menu_handle = base.create_menu(|| {
+            // Replaced by wire_lifecycle before the popover is shown
+            gtk4::Label::new(None).upcast::<Widget>()
+        });
+        Self::wire_lifecycle(&menu_handle)
+    }
+
+    /// Create a binding that uses an existing `MenuHandle` instead of creating
+    /// one from a `BaseWidget`.
+    ///
+    /// Used by the merge-group wrapper in `bar.rs`: the wrapper owns a single
+    /// shared `MenuHandle` and all passive widgets in the group share this
+    /// binding to update the popover when it's open.
+    pub(crate) fn new_for_menu(menu_handle: &Rc<crate::widgets::base::MenuHandle>) -> Self {
+        Self::wire_lifecycle(menu_handle)
+    }
+
+    /// Shared lifecycle wiring: installs the builder, reuse-content mode,
+    /// and on-show/on-close callbacks for GPU polling on a `MenuHandle`.
+    fn wire_lifecycle(menu_handle: &Rc<crate::widgets::base::MenuHandle>) -> Self {
         let controller: Rc<RefCell<Option<SystemPopoverController>>> = Rc::new(RefCell::new(None));
         let gpu_callback_id: Rc<Cell<Option<CallbackId>>> = Rc::new(Cell::new(None));
-        let controller_for_builder = controller.clone();
 
-        let menu_handle = base.create_menu(move || {
+        let controller_for_builder = controller.clone();
+        menu_handle.set_builder(move || {
             let (widget, ctrl) = build_system_popover_with_controller();
             *controller_for_builder.borrow_mut() = Some(ctrl);
             widget
@@ -620,14 +640,13 @@ impl SystemPopoverBinding {
 
         menu_handle.set_reuse_content(true);
 
-        // Start GPU polling and subscribe to updates each time the popover opens.
+        // Start GPU polling and push fresh snapshots each time the popover opens.
         let controller_for_show = controller.clone();
         let gpu_cb_for_show = gpu_callback_id.clone();
         menu_handle.set_on_show(move || {
             let gpu_service = GpuService::global();
             GpuService::request_polling(&gpu_service);
 
-            // Push fresh system + GPU snapshots so values are current on open.
             if let Some(ctrl) = controller_for_show.borrow().as_ref() {
                 let sys_snapshot = SystemService::global().snapshot();
                 ctrl.update_from_snapshot(&sys_snapshot);
@@ -635,7 +654,6 @@ impl SystemPopoverBinding {
                 ctrl.update_from_gpu_snapshot(&gpu_snapshot);
             }
 
-            // Subscribe to GPU snapshot updates so metrics refresh while open.
             let controller_for_gpu = controller_for_show.clone();
             let cb_id = gpu_service.connect(move |snapshot: &GpuSnapshot| {
                 if let Some(ctrl) = controller_for_gpu.borrow().as_ref() {


### PR DESCRIPTION
When adjacent widgets in a group share the same popover type (cpu, memory, gpu), merge them into a single visual button with shared hover background, ripple animation, and popover.