### PR TITLE
feat: toggle bar and popover with the cli

### DIFF
--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -5,6 +5,7 @@ use gtk4::{Application, ApplicationWindow, GestureClick, Overlay, gdk};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::RefCell;
 use std::path::PathBuf;
+use std::rc::Rc;
 use tracing::{debug, info, warn};
 
 use vibepanel_core::config::{WidgetEntry, WidgetOrGroup};
@@ -148,6 +149,12 @@ pub fn create_bar_window(
     // Create handle for this bar's Quick Settings window.
     // The window is created lazily on first open and kept alive for instant re-show.
     let qs_handle = crate::widgets::QuickSettingsWindowHandle::new(app.clone(), qs_config.clone());
+
+    // Register QS handle with the popover registry for IPC control.
+    crate::popover_registry::register(
+        "quick_settings",
+        Rc::new(qs_handle.clone()) as Rc<dyn crate::popover_registry::PopoverToggleable>,
+    );
 
     // Create left section
     let left_section = create_section("left", config, state, &qs_handle, Some(output_id));
@@ -424,6 +431,16 @@ fn build_merge_group(
     }
 
     parent_content.append(&wrapper);
+
+    // Register the shared menu handle under ALL participating widget names
+    // for IPC popover control. Uses underscores (config convention).
+    for entry in entries {
+        crate::popover_registry::register(
+            &entry.name,
+            menu_handle.clone() as Rc<dyn crate::popover_registry::PopoverToggleable>,
+        );
+    }
+
     // Keep the menu handle, gesture, and ripple alive
     state.add_handle(Box::new(menu_handle));
     state.add_handle(Box::new(gesture_click));

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -170,14 +170,14 @@ enum BarAction {
 
 #[derive(Subcommand, Debug)]
 enum PopoverAction {
-    /// Open a widget's popover
-    Open {
+    /// Show a widget's popover
+    Show {
         /// Widget name (e.g., clock, battery, quick-settings)
         widget: String,
     },
-    /// Close a popover (dismiss active if no widget specified)
-    Close {
-        /// Widget name (optional — closes active popover if omitted)
+    /// Hide a popover (dismiss active if no widget specified)
+    Hide {
+        /// Widget name (optional — hides active popover if omitted)
         widget: Option<String>,
     },
     /// Toggle a widget's popover
@@ -534,13 +534,13 @@ fn handle_bar_command(action: BarAction) -> ExitCode {
     }
 }
 
-/// Handle popover subcommands (open/close/toggle) via IPC.
+/// Handle popover subcommands (show/hide/toggle) via IPC.
 fn handle_popover_command(action: PopoverAction) -> ExitCode {
     use crate::services::ipc::{IpcMessage, PopoverIpcAction, send_ipc_message};
 
     let ipc_action = match action {
-        PopoverAction::Open { widget } => PopoverIpcAction::Open(widget),
-        PopoverAction::Close { widget } => PopoverIpcAction::Close(widget),
+        PopoverAction::Show { widget } => PopoverIpcAction::Show(widget),
+        PopoverAction::Hide { widget } => PopoverIpcAction::Hide(widget),
         PopoverAction::Toggle { widget } => PopoverIpcAction::Toggle(widget),
     };
     let msg = IpcMessage::Popover { action: ipc_action };
@@ -759,14 +759,14 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
                             use crate::popover_registry::{self as registry, DispatchAction};
                             use crate::services::ipc::PopoverIpcAction;
                             match action {
-                                PopoverIpcAction::Open(name) => {
+                                PopoverIpcAction::Show(name) => {
                                     registry::dispatch(name, DispatchAction::Show);
                                 }
-                                PopoverIpcAction::Close(None) => {
+                                PopoverIpcAction::Hide(None) => {
                                     crate::popover_tracker::PopoverTracker::global()
                                         .dismiss_active();
                                 }
-                                PopoverIpcAction::Close(Some(name)) => {
+                                PopoverIpcAction::Hide(Some(name)) => {
                                     registry::dispatch(name, DispatchAction::Hide);
                                 }
                                 PopoverIpcAction::Toggle(name) => {

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -4,6 +4,7 @@
 
 mod bar;
 pub mod layout_math;
+pub mod popover_registry;
 pub mod popover_tracker;
 mod sectioned_bar;
 mod services;
@@ -70,6 +71,16 @@ enum Command {
     Media {
         #[command(subcommand)]
         action: MediaAction,
+    },
+    /// Control bar visibility
+    Bar {
+        #[command(subcommand)]
+        action: BarAction,
+    },
+    /// Control widget popovers
+    Popover {
+        #[command(subcommand)]
+        action: PopoverAction,
     },
 }
 
@@ -147,6 +158,35 @@ enum InhibitAction {
     Toggle,
 }
 
+#[derive(Subcommand, Debug)]
+enum BarAction {
+    /// Show the bar
+    Show,
+    /// Hide the bar (releases exclusive zone)
+    Hide,
+    /// Toggle bar visibility
+    Toggle,
+}
+
+#[derive(Subcommand, Debug)]
+enum PopoverAction {
+    /// Open a widget's popover
+    Open {
+        /// Widget name (e.g., clock, battery, quick-settings)
+        widget: String,
+    },
+    /// Close a popover (dismiss active if no widget specified)
+    Close {
+        /// Widget name (optional — closes active popover if omitted)
+        widget: Option<String>,
+    },
+    /// Toggle a widget's popover
+    Toggle {
+        /// Widget name (e.g., clock, battery, quick-settings)
+        widget: String,
+    },
+}
+
 fn main() -> ExitCode {
     let args = Args::parse();
 
@@ -220,6 +260,8 @@ fn handle_command(command: Command) -> ExitCode {
         Command::Volume { action } => handle_volume_command(action),
         Command::Inhibit { action } => handle_inhibit_command(action),
         Command::Media { action } => handle_media_command(action),
+        Command::Bar { action } => handle_bar_command(action),
+        Command::Popover { action } => handle_popover_command(action),
     }
 }
 
@@ -470,6 +512,50 @@ fn handle_media_command(action: MediaAction) -> ExitCode {
     }
 }
 
+/// Handle bar subcommands (show/hide/toggle) via IPC.
+fn handle_bar_command(action: BarAction) -> ExitCode {
+    use crate::services::ipc::{BarIpcAction, IpcMessage, send_ipc_message};
+
+    let ipc_action = match action {
+        BarAction::Show => BarIpcAction::Show,
+        BarAction::Hide => BarIpcAction::Hide,
+        BarAction::Toggle => BarIpcAction::Toggle,
+    };
+    let msg = IpcMessage::Bar { action: ipc_action };
+    match send_ipc_message(&msg) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!(
+                "Error: could not reach vibepanel IPC socket (is the panel running?): {}",
+                e
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Handle popover subcommands (open/close/toggle) via IPC.
+fn handle_popover_command(action: PopoverAction) -> ExitCode {
+    use crate::services::ipc::{IpcMessage, PopoverIpcAction, send_ipc_message};
+
+    let ipc_action = match action {
+        PopoverAction::Open { widget } => PopoverIpcAction::Open(widget),
+        PopoverAction::Close { widget } => PopoverIpcAction::Close(widget),
+        PopoverAction::Toggle { widget } => PopoverIpcAction::Toggle(widget),
+    };
+    let msg = IpcMessage::Popover { action: ipc_action };
+    match send_ipc_message(&msg) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!(
+                "Error: could not reach vibepanel IPC socket (is the panel running?): {}",
+                e
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
 /// Initialize and run the GTK4 application.
 fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
     // Log the config source for diagnostics
@@ -658,6 +744,34 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
                         | IpcMessage::Brightness { .. } => {
                             if let Some(ref overlay) = osd_for_ipc {
                                 overlay.handle_ipc_message(&msg);
+                            }
+                        }
+                        IpcMessage::Bar { action } => {
+                            use crate::services::ipc::BarIpcAction;
+                            let manager = BarManager::global();
+                            match action {
+                                BarIpcAction::Show => manager.ipc_show(),
+                                BarIpcAction::Hide => manager.ipc_hide(),
+                                BarIpcAction::Toggle => manager.ipc_toggle(),
+                            }
+                        }
+                        IpcMessage::Popover { action } => {
+                            use crate::popover_registry::{self as registry, DispatchAction};
+                            use crate::services::ipc::PopoverIpcAction;
+                            match action {
+                                PopoverIpcAction::Open(name) => {
+                                    registry::dispatch(name, DispatchAction::Show);
+                                }
+                                PopoverIpcAction::Close(None) => {
+                                    crate::popover_tracker::PopoverTracker::global()
+                                        .dismiss_active();
+                                }
+                                PopoverIpcAction::Close(Some(name)) => {
+                                    registry::dispatch(name, DispatchAction::Hide);
+                                }
+                                PopoverIpcAction::Toggle(name) => {
+                                    registry::dispatch(name, DispatchAction::Toggle);
+                                }
                             }
                         }
                     }

--- a/crates/vibepanel/src/popover_registry.rs
+++ b/crates/vibepanel/src/popover_registry.rs
@@ -1,0 +1,164 @@
+//! Name-based popover registry for IPC control.
+//!
+//! Maps widget names (e.g., "clock", "quick_settings") to their
+//! `PopoverToggleable` handles, enabling IPC commands like
+//! `vibepanel popover open clock`.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use tracing::{debug, warn};
+
+/// Trait for popovers that can be controlled via IPC.
+///
+/// Object-safe: no generics, no `Self` return types, no `Sized` bound.
+pub trait PopoverToggleable {
+    /// Show the popover (idempotent — no-op if already visible).
+    fn ipc_show(&self);
+    /// Hide the popover (idempotent — no-op if already hidden).
+    fn ipc_hide(&self);
+    /// Toggle the popover visibility.
+    ///
+    /// Default calls `ipc_show()`/`ipc_hide()` based on `ipc_is_visible()`.
+    /// Implementors may override if their toggle has different semantics.
+    fn ipc_toggle(&self) {
+        if self.ipc_is_visible() {
+            self.ipc_hide();
+        } else {
+            self.ipc_show();
+        }
+    }
+    /// Check if the popover is currently visible.
+    fn ipc_is_visible(&self) -> bool;
+
+    /// Enable keyboard navigation for this popover.
+    /// Default: no-op. Implementors override to remove `.vp-no-focus`.
+    fn ipc_enable_keyboard_nav(&self) {}
+
+    /// Prepare deferred keyboard navigation for IPC-opened popovers.
+    ///
+    /// Clears auto-focus and installs a one-shot Tab listener. On first Tab,
+    /// `enable_keyboard_nav()` fires and Tab propagates through GTK's own
+    /// keynav path — landing on the first widget with correct `:focus-visible`.
+    ///
+    /// Default: falls back to `ipc_enable_keyboard_nav()` (immediate activation).
+    fn ipc_prepare_keyboard_nav(&self) {
+        self.ipc_enable_keyboard_nav();
+    }
+
+    /// Return the monitor connector name (e.g., "eDP-1") this handle belongs to.
+    /// Used on multi-monitor setups to dispatch to the focused monitor's handle.
+    /// Default: `None` (treat as unknown — will match any monitor as fallback).
+    fn monitor_connector(&self) -> Option<String> {
+        None
+    }
+}
+
+/// Actions that can be dispatched to a registered popover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchAction {
+    Show,
+    Hide,
+    Toggle,
+}
+
+thread_local! {
+    static REGISTRY: RefCell<HashMap<String, Vec<Rc<dyn PopoverToggleable>>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Register a popover handle under the given widget name.
+///
+/// Names use underscores internally (e.g., "quick_settings"). The CLI uses
+/// hyphens ("quick-settings") and normalization happens at dispatch time.
+///
+/// On multi-monitor setups, multiple handles may be registered under the same
+/// name (one per bar). Dispatch resolves to the focused monitor's handle.
+pub fn register(name: &str, handle: Rc<dyn PopoverToggleable>) {
+    REGISTRY.with(|r| {
+        debug!("PopoverRegistry: registered '{}'", name);
+        r.borrow_mut()
+            .entry(name.to_string())
+            .or_default()
+            .push(handle);
+    });
+}
+
+/// Dispatch an action to a named popover.
+///
+/// The name is normalized (hyphens -> underscores) before lookup.
+/// On multi-monitor setups, dispatches to the handle on the focused monitor.
+/// Falls back to the first registered handle if the focused monitor can't be determined.
+/// Returns `true` if a handle was found and the action was dispatched.
+pub fn dispatch(name: &str, action: DispatchAction) -> bool {
+    let normalized = name.replace('-', "_");
+    let handle = REGISTRY.with(|r| {
+        let reg = r.borrow();
+        let handles = reg.get(&normalized)?;
+        if handles.len() == 1 {
+            return Some(handles[0].clone());
+        }
+        // Multi-monitor: resolve to the focused monitor's handle.
+        resolve_focused_handle(handles)
+    });
+
+    if let Some(handle) = handle {
+        match action {
+            DispatchAction::Show => handle.ipc_show(),
+            DispatchAction::Hide => handle.ipc_hide(),
+            DispatchAction::Toggle => handle.ipc_toggle(),
+        }
+        debug!(
+            "PopoverRegistry: dispatched {:?} to '{}'",
+            action, normalized
+        );
+        true
+    } else {
+        warn!(
+            "PopoverRegistry: no handle registered for '{}' (normalized from '{}')",
+            normalized, name
+        );
+        false
+    }
+}
+
+/// Resolve which handle to dispatch to based on the focused monitor.
+///
+/// Queries the compositor for the focused window's output, then finds the
+/// handle whose `monitor_connector()` matches. Falls back to the first handle.
+fn resolve_focused_handle(
+    handles: &[Rc<dyn PopoverToggleable>],
+) -> Option<Rc<dyn PopoverToggleable>> {
+    if handles.is_empty() {
+        return None;
+    }
+    let focused_output = crate::services::compositor::CompositorManager::global()
+        .get_focused_window()
+        .and_then(|w| w.output);
+
+    if let Some(ref output) = focused_output {
+        for handle in handles {
+            if handle.monitor_connector().as_deref() == Some(output) {
+                return Some(handle.clone());
+            }
+        }
+        debug!(
+            "PopoverRegistry: no handle matches focused output '{}', using first",
+            output
+        );
+    }
+    Some(handles[0].clone())
+}
+
+/// Clear all registered handles.
+///
+/// Called from `BarManager::reconfigure_all()` before bars are destroyed.
+/// New registrations happen during bar rebuild.
+pub fn clear() {
+    REGISTRY.with(|r| {
+        let count: usize = r.borrow().values().map(|v| v.len()).sum();
+        r.borrow_mut().clear();
+        debug!("PopoverRegistry: cleared {} handle(s)", count);
+    });
+}

--- a/crates/vibepanel/src/popover_registry.rs
+++ b/crates/vibepanel/src/popover_registry.rs
@@ -32,21 +32,6 @@ pub trait PopoverToggleable {
     /// Check if the popover is currently visible.
     fn ipc_is_visible(&self) -> bool;
 
-    /// Enable keyboard navigation for this popover.
-    /// Default: no-op. Implementors override to remove `.vp-no-focus`.
-    fn ipc_enable_keyboard_nav(&self) {}
-
-    /// Prepare deferred keyboard navigation for IPC-opened popovers.
-    ///
-    /// Clears auto-focus and installs a one-shot Tab listener. On first Tab,
-    /// `enable_keyboard_nav()` fires and Tab propagates through GTK's own
-    /// keynav path — landing on the first widget with correct `:focus-visible`.
-    ///
-    /// Default: falls back to `ipc_enable_keyboard_nav()` (immediate activation).
-    fn ipc_prepare_keyboard_nav(&self) {
-        self.ipc_enable_keyboard_nav();
-    }
-
     /// Return the monitor connector name (e.g., "eDP-1") this handle belongs to.
     /// Used on multi-monitor setups to dispatch to the focused monitor's handle.
     /// Default: `None` (treat as unknown — will match any monitor as fallback).

--- a/crates/vibepanel/src/services/bar_manager.rs
+++ b/crates/vibepanel/src/services/bar_manager.rs
@@ -19,7 +19,7 @@
 //! - Widget list changes
 //! - Output allow-list changes
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
@@ -67,6 +67,8 @@ pub struct BarManager {
     app: RefCell<Option<Application>>,
     /// Bar instances keyed by monitor connector name.
     bars: RefCell<HashMap<String, BarInstance>>,
+    /// Whether bars are hidden via IPC (full hide: exclusive zone + opacity + input).
+    hidden: Cell<bool>,
 }
 
 // Thread-local singleton storage
@@ -101,6 +103,7 @@ impl BarManager {
         Rc::new(Self {
             app: RefCell::new(None),
             bars: RefCell::new(HashMap::new()),
+            hidden: Cell::new(false),
         })
     }
 
@@ -159,6 +162,11 @@ impl BarManager {
         };
 
         self.bars.borrow_mut().insert(key.clone(), instance);
+
+        // If bars are IPC-hidden, unmap the newly created bar immediately
+        if self.hidden.get() {
+            window.set_visible(false);
+        }
 
         info!(
             "Created bar for monitor key={} connector={:?}",
@@ -237,6 +245,10 @@ impl BarManager {
     pub fn reconfigure_all(&self, display: &gtk4::gdk::Display, config: &Config) {
         info!("Reconfiguring all bars...");
 
+        // Clear the popover registry before destroying bars — handles will be
+        // re-registered during bar rebuild.
+        crate::popover_registry::clear();
+
         // Remove all existing bars
         let keys: Vec<String> = self.bars.borrow().keys().cloned().collect();
         for key in keys {
@@ -295,11 +307,58 @@ impl BarManager {
     /// Show all bars.
     ///
     /// Called after sync_monitors to reveal bars that weren't removed.
+    /// No-op if bars are IPC-hidden (the hidden state takes precedence).
     pub fn show_all(&self) {
+        if self.hidden.get() {
+            debug!("show_all skipped: bars are IPC-hidden");
+            return;
+        }
         for instance in self.bars.borrow().values() {
             instance.window.set_opacity(1.0);
         }
         debug!("All bars shown after monitor sync");
+    }
+
+    /// Hide all bars via IPC (full hide).
+    ///
+    /// Unmaps bar surfaces so they are completely invisible and release their
+    /// exclusive zone. Uses `set_visible(false)` which unmaps the layer-shell
+    /// surface at the compositor level — `set_opacity(0.0)` alone is not
+    /// sufficient because the compositor still composites the surface.
+    pub fn ipc_hide(&self) {
+        if self.hidden.get() {
+            return;
+        }
+        self.hidden.set(true);
+        for instance in self.bars.borrow().values() {
+            instance.window.set_visible(false);
+        }
+        info!("Bars hidden via IPC");
+    }
+
+    /// Show all bars via IPC (reverse full hide).
+    ///
+    /// Remaps bar surfaces. Layer-shell properties (anchors, monitor binding,
+    /// auto exclusive zone) are preserved across unmap/remap cycles by
+    /// gtk4-layer-shell, so `set_visible(true)` restores the bar fully.
+    pub fn ipc_show(&self) {
+        if !self.hidden.get() {
+            return;
+        }
+        self.hidden.set(false);
+        for instance in self.bars.borrow().values() {
+            instance.window.set_visible(true);
+        }
+        info!("Bars shown via IPC");
+    }
+
+    /// Toggle bar visibility via IPC.
+    pub fn ipc_toggle(&self) {
+        if self.hidden.get() {
+            self.ipc_show();
+        } else {
+            self.ipc_hide();
+        }
     }
 }
 

--- a/crates/vibepanel/src/services/ipc.rs
+++ b/crates/vibepanel/src/services/ipc.rs
@@ -39,6 +39,25 @@ pub fn socket_path() -> PathBuf {
     }
 }
 
+/// Bar visibility actions for IPC control.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BarIpcAction {
+    Show,
+    Hide,
+    Toggle,
+}
+
+/// Popover control actions for IPC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PopoverIpcAction {
+    /// Open a specific widget's popover.
+    Open(String),
+    /// Close a specific widget's popover, or dismiss the active one if no target.
+    Close(Option<String>),
+    /// Toggle a specific widget's popover.
+    Toggle(String),
+}
+
 /// Panel IPC message types.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IpcMessage {
@@ -50,6 +69,10 @@ pub enum IpcMessage {
     Brightness { percent: u32 },
     /// Toggle the idle inhibitor on/off.
     ToggleInhibitor,
+    /// Control bar visibility (show/hide/toggle).
+    Bar { action: BarIpcAction },
+    /// Control a popover (open/close/toggle).
+    Popover { action: PopoverIpcAction },
 }
 
 impl IpcMessage {
@@ -62,6 +85,17 @@ impl IpcMessage {
             IpcMessage::VolumeUnavailable => "volume_unavailable".to_string(),
             IpcMessage::Brightness { percent } => format!("brightness:{}", percent),
             IpcMessage::ToggleInhibitor => "toggle_inhibitor".to_string(),
+            IpcMessage::Bar { action } => match action {
+                BarIpcAction::Show => "bar:show".to_string(),
+                BarIpcAction::Hide => "bar:hide".to_string(),
+                BarIpcAction::Toggle => "bar:toggle".to_string(),
+            },
+            IpcMessage::Popover { action } => match action {
+                PopoverIpcAction::Open(name) => format!("popover:open:{}", name),
+                PopoverIpcAction::Close(None) => "popover:close".to_string(),
+                PopoverIpcAction::Close(Some(name)) => format!("popover:close:{}", name),
+                PopoverIpcAction::Toggle(name) => format!("popover:toggle:{}", name),
+            },
         }
     }
 
@@ -85,6 +119,50 @@ impl IpcMessage {
         if let Some(rest) = s.strip_prefix("brightness:") {
             let percent = rest.parse().ok()?;
             return Some(IpcMessage::Brightness { percent });
+        }
+        // Bar commands: bar:show, bar:hide, bar:toggle
+        if let Some(rest) = s.strip_prefix("bar:") {
+            let action = match rest {
+                "show" => BarIpcAction::Show,
+                "hide" => BarIpcAction::Hide,
+                "toggle" => BarIpcAction::Toggle,
+                _ => return None,
+            };
+            return Some(IpcMessage::Bar { action });
+        }
+        // Popover commands: popover:open:<widget>, popover:close, popover:close:<widget>,
+        //                   popover:toggle:<widget>
+        if let Some(rest) = s.strip_prefix("popover:") {
+            if rest == "close" {
+                return Some(IpcMessage::Popover {
+                    action: PopoverIpcAction::Close(None),
+                });
+            }
+            if let Some(name) = rest.strip_prefix("open:") {
+                if name.is_empty() {
+                    return None; // targetless open rejected
+                }
+                return Some(IpcMessage::Popover {
+                    action: PopoverIpcAction::Open(name.to_string()),
+                });
+            }
+            if let Some(name) = rest.strip_prefix("close:") {
+                if name.is_empty() {
+                    return None;
+                }
+                return Some(IpcMessage::Popover {
+                    action: PopoverIpcAction::Close(Some(name.to_string())),
+                });
+            }
+            if let Some(name) = rest.strip_prefix("toggle:") {
+                if name.is_empty() {
+                    return None; // targetless toggle rejected
+                }
+                return Some(IpcMessage::Popover {
+                    action: PopoverIpcAction::Toggle(name.to_string()),
+                });
+            }
+            return None;
         }
         None
     }
@@ -345,5 +423,82 @@ mod tests {
             IpcMessage::from_wire("\ntoggle_inhibitor\n"),
             Some(IpcMessage::ToggleInhibitor)
         );
+    }
+
+    #[test]
+    fn test_bar_message_roundtrip() {
+        let cases = vec![
+            IpcMessage::Bar {
+                action: BarIpcAction::Show,
+            },
+            IpcMessage::Bar {
+                action: BarIpcAction::Hide,
+            },
+            IpcMessage::Bar {
+                action: BarIpcAction::Toggle,
+            },
+        ];
+        for msg in cases {
+            let wire = msg.to_wire();
+            let parsed = IpcMessage::from_wire(&wire).expect("failed to parse");
+            assert_eq!(msg, parsed);
+        }
+    }
+
+    #[test]
+    fn test_popover_message_roundtrip() {
+        let cases = vec![
+            IpcMessage::Popover {
+                action: PopoverIpcAction::Open("clock".to_string()),
+            },
+            IpcMessage::Popover {
+                action: PopoverIpcAction::Close(None),
+            },
+            IpcMessage::Popover {
+                action: PopoverIpcAction::Close(Some("battery".to_string())),
+            },
+            IpcMessage::Popover {
+                action: PopoverIpcAction::Toggle("quick-settings".to_string()),
+            },
+        ];
+        for msg in cases {
+            let wire = msg.to_wire();
+            let parsed = IpcMessage::from_wire(&wire).expect("failed to parse");
+            assert_eq!(msg, parsed);
+        }
+    }
+
+    #[test]
+    fn test_from_wire_rejects_bar_garbage() {
+        assert_eq!(IpcMessage::from_wire("bar:"), None);
+        assert_eq!(IpcMessage::from_wire("bar:unknown"), None);
+        assert_eq!(IpcMessage::from_wire("bar"), None);
+    }
+
+    #[test]
+    fn test_from_wire_rejects_targetless_popover_open_and_toggle() {
+        // open and toggle require a target
+        assert_eq!(IpcMessage::from_wire("popover:open:"), None);
+        assert_eq!(IpcMessage::from_wire("popover:toggle:"), None);
+        // bare "popover:open" without colon is just unknown
+        assert_eq!(IpcMessage::from_wire("popover:open"), None);
+        assert_eq!(IpcMessage::from_wire("popover:toggle"), None);
+    }
+
+    #[test]
+    fn test_from_wire_accepts_targetless_popover_close() {
+        assert_eq!(
+            IpcMessage::from_wire("popover:close"),
+            Some(IpcMessage::Popover {
+                action: PopoverIpcAction::Close(None),
+            })
+        );
+    }
+
+    #[test]
+    fn test_from_wire_rejects_popover_garbage() {
+        assert_eq!(IpcMessage::from_wire("popover:"), None);
+        assert_eq!(IpcMessage::from_wire("popover:unknown:foo"), None);
+        assert_eq!(IpcMessage::from_wire("popover"), None);
     }
 }

--- a/crates/vibepanel/src/services/ipc.rs
+++ b/crates/vibepanel/src/services/ipc.rs
@@ -50,10 +50,10 @@ pub enum BarIpcAction {
 /// Popover control actions for IPC.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PopoverIpcAction {
-    /// Open a specific widget's popover.
-    Open(String),
-    /// Close a specific widget's popover, or dismiss the active one if no target.
-    Close(Option<String>),
+    /// Show a specific widget's popover.
+    Show(String),
+    /// Hide a specific widget's popover, or dismiss the active one if no target.
+    Hide(Option<String>),
     /// Toggle a specific widget's popover.
     Toggle(String),
 }
@@ -91,9 +91,9 @@ impl IpcMessage {
                 BarIpcAction::Toggle => "bar:toggle".to_string(),
             },
             IpcMessage::Popover { action } => match action {
-                PopoverIpcAction::Open(name) => format!("popover:open:{}", name),
-                PopoverIpcAction::Close(None) => "popover:close".to_string(),
-                PopoverIpcAction::Close(Some(name)) => format!("popover:close:{}", name),
+                PopoverIpcAction::Show(name) => format!("popover:show:{}", name),
+                PopoverIpcAction::Hide(None) => "popover:hide".to_string(),
+                PopoverIpcAction::Hide(Some(name)) => format!("popover:hide:{}", name),
                 PopoverIpcAction::Toggle(name) => format!("popover:toggle:{}", name),
             },
         }
@@ -130,28 +130,28 @@ impl IpcMessage {
             };
             return Some(IpcMessage::Bar { action });
         }
-        // Popover commands: popover:open:<widget>, popover:close, popover:close:<widget>,
+        // Popover commands: popover:show:<widget>, popover:hide, popover:hide:<widget>,
         //                   popover:toggle:<widget>
         if let Some(rest) = s.strip_prefix("popover:") {
-            if rest == "close" {
+            if rest == "hide" {
                 return Some(IpcMessage::Popover {
-                    action: PopoverIpcAction::Close(None),
+                    action: PopoverIpcAction::Hide(None),
                 });
             }
-            if let Some(name) = rest.strip_prefix("open:") {
+            if let Some(name) = rest.strip_prefix("show:") {
                 if name.is_empty() {
-                    return None; // targetless open rejected
+                    return None; // targetless show rejected
                 }
                 return Some(IpcMessage::Popover {
-                    action: PopoverIpcAction::Open(name.to_string()),
+                    action: PopoverIpcAction::Show(name.to_string()),
                 });
             }
-            if let Some(name) = rest.strip_prefix("close:") {
+            if let Some(name) = rest.strip_prefix("hide:") {
                 if name.is_empty() {
                     return None;
                 }
                 return Some(IpcMessage::Popover {
-                    action: PopoverIpcAction::Close(Some(name.to_string())),
+                    action: PopoverIpcAction::Hide(Some(name.to_string())),
                 });
             }
             if let Some(name) = rest.strip_prefix("toggle:") {
@@ -449,13 +449,13 @@ mod tests {
     fn test_popover_message_roundtrip() {
         let cases = vec![
             IpcMessage::Popover {
-                action: PopoverIpcAction::Open("clock".to_string()),
+                action: PopoverIpcAction::Show("clock".to_string()),
             },
             IpcMessage::Popover {
-                action: PopoverIpcAction::Close(None),
+                action: PopoverIpcAction::Hide(None),
             },
             IpcMessage::Popover {
-                action: PopoverIpcAction::Close(Some("battery".to_string())),
+                action: PopoverIpcAction::Hide(Some("battery".to_string())),
             },
             IpcMessage::Popover {
                 action: PopoverIpcAction::Toggle("quick-settings".to_string()),
@@ -476,21 +476,21 @@ mod tests {
     }
 
     #[test]
-    fn test_from_wire_rejects_targetless_popover_open_and_toggle() {
-        // open and toggle require a target
-        assert_eq!(IpcMessage::from_wire("popover:open:"), None);
+    fn test_from_wire_rejects_targetless_popover_show_and_toggle() {
+        // show and toggle require a target
+        assert_eq!(IpcMessage::from_wire("popover:show:"), None);
         assert_eq!(IpcMessage::from_wire("popover:toggle:"), None);
-        // bare "popover:open" without colon is just unknown
-        assert_eq!(IpcMessage::from_wire("popover:open"), None);
+        // bare "popover:show" without colon is just unknown
+        assert_eq!(IpcMessage::from_wire("popover:show"), None);
         assert_eq!(IpcMessage::from_wire("popover:toggle"), None);
     }
 
     #[test]
-    fn test_from_wire_accepts_targetless_popover_close() {
+    fn test_from_wire_accepts_targetless_popover_hide() {
         assert_eq!(
-            IpcMessage::from_wire("popover:close"),
+            IpcMessage::from_wire("popover:hide"),
             Some(IpcMessage::Popover {
-                action: PopoverIpcAction::Close(None),
+                action: PopoverIpcAction::Hide(None),
             })
         );
     }

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -173,6 +173,13 @@ pub mod row {
     /// Row menu button (`.qs-row-menu-button`).
     pub const QS_MENU_BUTTON: &str = "qs-row-menu-button";
 
+    /// Row delegates focus to an inline button (`.vp-row-has-action`).
+    ///
+    /// Added to non-focusable rows that contain an inline action button so
+    /// CSS can suppress the row-level focus ring that GTK applies via
+    /// `:focus-visible` even on non-focusable rows.
+    pub const HAS_ACTION: &str = "vp-row-has-action";
+
     /// Row menu icon (`.qs-row-menu-icon`).
     pub const QS_MENU_ICON: &str = "qs-row-menu-icon";
 
@@ -646,6 +653,13 @@ pub mod surface {
 
     /// No focus outline container (`.vp-no-focus`).
     pub const NO_FOCUS: &str = "vp-no-focus";
+
+    /// Card-level focus indicator (`.vp-toggle-focused`).
+    ///
+    /// Toggled on a `.vp-card` box when the toggle button has keyboard focus.
+    /// Uses `box-shadow: inset` on the parent card so the ring wraps the
+    /// entire card (toggle + chevron), not just the focused button.
+    pub const TOGGLE_FOCUSED: &str = "vp-toggle-focused";
 
     /// Popover header icon button (`.vp-popover-icon-btn`).
     pub const POPOVER_ICON_BTN: &str = "vp-popover-icon-btn";

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -357,18 +357,6 @@ impl crate::popover_registry::PopoverToggleable for MenuHandle {
         self.is_visible()
     }
 
-    fn ipc_enable_keyboard_nav(&self) {
-        if let Some(ref popover) = *self.popover.borrow() {
-            popover.enable_keyboard_nav();
-        }
-    }
-
-    fn ipc_prepare_keyboard_nav(&self) {
-        if let Some(ref popover) = *self.popover.borrow() {
-            popover.prepare_keyboard_nav();
-        }
-    }
-
     fn monitor_connector(&self) -> Option<String> {
         self.parent
             .root()

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -340,6 +340,46 @@ impl Dismissible for MenuHandle {
     }
 }
 
+impl crate::popover_registry::PopoverToggleable for MenuHandle {
+    fn ipc_show(&self) {
+        if !self.is_visible() {
+            self.show();
+        }
+    }
+
+    fn ipc_hide(&self) {
+        if self.is_visible() {
+            self.hide();
+        }
+    }
+
+    fn ipc_is_visible(&self) -> bool {
+        self.is_visible()
+    }
+
+    fn ipc_enable_keyboard_nav(&self) {
+        if let Some(ref popover) = *self.popover.borrow() {
+            popover.enable_keyboard_nav();
+        }
+    }
+
+    fn ipc_prepare_keyboard_nav(&self) {
+        if let Some(ref popover) = *self.popover.borrow() {
+            popover.prepare_keyboard_nav();
+        }
+    }
+
+    fn monitor_connector(&self) -> Option<String> {
+        self.parent
+            .root()
+            .and_then(|r| r.downcast_ref::<gtk4::Window>().cloned())
+            .and_then(|w| w.surface())
+            .and_then(|s| gdk::Display::default().and_then(|d| d.monitor_at_surface(&s)))
+            .and_then(|m| m.connector())
+            .map(|c| c.to_string())
+    }
+}
+
 /// Describe a process exit status in human-readable form.
 ///
 /// Translates well-known shell exit codes (127 = command not found,
@@ -937,6 +977,14 @@ impl BaseWidget {
             .as_ref()
             .expect("create_menu called on passive BaseWidget");
         *menu.borrow_mut() = Some(handle.clone());
+
+        // Register with the popover registry for IPC control.
+        // widget_name uses hyphens (CSS convention); registry normalizes at dispatch time.
+        crate::popover_registry::register(
+            &self.widget_name,
+            handle.clone() as Rc<dyn crate::popover_registry::PopoverToggleable>,
+        );
+
         handle
     }
 }

--- a/crates/vibepanel/src/widgets/calendar_popover.rs
+++ b/crates/vibepanel/src/widgets/calendar_popover.rs
@@ -48,7 +48,6 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> (Widget, Rc<dyn 
     let prev_button = crate::widgets::base::vp_button_from_icon_name("go-previous-symbolic");
     prev_button.add_css_class(surface::POPOVER_ICON_BTN);
     prev_button.set_has_frame(false);
-    prev_button.set_focusable(false);
     prev_button.set_focus_on_click(false);
 
     let icons = IconsService::global();
@@ -59,14 +58,12 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> (Widget, Rc<dyn 
     today_button.set_child(Some(&today_icon.widget()));
     today_button.add_css_class(surface::POPOVER_ICON_BTN);
     today_button.set_has_frame(false);
-    today_button.set_focusable(false);
     today_button.set_focus_on_click(false);
     today_button.set_tooltip_text(Some("Go to today"));
 
     let next_button = crate::widgets::base::vp_button_from_icon_name("go-next-symbolic");
     next_button.add_css_class(surface::POPOVER_ICON_BTN);
     next_button.set_has_frame(false);
-    next_button.set_focusable(false);
     next_button.set_focus_on_click(false);
 
     nav_box.append(&prev_button);

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -255,6 +255,14 @@ popover.widget-menu.background > contents {{
     box-shadow: none;
 }}
 
+/* Power action rows are directly focusable (hold-to-confirm on the row
+   itself).  Restore the accent focus ring that :focus-within above kills. */
+.vp-surface-popover row.qs-power-row:focus-visible {{
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: -2px;
+    transition: none;
+}}
+
 /* ===== COMPONENT CLASSES ===== */
 /* Reusable component patterns for cards, rows, sliders */
 

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -6,7 +6,13 @@
 use super::POPOVER_BG_WITH_OPACITY;
 
 /// Return shared utility CSS.
-pub fn css(animations: bool) -> String {
+///
+/// When `override_focus_ring` is `true`, Adwaita's built-in `:focus-visible`
+/// color (GNOME blue) is overridden with `var(--color-accent-primary)` so focus
+/// rings match the user's custom or monochrome accent. When `false` (GTK accent
+/// mode), Adwaita's built-in focus color is already correct and no override
+/// rules are emitted.
+pub fn css(animations: bool, override_focus_ring: bool) -> String {
     let popover_bg = POPOVER_BG_WITH_OPACITY;
     // Hover background-color transitions are disabled unconditionally.
     // CSS transitions on widgets with nested child widgets (e.g. Box > Label,
@@ -18,6 +24,51 @@ pub fn css(animations: bool) -> String {
         "transition: transform 100ms ease-out;"
     } else {
         "transition: none;"
+    };
+    // When the user has a custom or monochrome accent color, override Adwaita's
+    // focus ring (which resolves to GNOME blue) with var(--color-accent-primary).
+    // Scoped under `.vp-surface-popover` for higher specificity so our rules
+    // override Adwaita's.
+    let focus_ring_css = if override_focus_ring {
+        r#"
+/* ===== KEYBOARD NAV FOCUS COLOR ===== */
+/* Card-level focus ring: wraps the entire card (toggle + chevron) when
+   the toggle button has focus. Uses box-shadow on the parent because a
+   native outline on the toggle would only wrap the toggle itself.
+   Toggled from Rust via the has-focus signal on the toggle button. */
+.vp-card.vp-toggle-focused {
+    box-shadow: inset 0 0 0 2px var(--color-accent-primary);
+    transition: none;
+}
+
+/* When set_focus_visible(true) is called on a window, GTK sets the
+   :focus-visible pseudo-class on the focused widget.  Adwaita styles
+   this with GNOME blue — override with the user's accent color.
+   Rules must be self-contained (full outline shorthand) because
+   transition:none at our priority (USER=800) blocks Adwaita's
+   outline-width animation from 0→2px at THEME=200.
+   Scoped under .vp-surface-popover for specificity. */
+.vp-surface-popover button:focus-visible,
+.vp-surface-popover row:focus-visible,
+.vp-surface-popover switch:focus-visible,
+.vp-surface-popover entry:focus-visible {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: -2px;
+    transition: none;
+}
+.vp-surface-popover scale:focus-visible > trough > slider {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: -2px;
+    transition: none;
+}
+/* Suppress Adwaita's outline transition on entries so the accent color
+   doesn't flash blue when focus leaves. */
+.vp-surface-popover entry {
+    transition: none;
+}"#
+        .to_string()
+    } else {
+        String::new()
     };
     format!(
         r#"
@@ -148,11 +199,23 @@ popover.widget-menu.background > contents {{
 }}
 
 /* ===== FOCUS SUPPRESSION ===== */
+/* When GTK's 3 s focus_visible timeout fires, the focused widget keeps :focus
+   but loses :focus-visible.  Suppress Adwaita's residual :focus outline so no
+   faint ring lingers after keyboard nav times out. */
+.vp-surface-popover *:focus:not(:focus-visible) {{
+    outline: none;
+    box-shadow: none;
+}}
+
 /* Hide focus outlines in popovers - keyboard nav not primary interaction */
 .vp-no-focus *:focus,
 .vp-no-focus *:focus-visible,
 .vp-no-focus *:focus-within {{
     outline: none;
+    box-shadow: none;
+}}
+/* Also suppress card-level focus ring under .vp-no-focus */
+.vp-no-focus .vp-card.vp-toggle-focused {{
     box-shadow: none;
 }}
 
@@ -161,6 +224,35 @@ popover.widget-menu.background > contents {{
 .vp-no-focus entry:focus-visible {{
     outline: 2px solid var(--color-accent-primary);
     outline-offset: -2px;
+}}
+
+/* Suppress the toggle button's own :focus-visible outline inside a card —
+   the card-level box-shadow (.vp-toggle-focused) already provides the ring.
+   Only suppress .vp-btn-reset (the toggle), not the expander chevron. */
+.vp-card > .vp-btn-reset:focus-visible {{
+    outline: none;
+}}
+
+{focus_ring_css}
+
+/* Rows with inline action buttons delegate focus to the button.  GTK still
+   sets :focus-visible on the row even when non-focusable, so suppress it.
+   Must come after focus_ring_css and use .vp-surface-popover scope to beat
+   the accent color rule's specificity. */
+.vp-surface-popover row.vp-row-has-action,
+.vp-surface-popover row.vp-row-has-action:focus,
+.vp-surface-popover row.vp-row-has-action:focus-visible {{
+    outline: none;
+    box-shadow: none;
+    transition: none;
+}}
+
+/* Suppress :focus-within outlines on rows whose children handle their own
+   focus rings (e.g. password entry row).  The child widget (entry, button)
+   already shows the accent-colored ring. */
+.vp-surface-popover row:focus-within {{
+    outline: none;
+    box-shadow: none;
 }}
 
 /* ===== COMPONENT CLASSES ===== */

--- a/crates/vibepanel/src/widgets/css/buttons.rs
+++ b/crates/vibepanel/src/widgets/css/buttons.rs
@@ -11,7 +11,6 @@ button.vp-btn-compact {
     background: transparent;
     border: none;
     box-shadow: none;
-    outline: none;
 }
 
 /* Compact button - reset + zero padding/margin for icon-only buttons */
@@ -20,15 +19,6 @@ button.vp-btn-compact {
     margin: 0;
     min-width: 0;
     min-height: 0;
-}
-
-button.vp-btn-reset:focus,
-button.vp-btn-reset:focus-visible,
-button.vp-btn-compact:focus,
-button.vp-btn-compact:focus-visible {
-    outline: none;
-    border: none;
-    box-shadow: none;
 }
 
 button.vp-btn-accent {

--- a/crates/vibepanel/src/widgets/css/calendar.rs
+++ b/crates/vibepanel/src/widgets/css/calendar.rs
@@ -47,12 +47,6 @@ calendar.view grid label.day-number {
     font-weight: 325;
 }
 
-calendar.view grid label.day-number:focus {
-    outline: none;
-    border: none;
-    box-shadow: none;
-}
-
 calendar.view grid *:selected:not(.today) {
     background: transparent;
     color: inherit;

--- a/crates/vibepanel/src/widgets/css/media.rs
+++ b/crates/vibepanel/src/widgets/css/media.rs
@@ -99,7 +99,6 @@ pub fn css(animations: bool) -> String {
 /* Player menu item - extends qs-row-menu-item */
 .media-player-menu-item {{
     border: none;
-    outline: none;
     box-shadow: none;
 }}
 

--- a/crates/vibepanel/src/widgets/css/mod.rs
+++ b/crates/vibepanel/src/widgets/css/mod.rs
@@ -58,7 +58,10 @@ use vibepanel_core::Config;
 /// These are truly shared styles that apply across multiple surfaces
 /// (bar, popovers, quick settings, etc).
 pub fn utility_css(config: &Config) -> String {
-    base::css(config.theme.animations)
+    // When using GTK's accent, Adwaita's built-in focus ring is already correct.
+    // For custom/none modes, we override with var(--color-accent-primary).
+    let override_focus_ring = !matches!(config.theme.accent.as_deref(), None | Some("gtk"));
+    base::css(config.theme.animations, override_focus_ring)
 }
 
 /// Generate all widget CSS.

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -13,6 +13,22 @@ use gtk4::prelude::*;
 use gtk4::{
     Application, ApplicationWindow, Box as GtkBox, EventControllerKey, GestureClick, Orientation,
 };
+
+/// Whether a key is a keyboard navigation key (Tab, arrows, Home, End).
+/// Used by the deferred keyboard nav controller to gate activation.
+pub fn is_keynav_key(keyval: gdk::Key) -> bool {
+    matches!(
+        keyval,
+        gdk::Key::Tab
+            | gdk::Key::ISO_Left_Tab
+            | gdk::Key::Up
+            | gdk::Key::Down
+            | gdk::Key::Left
+            | gdk::Key::Right
+            | gdk::Key::Home
+            | gdk::Key::End
+    )
+}
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -336,7 +352,7 @@ where
     catcher
 }
 
-/// Set up ESC key handler on a window to call the dismiss callback.
+/// Set up ESC key handler on a window to dismiss the popover.
 pub fn setup_esc_handler<F>(window: &ApplicationWindow, on_dismiss: F)
 where
     F: Fn() + 'static,
@@ -414,6 +430,9 @@ pub struct LayerShellPopover {
     /// Cached content widget for reuse mode. Kept alive across close cycles
     /// so it can be re-parented on the next open.
     cached_content: RefCell<Option<gtk4::Widget>>,
+    /// One-shot key controller installed by `prepare_keyboard_nav()`.
+    /// Stored so `hide()` can remove it if Tab was never pressed.
+    deferred_kbd_controller: RefCell<Option<EventControllerKey>>,
 }
 
 impl LayerShellPopover {
@@ -445,6 +464,7 @@ impl LayerShellPopover {
             content_dirty: Cell::new(false),
             reuse_content: Cell::new(false),
             cached_content: RefCell::new(None),
+            deferred_kbd_controller: RefCell::new(None),
         })
     }
 
@@ -490,6 +510,85 @@ impl LayerShellPopover {
         self.content_dirty.set(true);
     }
 
+    /// Enable keyboard navigation by removing the `.vp-no-focus` CSS class
+    /// from the outer wrapper and enabling GTK's `focus-visible` property so
+    /// Adwaita renders `:focus-visible` rings on focused widgets.
+    ///
+    /// Activated by the deferred Tab controller installed in `show_internal()`.
+    /// On `hide()`, `focus-visible` is reset to `false` and `.vp-no-focus`
+    /// is restored so the next open starts focus-suppressed.
+    pub fn enable_keyboard_nav(&self) {
+        if let Some(ref window) = *self.window.borrow()
+            && let Some(child) = window.child()
+        {
+            gtk4::prelude::GtkWindowExt::set_focus_visible(window, true);
+            child.remove_css_class(surface::NO_FOCUS);
+        }
+    }
+
+    /// Prepare deferred keyboard navigation.
+    ///
+    /// Clears any auto-focus set by `present()` and installs a one-shot key
+    /// controller that waits for a keynav key (Tab, arrows, Home, End).
+    /// On the first such press, `enable_keyboard_nav()` fires and focus
+    /// lands on the first focusable widget with correct `:focus-visible`
+    /// state. Until a keynav key is pressed, the popover shows no focus rings.
+    pub fn prepare_keyboard_nav(self: &Rc<Self>) {
+        let Some(ref window) = *self.window.borrow() else {
+            return;
+        };
+
+        // Clear any auto-focus from present() so Tab starts from nothing
+        // and lands on the first focusable widget.
+        gtk4::prelude::GtkWindowExt::set_focus(window, None::<&gtk4::Widget>);
+
+        // Remove any previous deferred controller (e.g. rapid toggle).
+        self.remove_deferred_kbd_controller();
+
+        let controller = EventControllerKey::new();
+        let weak_self = Rc::downgrade(self);
+        let ctrl_ref = controller.clone();
+        controller.connect_key_pressed(move |_, keyval, _, _| {
+            let is_keynav = is_keynav_key(keyval);
+            if is_keynav && let Some(popover) = weak_self.upgrade() {
+                popover.enable_keyboard_nav();
+                if let Some(ref window) = *popover.window.borrow() {
+                    window.remove_controller(&ctrl_ref);
+                }
+                *popover.deferred_kbd_controller.borrow_mut() = None;
+            }
+            if keyval == gdk::Key::Tab || keyval == gdk::Key::ISO_Left_Tab {
+                // Let Tab propagate — GTK focuses the first widget with
+                // correct :focus-visible via its own keynav path.
+                Propagation::Proceed
+            } else if is_keynav {
+                // For arrows/Home/End, consume the key and simulate Tab's
+                // focus behavior so we land on the first widget instead of
+                // skipping it.
+                if let Some(popover) = weak_self.upgrade()
+                    && let Some(ref window) = *popover.window.borrow()
+                {
+                    window.child_focus(gtk4::DirectionType::TabForward);
+                }
+                Propagation::Stop
+            } else {
+                Propagation::Proceed
+            }
+        });
+
+        window.add_controller(controller.clone());
+        *self.deferred_kbd_controller.borrow_mut() = Some(controller);
+    }
+
+    /// Remove the deferred keyboard nav controller if installed.
+    fn remove_deferred_kbd_controller(&self) {
+        if let Some(controller) = self.deferred_kbd_controller.borrow_mut().take()
+            && let Some(ref window) = *self.window.borrow()
+        {
+            window.remove_controller(&controller);
+        }
+    }
+
     /// Show the popover at the given anchor position.
     ///
     /// Reuses all persistent shells (window, animation, click-catcher) and
@@ -515,6 +614,18 @@ impl LayerShellPopover {
         // Mark as logically closed immediately — the toggle logic in BaseWidget
         // checks this to decide show vs hide on the next click.
         self.logically_open.set(false);
+
+        // Restore focus suppression so the next open starts no-focus.
+        // (keyboard nav defers removal to enable_keyboard_nav().)
+        if let Some(ref window) = *self.window.borrow() {
+            gtk4::prelude::GtkWindowExt::set_focus_visible(window, false);
+            if let Some(child) = window.child()
+                && !child.has_css_class(surface::NO_FOCUS)
+            {
+                child.add_css_class(surface::NO_FOCUS);
+            }
+        }
+        self.remove_deferred_kbd_controller();
 
         // Bump generation to cancel any pending idle callback from show_internal().
         let generation = self.anim_generation.get().wrapping_add(1);
@@ -632,6 +743,9 @@ impl LayerShellPopover {
 
             // Reverse into opening — tick callback picks up new direction.
             self.start_animation(AnimDirection::Opening, generation);
+
+            // Install deferred Tab controller so keyboard nav activates on Tab.
+            self.prepare_keyboard_nav();
             return;
         }
 
@@ -731,6 +845,11 @@ impl LayerShellPopover {
         window.set_opacity(0.0);
         window.set_visible(true);
         window.present();
+
+        // Install deferred Tab controller so keyboard nav activates on first
+        // Tab press (for both mouse and IPC opens). Must run after present()
+        // because present() auto-focuses a widget which we need to clear.
+        self.prepare_keyboard_nav();
 
         // After window is mapped, update position and start the open animation.
         let weak_self = Rc::downgrade(self);

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -387,6 +387,8 @@ pub struct MediaWidget {
     /// Bar waveform visualizer — held so `Drop` disconnects from cava.
     /// `None` when visualizer is disabled in config.
     _bar_visualizer: Option<BarVisualizer>,
+    /// Keeps the `MenuHandle` alive so the popout closure's `Weak` can close the popover.
+    _menu_handle_cell: Rc<RefCell<Option<Rc<MenuHandle>>>>,
 }
 
 #[derive(Clone)]
@@ -860,6 +862,7 @@ impl MediaWidget {
             pending_hide: pending_hide_for_drop,
             _art_state: art_state_for_drop,
             _bar_visualizer: bar_visualizer,
+            _menu_handle_cell: menu_handle_cell,
         }
     }
 

--- a/crates/vibepanel/src/widgets/media_popover.rs
+++ b/crates/vibepanel/src/widgets/media_popover.rs
@@ -70,7 +70,6 @@ where
     // Player selector button
     let player_btn = crate::widgets::base::vp_button();
     player_btn.set_has_frame(false);
-    player_btn.set_focusable(false);
     player_btn.set_focus_on_click(false);
     player_btn.set_valign(Align::Center);
     player_btn.add_css_class(surface::POPOVER_ICON_BTN);
@@ -91,7 +90,6 @@ where
     // Pop-out button
     let popout_btn = crate::widgets::base::vp_button();
     popout_btn.set_has_frame(false);
-    popout_btn.set_focusable(false);
     popout_btn.set_focus_on_click(false);
     popout_btn.set_valign(Align::Center);
     popout_btn.add_css_class(surface::POPOVER_ICON_BTN);

--- a/crates/vibepanel/src/widgets/media_window.rs
+++ b/crates/vibepanel/src/widgets/media_window.rs
@@ -12,7 +12,7 @@ use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::media::MediaService;
 use crate::services::surfaces::SurfaceStyleManager;
-use crate::styles::media;
+use crate::styles::{media, surface};
 use crate::widgets::media_components::{
     MediaViewController, build_album_art, build_media_controls, build_seek_section,
     build_track_info,
@@ -92,6 +92,7 @@ where
 
     let main_box = GtkBox::new(Orientation::Vertical, 0);
     main_box.add_css_class(media::CONTENT);
+    main_box.add_css_class(surface::NO_FOCUS);
     main_box.set_size_request(260, 150);
 
     // Apply surface styles for consistent theming

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -345,31 +345,24 @@ impl NotificationsWidget {
         let inner = Rc::clone(&self.inner);
         let suppress_rebuild = Rc::clone(&self.inner.suppress_rebuild);
 
-        // We need a reference to the menu handle inside the builder, but the handle
-        // is created by create_menu. Use a RefCell to store it after creation.
-        // The builder captures a Weak to avoid a reference cycle:
-        //   menu_handle_cell → MenuHandle → builder closure → menu_handle_cell
-        let menu_handle_cell: Rc<RefCell<Option<Rc<MenuHandle>>>> = Rc::new(RefCell::new(None));
-        let menu_handle_weak = Rc::downgrade(&menu_handle_cell);
+        // Placeholder builder — replaced immediately below once we have the handle.
+        let menu_handle = self
+            .base
+            .create_menu(|| GtkBox::new(Orientation::Vertical, 0).into());
 
-        let menu_handle = self.base.create_menu(move || {
-            // Mark as seen when popover opens
+        // Now that the handle exists, build the real builder with a Weak reference
+        // to it so the builder can create on_close callbacks that call handle.hide().
+        let handle_weak = Rc::downgrade(&menu_handle);
+        menu_handle.set_builder(move || {
             inner.mark_as_seen();
 
-            // Create close callback that hides the popover
-            let on_close: Option<ClosePopoverCallback> =
-                menu_handle_weak.upgrade().and_then(|cell| {
-                    cell.borrow().as_ref().map(|handle| {
-                        let handle_clone = Rc::clone(handle);
-                        Rc::new(move || handle_clone.hide()) as ClosePopoverCallback
-                    })
-                });
+            let on_close: Option<ClosePopoverCallback> = handle_weak
+                .upgrade()
+                .map(|handle| Rc::new(move || handle.hide()) as ClosePopoverCallback);
 
             build_popover_content(on_close, Rc::clone(&suppress_rebuild))
         });
 
-        // Store the menu handle in both places
-        *menu_handle_cell.borrow_mut() = Some(Rc::clone(&menu_handle));
         *self.inner.menu_handle.borrow_mut() = Some(menu_handle);
     }
 

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -155,7 +155,6 @@ fn build_header(on_close: Option<ClosePopoverCallback>) -> GtkBox {
     // Mute toggle button (always visible)
     let mute_btn = crate::widgets::base::vp_button();
     mute_btn.set_has_frame(false);
-    mute_btn.set_focusable(false);
     mute_btn.set_focus_on_click(false);
     mute_btn.add_css_class(surface::POPOVER_ICON_BTN);
     mute_btn.set_valign(Align::Start);
@@ -217,7 +216,6 @@ fn build_header(on_close: Option<ClosePopoverCallback>) -> GtkBox {
     if count > 0 {
         let clear_btn = crate::widgets::base::vp_button();
         clear_btn.set_has_frame(false);
-        clear_btn.set_focusable(false);
         clear_btn.set_focus_on_click(false);
         clear_btn.add_css_class(surface::POPOVER_ICON_BTN);
         clear_btn.set_valign(Align::Start);

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -244,6 +244,7 @@ impl NotificationToast {
         dismiss_btn.add_css_class(notif::TOAST_DISMISS);
         dismiss_btn.add_css_class(button::RESET);
         dismiss_btn.set_valign(Align::Start);
+        dismiss_btn.set_focusable(false);
 
         let dismiss_icon = Image::from_icon_name("window-close-symbolic");
         dismiss_icon.set_halign(Align::Center);
@@ -303,6 +304,7 @@ impl NotificationToast {
                 let action_btn = crate::widgets::base::vp_button_with_label(action_label);
                 action_btn.add_css_class(notif::TOAST_ACTION);
                 action_btn.add_css_class(button::GHOST);
+                action_btn.set_focusable(false);
 
                 let on_action_clone = on_action.clone();
                 let on_dismiss_clone = on_dismiss.clone();

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -530,7 +530,7 @@ impl OsdOverlay {
                 self.show_brightness(*percent);
             }
             // Non-OSD messages are handled at the panel level, not here.
-            IpcMessage::ToggleInhibitor => {
+            IpcMessage::ToggleInhibitor | IpcMessage::Bar { .. } | IpcMessage::Popover { .. } => {
                 trace!("OSD: ignoring non-OSD message: {:?}", msg);
             }
         }

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -579,6 +579,9 @@ impl QuickSettingsWidget {
 
         base.widget().add_controller(gesture);
 
+        // Store widget reference on the handle so IPC can derive anchor position.
+        qs_window.set_bar_widget(base.widget().clone().upcast::<gtk4::Widget>());
+
         Self {
             base,
             qs_window_handle: qs_window,

--- a/crates/vibepanel/src/widgets/quick_settings/components.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/components.rs
@@ -798,6 +798,44 @@ impl ToggleCard {
         toggle.set_child(Some(&content));
         card_box.append(&toggle);
 
+        // Card-level focus ring: when the toggle button has keyboard focus
+        // AND focus-visible is active, add .vp-toggle-focused on card_box so
+        // a box-shadow ring wraps the entire card (toggle + chevron).
+        // Also listen for focus_visible changes on the window so the ring
+        // disappears when GTK's 3 s timeout fires.
+        {
+            let cb = card_box.clone();
+            let cb2 = card_box.clone();
+            let toggle_weak = toggle.downgrade();
+            toggle.connect_notify_local(Some("has-focus"), move |btn, _| {
+                let dominated = btn.has_focus()
+                    && btn
+                        .root()
+                        .and_downcast_ref::<gtk4::Window>()
+                        .is_some_and(gtk4::prelude::GtkWindowExt::gets_focus_visible);
+                if dominated {
+                    cb.add_css_class(crate::styles::surface::TOGGLE_FOCUSED);
+                } else {
+                    cb.remove_css_class(crate::styles::surface::TOGGLE_FOCUSED);
+                }
+            });
+            toggle.connect_notify_local(Some("root"), move |btn, _| {
+                let Some(window) = btn.root().and_downcast::<gtk4::Window>() else {
+                    return;
+                };
+                let tw = toggle_weak.clone();
+                let cb = cb2.clone();
+                window.connect_focus_visible_notify(move |window| {
+                    let focused = tw.upgrade().is_some_and(|t| t.has_focus());
+                    if !focused || !gtk4::prelude::GtkWindowExt::gets_focus_visible(window) {
+                        cb.remove_css_class(crate::styles::surface::TOGGLE_FOCUSED);
+                    } else {
+                        cb.add_css_class(crate::styles::surface::TOGGLE_FOCUSED);
+                    }
+                });
+            });
+        }
+
         // Expander chevron
         let (expander_button, expander_icon) = if self.with_expander {
             let expander_result = ExpanderButton::new().build();
@@ -969,14 +1007,23 @@ impl ListRow {
         hbox.append(&label_result.container);
 
         // Trailing widget (e.g., menu button)
+        let has_trailing = self.trailing_widget.is_some();
         if let Some(trailing) = self.trailing_widget {
             trailing.set_halign(Align::End);
             hbox.append(&trailing);
         }
 
         list_row.set_child(Some(&hbox));
-        list_row.set_activatable(true);
-        list_row.set_focusable(true);
+        // When a trailing button is present it becomes the keyboard target —
+        // making the row itself non-focusable avoids a double focus ring
+        // (GTK keeps :focus-visible on the row even when a child button has
+        // focus).  Rows without trailing widgets remain focusable so they
+        // can be activated directly.
+        list_row.set_activatable(!has_trailing);
+        list_row.set_focusable(!has_trailing);
+        if has_trailing {
+            list_row.add_css_class(row::HAS_ACTION);
+        }
 
         ListRowResult {
             row: list_row,

--- a/crates/vibepanel/src/widgets/quick_settings/network_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/network_card.rs
@@ -1219,7 +1219,7 @@ pub fn populate_wifi_list(
         {
             let pwd_row = ListBoxRow::new();
             pwd_row.set_activatable(false);
-            pwd_row.set_focusable(true);
+            pwd_row.set_focusable(false);
             pwd_box.set_visible(true);
             pwd_row.set_child(Some(pwd_box));
             list_box.append(&pwd_row);
@@ -1235,7 +1235,7 @@ pub fn populate_wifi_list(
     {
         let pwd_row = ListBoxRow::new();
         pwd_row.set_activatable(false);
-        pwd_row.set_focusable(true);
+        pwd_row.set_focusable(false);
         pwd_box.set_visible(true);
         pwd_row.set_child(Some(pwd_box));
         list_box.append(&pwd_row);

--- a/crates/vibepanel/src/widgets/quick_settings/power_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/power_card.rs
@@ -19,8 +19,8 @@ use gtk4::gdk::BUTTON_PRIMARY;
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Button, GestureClick, Label, ListBox, ListBoxRow, Orientation, Overlay,
-    Popover, Revealer, RevealerTransitionType,
+    Align, Box as GtkBox, Button, EventControllerKey, GestureClick, Label, ListBox, ListBoxRow,
+    Orientation, Overlay, Popover, Revealer, RevealerTransitionType,
 };
 use tracing::{debug, warn};
 
@@ -113,7 +113,7 @@ fn execute_power_action(action: &PowerAction) {
     }
 }
 
-/// State for managing hold-to-confirm gesture.
+/// State for managing hold-to-confirm gesture (mouse/touch and keyboard).
 struct HoldToConfirmState {
     /// Timer ID for the animation completion callback.
     timeout_id: RefCell<Option<SourceId>>,
@@ -123,15 +123,20 @@ struct HoldToConfirmState {
     is_confirming: Cell<bool>,
     /// Animation start time (ms since epoch, approximate).
     start_time: Cell<u64>,
+    /// Weak ref to progress overlay for CSS/size resets.
+    progress: glib::WeakRef<GtkBox>,
 }
 
 impl HoldToConfirmState {
-    fn new() -> Self {
+    fn new(progress: &GtkBox) -> Self {
+        let weak = glib::WeakRef::new();
+        weak.set(Some(progress));
         Self {
             timeout_id: RefCell::new(None),
             anim_id: RefCell::new(None),
             is_confirming: Cell::new(false),
             start_time: Cell::new(0),
+            progress: weak,
         }
     }
 
@@ -145,12 +150,100 @@ impl HoldToConfirmState {
         }
         self.is_confirming.set(false);
     }
+
+    /// Cancel and reset progress bar visuals (CSS classes + width).
+    fn cancel_and_reset(&self) {
+        if !self.is_confirming.get() {
+            return;
+        }
+        self.cancel();
+        if let Some(progress) = self.progress.upgrade() {
+            progress.remove_css_class(qs::POWER_CONFIRMING);
+            if let Some(parent) = progress.parent() {
+                parent.remove_css_class(qs::POWER_CONFIRMING);
+            }
+            progress.set_size_request(0, -1);
+        }
+    }
+
+    /// Begin the hold-to-confirm animation and completion timer.
+    fn begin(
+        self: &Rc<Self>,
+        width_widget_weak: &glib::WeakRef<gtk4::Widget>,
+        on_confirmed: &Rc<dyn Fn()>,
+    ) {
+        self.cancel();
+
+        let Some(progress) = self.progress.upgrade() else {
+            return;
+        };
+
+        progress.add_css_class(qs::POWER_CONFIRMING);
+        if let Some(parent) = progress.parent() {
+            parent.add_css_class(qs::POWER_CONFIRMING);
+        }
+        self.is_confirming.set(true);
+
+        let start = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        self.start_time.set(start);
+        progress.set_size_request(0, -1);
+
+        // Animation loop
+        let state_anim = Rc::clone(self);
+        let width_weak = width_widget_weak.clone();
+        let anim_id = glib::timeout_add_local(Duration::from_millis(ANIM_FRAME_MS), move || {
+            if !state_anim.is_confirming.get() {
+                return glib::ControlFlow::Break;
+            }
+            let Some(progress) = state_anim.progress.upgrade() else {
+                return glib::ControlFlow::Break;
+            };
+            let Some(width_widget) = width_weak.upgrade() else {
+                return glib::ControlFlow::Break;
+            };
+
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            let elapsed = now.saturating_sub(state_anim.start_time.get());
+            let ratio = (elapsed as f64 / HOLD_DURATION_MS as f64).min(1.0);
+            let target_width = width_widget.width();
+            let current_width = (target_width as f64 * ratio) as i32;
+            progress.set_size_request(current_width, -1);
+
+            glib::ControlFlow::Continue
+        });
+        *self.anim_id.borrow_mut() = Some(anim_id);
+
+        // Completion timer
+        let state_timeout = Rc::clone(self);
+        let on_confirmed = Rc::clone(on_confirmed);
+        let timeout_id =
+            glib::timeout_add_local_once(Duration::from_millis(HOLD_DURATION_MS), move || {
+                if state_timeout.is_confirming.get() {
+                    state_timeout.cancel();
+                    if let Some(progress) = state_timeout.progress.upgrade() {
+                        progress.remove_css_class(qs::POWER_CONFIRMING);
+                        if let Some(parent) = progress.parent() {
+                            parent.remove_css_class(qs::POWER_CONFIRMING);
+                        }
+                        progress.set_size_request(0, -1);
+                    }
+                    on_confirmed();
+                }
+            });
+        *self.timeout_id.borrow_mut() = Some(timeout_id);
+    }
 }
 
 /// Animation frame interval in milliseconds (~60fps).
 const ANIM_FRAME_MS: u64 = 16;
 
-/// Set up hold-to-confirm gesture on a widget.
+/// Set up hold-to-confirm gesture on a widget (mouse/touch + keyboard).
 ///
 /// # Arguments
 /// * `gesture_widget` - The widget to attach the gesture to (receives click events)
@@ -170,157 +263,75 @@ fn setup_hold_to_confirm<W1, W2, F>(
     W2: IsA<gtk4::Widget>,
     F: Fn() + 'static,
 {
+    let state = Rc::new(HoldToConfirmState::new(progress_overlay));
+    let width_widget_weak: glib::WeakRef<gtk4::Widget> = glib::WeakRef::new();
+    width_widget_weak.set(Some(width_widget.upcast_ref()));
+    let on_confirmed: Rc<dyn Fn()> = Rc::new(on_confirmed);
+
+    // --- Mouse / touch: GestureClick ---
     let gesture = GestureClick::new();
     gesture.set_button(BUTTON_PRIMARY);
-    // Capture phase to get events before child widgets
     gesture.set_propagation_phase(gtk4::PropagationPhase::Capture);
 
-    let state = Rc::new(HoldToConfirmState::new());
-    let progress_weak = progress_overlay.downgrade();
-    let width_widget_weak = width_widget.upcast_ref::<gtk4::Widget>().downgrade();
-    let on_confirmed = Rc::new(on_confirmed);
-
-    // On mouse down: start the visual animation and completion timer
     {
         let state = Rc::clone(&state);
-        let progress_weak = progress_weak.clone();
-        let width_widget_weak = width_widget_weak.clone();
+        let width_weak = width_widget_weak.clone();
         let on_confirmed = Rc::clone(&on_confirmed);
-
         gesture.connect_pressed(move |gesture, _, _, _| {
-            // Cancel any previous animation
-            state.cancel();
-
-            let Some(progress) = progress_weak.upgrade() else {
-                return;
-            };
-
-            // Add confirming class for background color
-            progress.add_css_class(qs::POWER_CONFIRMING);
-            // Also add to parent overlay so CSS can make card background transparent
-            if let Some(parent) = progress.parent() {
-                parent.add_css_class(qs::POWER_CONFIRMING);
-            }
-            state.is_confirming.set(true);
-
-            // Record start time
-            let start = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0);
-            state.start_time.set(start);
-
-            // Reset progress width
-            progress.set_size_request(0, -1);
-
-            // Start animation loop
-            let state_anim = Rc::clone(&state);
-            let progress_weak_anim = progress_weak.clone();
-            let width_widget_weak_anim = width_widget_weak.clone();
-
-            let anim_id =
-                glib::timeout_add_local(Duration::from_millis(ANIM_FRAME_MS), move || {
-                    if !state_anim.is_confirming.get() {
-                        return glib::ControlFlow::Break;
-                    }
-
-                    let Some(progress) = progress_weak_anim.upgrade() else {
-                        return glib::ControlFlow::Break;
-                    };
-
-                    let Some(width_widget) = width_widget_weak_anim.upgrade() else {
-                        return glib::ControlFlow::Break;
-                    };
-
-                    // Calculate elapsed time
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis() as u64)
-                        .unwrap_or(0);
-                    let elapsed = now.saturating_sub(state_anim.start_time.get());
-
-                    // Calculate progress (0.0 to 1.0)
-                    let ratio = (elapsed as f64 / HOLD_DURATION_MS as f64).min(1.0);
-
-                    // Get target width from width widget
-                    let target_width = width_widget.width();
-                    let current_width = (target_width as f64 * ratio) as i32;
-
-                    progress.set_size_request(current_width, -1);
-
-                    glib::ControlFlow::Continue
-                });
-            *state.anim_id.borrow_mut() = Some(anim_id);
-
-            // Set completion timer
-            let state_timeout = Rc::clone(&state);
-            let progress_weak_timeout = progress_weak.clone();
-            let on_confirmed = Rc::clone(&on_confirmed);
-
-            let timeout_id =
-                glib::timeout_add_local_once(Duration::from_millis(HOLD_DURATION_MS), move || {
-                    if state_timeout.is_confirming.get() {
-                        state_timeout.cancel();
-
-                        if let Some(progress) = progress_weak_timeout.upgrade() {
-                            progress.remove_css_class(qs::POWER_CONFIRMING);
-                            if let Some(parent) = progress.parent() {
-                                parent.remove_css_class(qs::POWER_CONFIRMING);
-                            }
-                            progress.set_size_request(0, -1);
-                        }
-
-                        on_confirmed();
-                    }
-                });
-            *state.timeout_id.borrow_mut() = Some(timeout_id);
-
-            // Claim the gesture sequence to prevent other handlers
+            state.begin(&width_weak, &on_confirmed);
             gesture.set_state(gtk4::EventSequenceState::Claimed);
         });
     }
-
-    // On mouse up: cancel if still in progress
     {
         let state = Rc::clone(&state);
-        let progress_weak = progress_weak.clone();
-
         gesture.connect_released(move |_, _, _, _| {
-            if state.is_confirming.get() {
-                state.cancel();
-
-                if let Some(progress) = progress_weak.upgrade() {
-                    progress.remove_css_class(qs::POWER_CONFIRMING);
-                    if let Some(parent) = progress.parent() {
-                        parent.remove_css_class(qs::POWER_CONFIRMING);
-                    }
-                    progress.set_size_request(0, -1);
-                }
-            }
+            state.cancel_and_reset();
         });
     }
-
-    // Handle gesture cancel (pointer left, etc.)
     {
         let state = Rc::clone(&state);
-        let progress_weak = progress_weak.clone();
-
         gesture.connect_cancel(move |_, _| {
-            if state.is_confirming.get() {
-                state.cancel();
-
-                if let Some(progress) = progress_weak.upgrade() {
-                    progress.remove_css_class(qs::POWER_CONFIRMING);
-                    if let Some(parent) = progress.parent() {
-                        parent.remove_css_class(qs::POWER_CONFIRMING);
-                    }
-                    progress.set_size_request(0, -1);
-                }
-            }
+            state.cancel_and_reset();
         });
     }
 
     gesture_widget.add_controller(gesture);
+
+    // --- Keyboard: Enter / Space hold ---
+    let key_ctrl = EventControllerKey::new();
+    {
+        let state = Rc::clone(&state);
+        let width_weak = width_widget_weak.clone();
+        let on_confirmed = Rc::clone(&on_confirmed);
+        key_ctrl.connect_key_pressed(move |_, keyval, _, _| {
+            if !is_confirm_key(keyval) {
+                return glib::Propagation::Proceed;
+            }
+            // Ignore key-repeat while already holding
+            if !state.is_confirming.get() {
+                state.begin(&width_weak, &on_confirmed);
+            }
+            glib::Propagation::Stop
+        });
+    }
+    {
+        let state = Rc::clone(&state);
+        key_ctrl.connect_key_released(move |_, keyval, _, _| {
+            if is_confirm_key(keyval) {
+                state.cancel_and_reset();
+            }
+        });
+    }
+
+    gesture_widget.add_controller(key_ctrl);
+}
+
+/// Whether a key is a hold-to-confirm activation key (Return/Enter/Space).
+fn is_confirm_key(keyval: gtk4::gdk::Key) -> bool {
+    matches!(
+        keyval,
+        gtk4::gdk::Key::Return | gtk4::gdk::Key::KP_Enter | gtk4::gdk::Key::space
+    )
 }
 
 /// Create a card-like button with hold-to-confirm overlay.

--- a/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides reusable UI builders for the quick settings control center panels.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use crate::services::icons::{CairoSpinner, IconHandle, IconsService};
@@ -332,7 +332,6 @@ where
 {
     let btn = crate::widgets::base::vp_button();
     btn.set_has_frame(false);
-    btn.set_focusable(false);
     btn.set_focus_on_click(false);
     btn.add_css_class(qs::ROW_MENU_ITEM);
     btn.add_css_class(button::GHOST);
@@ -447,6 +446,9 @@ pub struct ScanButton {
     button: Button,
     label: Label,
     spinner: CairoSpinner,
+    /// Whether the button had keyboard-navigated focus when it was made
+    /// insensitive (i.e. `focus_visible` was active on the window).
+    had_keyboard_focus: Cell<bool>,
 }
 
 impl ScanButton {
@@ -494,6 +496,7 @@ impl ScanButton {
             button,
             label,
             spinner,
+            had_keyboard_focus: Cell::new(false),
         })
     }
 
@@ -503,7 +506,22 @@ impl ScanButton {
     }
 
     /// Set button sensitivity.
+    ///
+    /// When becoming insensitive, records whether the button had
+    /// keyboard-navigated focus (i.e. `focus_visible` was active) so it
+    /// can be restored when scanning ends.
     pub fn set_sensitive(&self, sensitive: bool) {
+        if !sensitive && self.button.has_focus() {
+            // Record that we had focus *and* that keyboard nav was active.
+            // We check focus_visible now because GTK may clear it once the
+            // focused widget becomes insensitive.
+            let kbd_nav = self
+                .button
+                .root()
+                .and_then(|r| r.downcast::<gtk4::Window>().ok())
+                .is_some_and(|w| gtk4::prelude::GtkWindowExt::gets_focus_visible(&w));
+            self.had_keyboard_focus.set(kbd_nav);
+        }
         self.button.set_sensitive(sensitive);
     }
 
@@ -514,8 +532,10 @@ impl ScanButton {
 
     /// Update active/scanning state.
     ///
-    /// When `active` is true, hides label and shows spinner.
-    /// When false, hides spinner and shows idle text.
+    /// When `active` is true, hides label and shows spinner.  When false,
+    /// hides spinner and shows idle text.  If the button had
+    /// keyboard-navigated focus before scanning started, focus is restored
+    /// automatically and `focus_visible` is re-enabled on the window.
     pub fn set_scanning(&self, active: bool) {
         if active {
             self.label.set_visible(false);
@@ -523,6 +543,17 @@ impl ScanButton {
         } else {
             self.spinner.stop();
             self.label.set_visible(true);
+            // Restore focus if the button had keyboard-nav focus before it
+            // was made insensitive.  We also re-enable focus_visible since
+            // GTK may have cleared it when focus was lost.
+            if self.had_keyboard_focus.replace(false) && self.button.is_sensitive() {
+                if let Some(root) = self.button.root()
+                    && let Some(window) = root.downcast_ref::<gtk4::Window>()
+                {
+                    gtk4::prelude::GtkWindowExt::set_focus_visible(window, true);
+                }
+                self.button.grab_focus();
+            }
         }
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -1908,22 +1908,6 @@ impl crate::popover_registry::PopoverToggleable for QuickSettingsWindowHandle {
             .is_some_and(|w| w.logically_open.get())
     }
 
-    fn ipc_enable_keyboard_nav(&self) {
-        if let Some(qs) = self.window.borrow().as_ref()
-            && qs.logically_open.get()
-        {
-            qs.enable_keyboard_nav();
-        }
-    }
-
-    fn ipc_prepare_keyboard_nav(&self) {
-        if let Some(qs) = self.window.borrow().as_ref()
-            && qs.logically_open.get()
-        {
-            qs.prepare_keyboard_nav();
-        }
-    }
-
     fn monitor_connector(&self) -> Option<String> {
         let widget_ref = self.bar_widget.borrow();
         widget_ref

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -10,8 +10,8 @@ use gtk4::gdk::{self, Monitor};
 use gtk4::glib::{self, ControlFlow};
 use gtk4::prelude::*;
 use gtk4::{
-    Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation, PolicyType,
-    Revealer, RevealerTransitionType, ScrolledWindow,
+    Application, ApplicationWindow, Box as GtkBox, Button, EventControllerKey, Label, Orientation,
+    PolicyType, Revealer, RevealerTransitionType, ScrolledWindow,
 };
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
@@ -32,7 +32,7 @@ use crate::styles::{qs, state, surface};
 use crate::widgets::layer_shell_popover::{
     ANIM_SCALE_FROM, AnimDirection, AnimState, Dismissible, calculate_bar_exclusive_zone,
     calculate_popover_bar_margin, calculate_popover_right_margin, create_click_catcher,
-    popover_bar_edge, popover_keyboard_mode, setup_esc_handler,
+    is_keynav_key, popover_bar_edge, popover_keyboard_mode, setup_esc_handler,
 };
 use crate::widgets::scale_box::ScaleBox;
 
@@ -172,6 +172,9 @@ pub struct QuickSettingsWindow {
     /// Power card state (expander variant only). Stored here so
     /// `reset_ui_state()` can collapse it without walking the widget tree.
     pub power: RefCell<Option<Rc<PowerCardExpanderState>>>,
+    /// One-shot key controller installed by `prepare_keyboard_nav()`.
+    /// Stored so `hide_panel()` can remove it if Tab was never pressed.
+    deferred_kbd_controller: RefCell<Option<EventControllerKey>>,
 }
 
 impl QuickSettingsWindow {
@@ -250,6 +253,7 @@ impl QuickSettingsWindow {
             brightness: Rc::new(BrightnessCardState::new()),
             updates: Rc::new(UpdatesCardState::new()),
             power: RefCell::new(None),
+            deferred_kbd_controller: RefCell::new(None),
         });
 
         let outer = Self::build_content(&qs);
@@ -1386,6 +1390,9 @@ impl QuickSettingsWindow {
             self.window.set_visible(true);
             self.window.present();
 
+            // Install deferred Tab controller for keyboard nav on first Tab.
+            self.prepare_keyboard_nav();
+
             // Start open animation + re-deliver service snapshots.
             let window_weak = self.window.downgrade();
             let gen_rc = Rc::clone(&self.anim_generation);
@@ -1414,6 +1421,9 @@ impl QuickSettingsWindow {
             self.window.set_visible(true);
             self.window.present();
 
+            // Install deferred Tab controller for keyboard nav on first Tab.
+            self.prepare_keyboard_nav();
+
             let window_weak = self.window.downgrade();
             let gen_rc = Rc::clone(&self.anim_generation);
             glib::idle_add_local_once(move || {
@@ -1440,6 +1450,72 @@ impl QuickSettingsWindow {
         }
     }
 
+    /// Enable keyboard navigation (remove focus suppression).
+    ///
+    /// Activated by the deferred keynav controller installed in `show_panel()`.
+    /// On `hide_panel()`, `focus-visible` is reset and `.vp-no-focus` is
+    /// restored so the next open starts focus-suppressed.
+    fn enable_keyboard_nav(&self) {
+        if let Some(ref outer) = *self.outer_container.borrow() {
+            gtk4::prelude::GtkWindowExt::set_focus_visible(&self.window, true);
+            outer.remove_css_class(surface::NO_FOCUS);
+        }
+    }
+
+    /// Prepare deferred keyboard navigation.
+    ///
+    /// Clears auto-focus and installs a one-shot keynav controller.
+    /// On the first keynav key (Tab, arrows, Home, End),
+    /// `enable_keyboard_nav()` fires and focus lands on the first
+    /// focusable widget.
+    fn prepare_keyboard_nav(&self) {
+        // Clear any auto-focus from present() so Tab starts from nothing.
+        gtk4::prelude::GtkWindowExt::set_focus(&self.window, None::<&gtk4::Widget>);
+
+        // Remove any previous deferred controller.
+        self.remove_deferred_kbd_controller();
+
+        let controller = EventControllerKey::new();
+        let window_weak = self.window.downgrade();
+        let ctrl_ref = controller.clone();
+        controller.connect_key_pressed(move |_, keyval, _, _| {
+            let is_keynav = is_keynav_key(keyval);
+            if is_keynav
+                && let Some(window) = window_weak.upgrade()
+                && let Some(qs) = get_qs_window_data(&window)
+            {
+                qs.enable_keyboard_nav();
+                window.remove_controller(&ctrl_ref);
+                *qs.deferred_kbd_controller.borrow_mut() = None;
+            }
+            if keyval == gdk::Key::Tab || keyval == gdk::Key::ISO_Left_Tab {
+                // Let Tab propagate — GTK focuses the first widget with
+                // correct :focus-visible via its own keynav path.
+                glib::Propagation::Proceed
+            } else if is_keynav {
+                // For arrows/Home/End, consume the key and simulate Tab's
+                // focus behavior so we land on the first widget instead of
+                // skipping it.
+                if let Some(window) = window_weak.upgrade() {
+                    window.child_focus(gtk4::DirectionType::TabForward);
+                }
+                glib::Propagation::Stop
+            } else {
+                glib::Propagation::Proceed
+            }
+        });
+
+        self.window.add_controller(controller.clone());
+        *self.deferred_kbd_controller.borrow_mut() = Some(controller);
+    }
+
+    /// Remove the deferred keyboard nav controller if installed.
+    fn remove_deferred_kbd_controller(&self) {
+        if let Some(controller) = self.deferred_kbd_controller.borrow_mut().take() {
+            self.window.remove_controller(&controller);
+        }
+    }
+
     /// Hide the panel with a close animation, keeping the window alive.
     ///
     /// The click-catcher is hidden and keyboard grab released immediately
@@ -1454,6 +1530,15 @@ impl QuickSettingsWindow {
         // Mark as logically closed immediately so toggle_at() can re-open
         // during the close animation instead of swallowing the click.
         self.logically_open.set(false);
+
+        // Restore focus suppression so the next open starts no-focus.
+        gtk4::prelude::GtkWindowExt::set_focus_visible(&self.window, false);
+        if let Some(ref outer) = *self.outer_container.borrow()
+            && !outer.has_css_class(surface::NO_FOCUS)
+        {
+            outer.add_css_class(surface::NO_FOCUS);
+        }
+        self.remove_deferred_kbd_controller();
 
         // Restore keyboard mode if it was released for VPN password dialogs
         vpn_card::restore_keyboard_if_released();
@@ -1821,6 +1906,22 @@ impl crate::popover_registry::PopoverToggleable for QuickSettingsWindowHandle {
             .borrow()
             .as_ref()
             .is_some_and(|w| w.logically_open.get())
+    }
+
+    fn ipc_enable_keyboard_nav(&self) {
+        if let Some(qs) = self.window.borrow().as_ref()
+            && qs.logically_open.get()
+        {
+            qs.enable_keyboard_nav();
+        }
+    }
+
+    fn ipc_prepare_keyboard_nav(&self) {
+        if let Some(qs) = self.window.borrow().as_ref()
+            && qs.logically_open.get()
+        {
+            qs.prepare_keyboard_nav();
+        }
     }
 
     fn monitor_connector(&self) -> Option<String> {

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -1688,6 +1688,9 @@ pub struct QuickSettingsWindowHandle {
     /// (which needs to clear it when dismissed) and mutated from multiple places
     /// (toggle_at close path and Dismissible::dismiss).
     tracker_id: Rc<Cell<Option<PopoverId>>>,
+    /// Reference to the bar-side QS widget for deriving anchor position.
+    /// Set after widget construction; `None` if the widget hasn't been built yet.
+    bar_widget: Rc<RefCell<Option<gtk4::Widget>>>,
 }
 
 impl QuickSettingsWindowHandle {
@@ -1697,6 +1700,7 @@ impl QuickSettingsWindowHandle {
             config,
             window: Rc::new(RefCell::new(None)),
             tracker_id: Rc::new(Cell::new(None)),
+            bar_widget: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -1715,9 +1719,40 @@ impl QuickSettingsWindowHandle {
         *self.window.borrow_mut() = None;
     }
 
+    /// Store a reference to the bar-side QS widget for anchor derivation.
+    pub fn set_bar_widget(&self, widget: gtk4::Widget) {
+        *self.bar_widget.borrow_mut() = Some(widget);
+    }
+
+    /// Derive anchor position and monitor from the bar widget.
+    ///
+    /// Replicates the bar widget click handler's positioning logic
+    /// (`compute_bounds` center + `screen_margin` adjustment).
+    fn get_anchor_info(&self) -> (i32, Option<Monitor>) {
+        let widget_ref = self.bar_widget.borrow();
+        let Some(ref widget) = *widget_ref else {
+            return (0, None);
+        };
+        let Some(native) = widget.native() else {
+            return (0, None);
+        };
+        let Some(bounds) = widget.compute_bounds(&native) else {
+            return (0, None);
+        };
+
+        let screen_margin = ConfigManager::global().screen_margin() as i32;
+        let anchor_x = (bounds.x() + bounds.width() / 2.0) as i32 + screen_margin;
+
+        let monitor = native
+            .surface()
+            .and_then(|s| s.display().monitor_at_surface(&s));
+
+        (anchor_x, monitor)
+    }
+
     pub fn toggle_at(&self, x: i32, monitor: Option<Monitor>) {
-        // Check logical state, not window visibility — the window may still
-        // be visible during a close animation but logically_open is already false.
+        // Check logical state, not window visibility — the window may still be
+        // visible during a close animation but logically_open is already false.
         let is_visible = self
             .window
             .borrow()
@@ -1759,6 +1794,44 @@ impl QuickSettingsWindowHandle {
         };
         let id = PopoverTracker::global().set_active(Rc::new(dismissible));
         self.tracker_id.set(Some(id));
+    }
+}
+
+impl crate::popover_registry::PopoverToggleable for QuickSettingsWindowHandle {
+    fn ipc_show(&self) {
+        if !self.ipc_is_visible() {
+            let (x, monitor) = self.get_anchor_info();
+            self.toggle_at(x, monitor);
+        }
+    }
+
+    fn ipc_hide(&self) {
+        if self.ipc_is_visible() {
+            if let Some(qs) = self.window.borrow().as_ref() {
+                qs.hide_panel();
+            }
+            if let Some(id) = self.tracker_id.take() {
+                PopoverTracker::global().clear_if_active(id);
+            }
+        }
+    }
+
+    fn ipc_is_visible(&self) -> bool {
+        self.window
+            .borrow()
+            .as_ref()
+            .is_some_and(|w| w.logically_open.get())
+    }
+
+    fn monitor_connector(&self) -> Option<String> {
+        let widget_ref = self.bar_widget.borrow();
+        widget_ref
+            .as_ref()
+            .and_then(|w| w.native())
+            .and_then(|n| n.surface())
+            .and_then(|s| s.display().monitor_at_surface(&s))
+            .and_then(|m| m.connector())
+            .map(|c| c.to_string())
     }
 }
 

--- a/crates/vibepanel/src/widgets/tray.rs
+++ b/crates/vibepanel/src/widgets/tray.rs
@@ -903,7 +903,6 @@ fn render_menu_level(state: &Rc<RefCell<WidgetState>>) {
 
         let button = crate::widgets::base::vp_button();
         button.set_sensitive(entry.enabled);
-        button.set_focusable(false);
         button.set_focus_on_click(false);
         button.add_css_class(widget::TRAY_MENU_BUTTON);
 


### PR DESCRIPTION
This PR adds CLI commands to control bar visibility and widget popovers via IPC, plus keyboard navigation support across all popovers.

**Commands:** 
`vibepanel bar show|hide|toggle`
`vibepanel popover show|hide|toggle <widget>`
