### PR TITLE
feat(widgets): add keyboard layout widget with layout cycling on click

### DIFF
--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    CompositorBackend, WindowCallback, WindowInfo, WorkspaceCallback, WorkspaceMeta,
-    WorkspaceSnapshot,
+    CompositorBackend, KeyboardLayoutCallback, KeyboardLayoutInfo, WindowCallback, WindowInfo,
+    WorkspaceCallback, WorkspaceMeta, WorkspaceSnapshot,
 };
 
 /// Default workspaces for Hyprland (dynamic workspaces, but we expose 1-10).
@@ -43,6 +43,12 @@ pub struct HyprlandBackend {
     callbacks: Mutex<Option<(WorkspaceCallback, WindowCallback)>>,
     monitor_workspaces: RwLock<HashMap<String, i32>>,
     focused_monitor: RwLock<Option<String>>,
+    /// Callback for keyboard layout changes, set by CompositorManager.
+    keyboard_layout_callback: Mutex<Option<KeyboardLayoutCallback>>,
+    /// Current keyboard layout info.
+    keyboard_layout: RwLock<Option<KeyboardLayoutInfo>>,
+    /// Name of the main keyboard device (auto-detected from `hyprctl devices`).
+    main_keyboard_name: RwLock<Option<String>>,
 }
 
 impl HyprlandBackend {
@@ -70,6 +76,9 @@ impl HyprlandBackend {
             callbacks: Mutex::new(None),
             monitor_workspaces: RwLock::new(HashMap::new()),
             focused_monitor: RwLock::new(None),
+            keyboard_layout_callback: Mutex::new(None),
+            keyboard_layout: RwLock::new(None),
+            main_keyboard_name: RwLock::new(None),
         }
     }
 
@@ -268,6 +277,60 @@ impl HyprlandBackend {
         debug!("Fetched initial Hyprland state");
     }
 
+    /// Fetch keyboard layout info from Hyprland devices.
+    fn fetch_keyboard_layout(&self) {
+        let Some(devices) = self.query_json("devices") else {
+            debug!("fetch_keyboard_layout: failed to query devices");
+            return;
+        };
+
+        let Some(keyboards) = devices.get("keyboards").and_then(|v| v.as_array()) else {
+            debug!("fetch_keyboard_layout: no keyboards in devices response");
+            return;
+        };
+
+        // Use Hyprland's `main` flag to find the primary keyboard.
+        // Falls back to first keyboard if none is marked main.
+        let main_kb = keyboards
+            .iter()
+            .find(|kb| kb.get("main").and_then(|v| v.as_bool()) == Some(true))
+            .or_else(|| keyboards.first());
+
+        let Some(kb) = main_kb else {
+            debug!("fetch_keyboard_layout: no suitable keyboard found");
+            return;
+        };
+
+        let kb_name = kb
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let active_layout = kb
+            .get("active_keymap")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Hyprland's "layout" field is a comma-separated list of layout codes
+        let layout_count = kb
+            .get("layout")
+            .and_then(|v| v.as_str())
+            .map(|layout_str| layout_str.split(',').filter(|s| !s.is_empty()).count());
+
+        debug!(
+            "fetch_keyboard_layout: main_kb='{}', layout='{}', layout_count={:?}",
+            kb_name, active_layout, layout_count
+        );
+
+        *self.main_keyboard_name.write() = Some(kb_name);
+        *self.keyboard_layout.write() = Some(KeyboardLayoutInfo {
+            layout_name: active_layout,
+            short_name: String::new(), // Widget extracts short name
+            layout_count,
+        });
+    }
+
     /// Refresh occupied workspaces and window counts from Hyprland.
     ///
     /// Also updates per-output state and monitor tracking.
@@ -444,10 +507,10 @@ impl HyprlandBackend {
     }
 
     /// Handle a Hyprland event line.
-    /// Returns (workspace_changed, window_changed).
-    fn handle_event(&self, line: &str) -> (bool, bool) {
+    /// Returns (workspace_changed, window_changed, keyboard_layout_changed).
+    fn handle_event(&self, line: &str) -> (bool, bool, bool) {
         let Some((event, data)) = line.split_once(">>") else {
-            return (false, false);
+            return (false, false, false);
         };
 
         trace!(
@@ -458,6 +521,7 @@ impl HyprlandBackend {
 
         let mut workspace_changed = false;
         let mut window_changed = false;
+        let mut keyboard_layout_changed = false;
 
         match event {
             "workspace" => {
@@ -549,10 +613,35 @@ impl HyprlandBackend {
                 // Workspace moved to different monitor - refresh all state
                 workspace_changed = self.refresh_occupied();
             }
+            "activelayout" => {
+                // activelayout>>KEYBOARD_NAME,LAYOUT_NAME
+                // Only process events from the main keyboard
+                if let Some((kb_name, layout_name)) = data.split_once(',') {
+                    let is_main = self
+                        .main_keyboard_name
+                        .read()
+                        .as_ref()
+                        .is_some_and(|name| name == kb_name);
+
+                    if is_main {
+                        let info = KeyboardLayoutInfo {
+                            layout_name: layout_name.to_string(),
+                            short_name: String::new(), // Widget extracts short name
+                            layout_count: self
+                                .keyboard_layout
+                                .read()
+                                .as_ref()
+                                .and_then(|i| i.layout_count),
+                        };
+                        *self.keyboard_layout.write() = Some(info);
+                        keyboard_layout_changed = true;
+                    }
+                }
+            }
             _ => {}
         }
 
-        (workspace_changed, window_changed)
+        (workspace_changed, window_changed, keyboard_layout_changed)
     }
 
     /// Run the event loop (in background thread).
@@ -571,6 +660,9 @@ impl HyprlandBackend {
         // Fetch initial state and emit
         backend.fetch_initial_state();
 
+        // Fetch initial keyboard layout (queries devices, auto-detects main keyboard)
+        backend.fetch_keyboard_layout();
+
         // Emit initial state
         if let Some((ws_cb, win_cb)) = backend
             .callbacks
@@ -582,6 +674,15 @@ impl HyprlandBackend {
             if let Some(ref win) = *backend.focused_window.read() {
                 win_cb(win.clone());
             }
+        }
+        // Emit initial keyboard layout
+        if let Some(ref kb_cb) = *backend
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            && let Some(ref info) = *backend.keyboard_layout.read()
+        {
+            kb_cb(info.clone());
         }
 
         // Exponential backoff state
@@ -623,7 +724,7 @@ impl HyprlandBackend {
 
                 match line {
                     Ok(line) => {
-                        let (ws_changed, win_changed) = backend.handle_event(&line);
+                        let (ws_changed, win_changed, kb_changed) = backend.handle_event(&line);
 
                         if let Some((ws_cb, win_cb)) = backend
                             .callbacks
@@ -637,6 +738,16 @@ impl HyprlandBackend {
                             if win_changed && let Some(ref win) = *backend.focused_window.read() {
                                 win_cb(win.clone());
                             }
+                        }
+
+                        if kb_changed
+                            && let Some(ref kb_cb) = *backend
+                                .keyboard_layout_callback
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                            && let Some(ref info) = *backend.keyboard_layout.read()
+                        {
+                            kb_cb(info.clone());
                         }
                     }
                     Err(e) => {
@@ -692,6 +803,11 @@ impl CompositorBackend for HyprlandBackend {
             .clone();
         let allowed_outputs = self.allowed_outputs.read().clone();
         let workspaces = self.workspaces.read().clone();
+        let kb_callback = self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
 
         // Share the running flag with the thread so stop() works correctly
         let running = Arc::clone(&self.running);
@@ -712,6 +828,9 @@ impl CompositorBackend for HyprlandBackend {
             callbacks: Mutex::new(callbacks),
             monitor_workspaces: RwLock::new(HashMap::new()),
             focused_monitor: RwLock::new(None),
+            keyboard_layout_callback: Mutex::new(kb_callback),
+            keyboard_layout: RwLock::new(None),
+            main_keyboard_name: RwLock::new(None),
         });
 
         // Start event loop thread
@@ -770,6 +889,29 @@ impl CompositorBackend for HyprlandBackend {
 
     fn name(&self) -> &'static str {
         "Hyprland"
+    }
+
+    fn set_keyboard_layout_callback(&self, callback: KeyboardLayoutCallback) {
+        *self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(callback);
+    }
+
+    fn get_keyboard_layout(&self) -> Option<KeyboardLayoutInfo> {
+        self.keyboard_layout.read().clone()
+    }
+
+    fn switch_keyboard_layout_next(&self) {
+        let main_kb = self.main_keyboard_name.read().clone();
+        if let Some(kb_name) = main_kb {
+            debug!("Switching keyboard layout for '{}'", kb_name);
+            let _ = self.send_command(&format!("switchxkblayout {} next", kb_name));
+        } else {
+            // Fallback: try "all" which switches all keyboards
+            debug!("No main keyboard detected, switching all keyboards");
+            let _ = self.send_command("switchxkblayout all next");
+        }
     }
 }
 

--- a/crates/vibepanel/src/services/compositor/manager.rs
+++ b/crates/vibepanel/src/services/compositor/manager.rs
@@ -33,8 +33,8 @@ use tracing::{debug, info};
 use vibepanel_core::config::AdvancedConfig;
 
 use super::{
-    BackendKind, CompositorBackend, WindowCallback, WindowInfo, WorkspaceCallback, WorkspaceMeta,
-    WorkspaceSnapshot, factory,
+    BackendKind, CompositorBackend, KeyboardLayoutCallback, KeyboardLayoutInfo, WindowCallback,
+    WindowInfo, WorkspaceCallback, WorkspaceMeta, WorkspaceSnapshot, factory,
 };
 use crate::services::callbacks::{CallbackId, Callbacks};
 
@@ -48,8 +48,10 @@ pub struct CompositorManager {
     backend: RefCell<Option<Box<dyn CompositorBackend>>>,
     workspace_callbacks: Callbacks<WorkspaceSnapshot>,
     window_callbacks: Callbacks<WindowInfo>,
+    keyboard_layout_callbacks: Callbacks<KeyboardLayoutInfo>,
     last_workspace_snapshot: RefCell<Option<WorkspaceSnapshot>>,
     last_window_info: RefCell<Option<WindowInfo>>,
+    last_keyboard_layout: RefCell<Option<KeyboardLayoutInfo>>,
     started: RefCell<bool>,
 }
 
@@ -59,8 +61,10 @@ impl CompositorManager {
             backend: RefCell::new(None),
             workspace_callbacks: Callbacks::new(),
             window_callbacks: Callbacks::new(),
+            keyboard_layout_callbacks: Callbacks::new(),
             last_workspace_snapshot: RefCell::new(None),
             last_window_info: RefCell::new(None),
+            last_keyboard_layout: RefCell::new(None),
             started: RefCell::new(false),
         });
 
@@ -182,6 +186,36 @@ impl CompositorManager {
         }
     }
 
+    /// Register a callback for keyboard layout changes.
+    ///
+    /// The callback will be immediately invoked with the current state if available.
+    /// Returns a `CallbackId` that can be used to unregister the callback.
+    pub fn register_keyboard_layout_callback<F>(&self, callback: F) -> CallbackId
+    where
+        F: Fn(&KeyboardLayoutInfo) + 'static,
+    {
+        let id = self.keyboard_layout_callbacks.register(callback);
+
+        // Immediately send current state if available
+        if let Some(ref info) = *self.last_keyboard_layout.borrow() {
+            self.keyboard_layout_callbacks.notify_single(id, info);
+        }
+
+        id
+    }
+
+    /// Unregister a keyboard layout callback by its ID.
+    pub fn unregister_keyboard_layout_callback(&self, id: CallbackId) -> bool {
+        self.keyboard_layout_callbacks.unregister(id)
+    }
+
+    /// Switch to the next keyboard layout.
+    pub fn switch_keyboard_layout_next(&self) {
+        if let Some(ref backend) = *self.backend.borrow() {
+            backend.switch_keyboard_layout_next();
+        }
+    }
+
     /// Get the backend name (e.g., "Hyprland", "Niri", "MangoWC").
     pub fn backend_name(&self) -> &'static str {
         if let Some(ref backend) = *self.backend.borrow() {
@@ -209,6 +243,16 @@ impl CompositorManager {
 
         // Dispatch to all registered callbacks
         self.window_callbacks.notify(&window_info);
+    }
+
+    /// Handle a keyboard layout update from the backend.
+    /// Called via glib::idle_add_once from the backend thread.
+    pub(crate) fn handle_keyboard_layout_update(&self, info: KeyboardLayoutInfo) {
+        // Store for new listeners
+        *self.last_keyboard_layout.borrow_mut() = Some(info.clone());
+
+        // Dispatch to all registered callbacks
+        self.keyboard_layout_callbacks.notify(&info);
     }
 
     /// Initialize the backend.
@@ -263,12 +307,26 @@ impl CompositorManager {
             });
         });
 
+        // Keyboard layout events: no coalescing needed — layout changes are
+        // infrequent, user-initiated, and atomic (one event per switch).
+        let on_keyboard_layout_update: KeyboardLayoutCallback =
+            Arc::new(move |keyboard_layout_info| {
+                glib::idle_add_once(move || {
+                    CompositorManager::global().handle_keyboard_layout_update(keyboard_layout_info);
+                });
+            });
+
+        // Register keyboard layout callback before start() so the backend
+        // can fire it during initialization if it discovers the current layout.
+        backend.set_keyboard_layout_callback(on_keyboard_layout_update);
+
         // Start the backend first (which fetches initial state internally)
         backend.start(on_workspace_update, on_window_update);
 
         // Now store initial state - backend has fetched it during start()
         *this.last_workspace_snapshot.borrow_mut() = Some(backend.get_workspace_snapshot());
         *this.last_window_info.borrow_mut() = backend.get_focused_window();
+        *this.last_keyboard_layout.borrow_mut() = backend.get_keyboard_layout();
 
         // Store backend
         *this.backend.borrow_mut() = Some(backend);

--- a/crates/vibepanel/src/services/compositor/mango.rs
+++ b/crates/vibepanel/src/services/compositor/mango.rs
@@ -33,8 +33,8 @@ use super::dwl_ipc::{
     TagState, ZdwlIpcManagerV2, ZdwlIpcOutputV2, zdwl_ipc_manager_v2, zdwl_ipc_output_v2,
 };
 use super::{
-    CompositorBackend, WindowCallback, WindowInfo, WorkspaceCallback, WorkspaceMeta,
-    WorkspaceSnapshot,
+    CompositorBackend, KeyboardLayoutCallback, KeyboardLayoutInfo, WindowCallback, WindowInfo,
+    WorkspaceCallback, WorkspaceMeta, WorkspaceSnapshot, xkb_names,
 };
 
 /// Default number of workspaces/tags for DWL.
@@ -87,12 +87,16 @@ struct SharedState {
     snapshot: RwLock<WorkspaceSnapshot>,
     /// Current focused window info.
     focused_window: RwLock<Option<WindowInfo>>,
+    /// Current keyboard layout info.
+    keyboard_layout: RwLock<Option<KeyboardLayoutInfo>>,
     /// Number of tags from protocol.
     tag_count: AtomicU32,
     /// Pending workspace switch request (-1 = none).
     pending_switch: AtomicI32,
     /// Pending compositor quit request.
     pending_quit: AtomicBool,
+    /// Pending keyboard layout switch request.
+    pending_kb_switch: AtomicBool,
 }
 
 impl Default for SharedState {
@@ -100,9 +104,11 @@ impl Default for SharedState {
         Self {
             snapshot: RwLock::new(WorkspaceSnapshot::default()),
             focused_window: RwLock::new(None),
+            keyboard_layout: RwLock::new(None),
             tag_count: AtomicU32::new(DEFAULT_WORKSPACE_COUNT),
             pending_switch: AtomicI32::new(-1),
             pending_quit: AtomicBool::new(false),
+            pending_kb_switch: AtomicBool::new(false),
         }
     }
 }
@@ -127,6 +133,8 @@ struct WaylandState {
     on_workspace_update: Option<WorkspaceCallback>,
     /// Window update callback.
     on_window_update: Option<WindowCallback>,
+    /// Keyboard layout update callback.
+    on_keyboard_layout_update: Option<KeyboardLayoutCallback>,
     /// Shared state for cross-thread access.
     shared: Arc<SharedState>,
 }
@@ -143,6 +151,7 @@ impl WaylandState {
             focused_output: None,
             on_workspace_update: None,
             on_window_update: None,
+            on_keyboard_layout_update: None,
             shared,
         }
     }
@@ -193,6 +202,23 @@ impl WaylandState {
         {
             debug!("Sending quit request to compositor");
             dwl_output.quit();
+        }
+    }
+
+    /// Check for and process any pending keyboard layout switch.
+    fn process_pending_kb_switch(&self) {
+        if self.shared.pending_kb_switch.swap(false, Ordering::SeqCst)
+            && let Some(dwl_output) = self.get_focused_dwl_output()
+        {
+            debug!("Sending keyboard layout switch via dispatch");
+            dwl_output.dispatch(
+                "switch_keyboard_layout".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+            );
         }
     }
 
@@ -501,6 +527,23 @@ impl Dispatch<ZdwlIpcOutputV2, ObjectId> for WaylandState {
             zdwl_ipc_output_v2::Event::LayoutSymbol { layout: _ } => {}
             zdwl_ipc_output_v2::Event::Fullscreen { is_fullscreen: _ } => {}
             zdwl_ipc_output_v2::Event::Floating { is_floating: _ } => {}
+            zdwl_ipc_output_v2::Event::KbLayout { kb_layout } => {
+                debug!("DWL keyboard layout: {}", kb_layout);
+
+                let info = KeyboardLayoutInfo {
+                    layout_name: xkb_names::language_from_xkb(&kb_layout)
+                        .map(String::from)
+                        .unwrap_or_else(|| kb_layout.to_uppercase()),
+                    short_name: kb_layout,
+                    layout_count: None,
+                };
+
+                *state.shared.keyboard_layout.write() = Some(info.clone());
+
+                if let Some(ref cb) = state.on_keyboard_layout_update {
+                    cb(info);
+                }
+            }
             _ => {}
         }
     }
@@ -538,6 +581,8 @@ pub struct MangoBackend {
     source_ids: Mutex<Vec<glib::SourceId>>,
     /// Eventfd used to wake the fd watcher for workspace switching.
     wake_fd: Mutex<Option<OwnedFd>>,
+    /// Keyboard layout change callback.
+    keyboard_layout_callback: Mutex<Option<KeyboardLayoutCallback>>,
 }
 
 impl MangoBackend {
@@ -549,6 +594,7 @@ impl MangoBackend {
             running: AtomicBool::new(false),
             source_ids: Mutex::new(Vec::new()),
             wake_fd: Mutex::new(None),
+            keyboard_layout_callback: Mutex::new(None),
         }
     }
 
@@ -582,6 +628,11 @@ impl CompositorBackend for MangoBackend {
         let mut state = WaylandState::new(shared);
         state.on_workspace_update = Some(on_workspace_update.clone());
         state.on_window_update = Some(on_window_update.clone());
+        state.on_keyboard_layout_update = self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
 
         // Get the registry and bind to globals
         let display = connection.display();
@@ -719,6 +770,7 @@ impl CompositorBackend for MangoBackend {
                     let st = state_for_wake.borrow();
                     st.process_pending_switch();
                     st.process_pending_quit();
+                    st.process_pending_kb_switch();
                 }
 
                 // Flush to send the request
@@ -851,6 +903,50 @@ impl CompositorBackend for MangoBackend {
 
     fn name(&self) -> &'static str {
         "MangoWC/DWL"
+    }
+
+    fn set_keyboard_layout_callback(&self, callback: KeyboardLayoutCallback) {
+        *self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(callback);
+    }
+
+    fn get_keyboard_layout(&self) -> Option<KeyboardLayoutInfo> {
+        self.shared.keyboard_layout.read().clone()
+    }
+
+    fn switch_keyboard_layout_next(&self) {
+        // MangoWC uses the dispatch request with "switch_keyboard_layout".
+        // We need to signal the main thread to process this, similar to
+        // switch_workspace. For now, we store a pending request and wake
+        // the eventfd — but dispatch requires a DWL output proxy which
+        // is only accessible on the main thread.
+        //
+        // Since the WaylandState with the DWL output proxy runs on the
+        // glib main loop, we use a similar wake mechanism as switch_workspace.
+        // However, dispatch is a different operation — we use a separate
+        // atomic flag for it.
+        debug!("Requesting keyboard layout switch");
+        self.shared.pending_kb_switch.store(true, Ordering::SeqCst);
+
+        // Wake the fd watcher to process the switch.
+        if let Some(wake_fd) = self
+            .wake_fd
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            // SAFETY: wake_fd is valid (held by Mutex), writing 8-byte u64 with correct alignment.
+            let val: u64 = 1;
+            unsafe {
+                libc::write(
+                    wake_fd.as_raw_fd(),
+                    &val as *const u64 as *const libc::c_void,
+                    8,
+                );
+            }
+        }
     }
 }
 

--- a/crates/vibepanel/src/services/compositor/mod.rs
+++ b/crates/vibepanel/src/services/compositor/mod.rs
@@ -23,6 +23,7 @@ mod mango;
 mod niri;
 mod sway;
 pub mod types;
+pub mod xkb_names;
 
 pub use factory::BackendKind;
 pub use hyprland::HyprlandBackend;
@@ -30,4 +31,4 @@ pub use manager::CompositorManager;
 pub use mango::MangoBackend;
 pub use niri::NiriBackend;
 pub use sway::SwayBackend;
-pub use types::*;
+pub use types::*; // Includes KeyboardLayoutInfo, KeyboardLayoutCallback

--- a/crates/vibepanel/src/services/compositor/niri.rs
+++ b/crates/vibepanel/src/services/compositor/niri.rs
@@ -22,8 +22,8 @@ use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
 use super::{
-    CompositorBackend, WindowCallback, WindowInfo, WorkspaceCallback, WorkspaceMeta,
-    WorkspaceSnapshot,
+    CompositorBackend, KeyboardLayoutCallback, KeyboardLayoutInfo, WindowCallback, WindowInfo,
+    WorkspaceCallback, WorkspaceMeta, WorkspaceSnapshot,
 };
 
 const RECONNECT_INITIAL_MS: u64 = 1000;
@@ -40,6 +40,12 @@ struct SharedState {
     /// Per-output active window info (output name -> WindowInfo).
     /// This tracks the "would be focused" window for each monitor.
     per_output_window: RwLock<HashMap<String, WindowInfo>>,
+    /// Current keyboard layout info.
+    keyboard_layout: RwLock<Option<KeyboardLayoutInfo>>,
+    /// List of available keyboard layout names (from Niri's KeyboardLayouts).
+    keyboard_layout_names: RwLock<Vec<String>>,
+    /// Current keyboard layout index.
+    keyboard_layout_idx: RwLock<usize>,
 }
 
 impl Default for SharedState {
@@ -51,6 +57,9 @@ impl Default for SharedState {
             id_to_output: RwLock::new(HashMap::new()),
             windows: RwLock::new(HashMap::new()),
             per_output_window: RwLock::new(HashMap::new()),
+            keyboard_layout: RwLock::new(None),
+            keyboard_layout_names: RwLock::new(Vec::new()),
+            keyboard_layout_idx: RwLock::new(0),
         }
     }
 }
@@ -63,6 +72,7 @@ pub struct NiriBackend {
     socket_path: RwLock<Option<String>>,
     shared: Arc<SharedState>,
     callbacks: Mutex<Option<(WorkspaceCallback, WindowCallback)>>,
+    keyboard_layout_callback: Mutex<Option<KeyboardLayoutCallback>>,
 }
 
 #[derive(Debug, Clone)]
@@ -83,6 +93,7 @@ impl NiriBackend {
             socket_path: RwLock::new(None),
             shared: Arc::new(SharedState::default()),
             callbacks: Mutex::new(None),
+            keyboard_layout_callback: Mutex::new(None),
         }
     }
 
@@ -457,15 +468,113 @@ impl NiriBackend {
             Self::process_windows(shared, windows);
         }
 
+        // Fetch keyboard layouts
+        Self::fetch_keyboard_layouts(socket_path, shared);
+
         debug!("Fetched initial Niri state");
     }
 
+    /// Fetch keyboard layouts from Niri.
+    fn fetch_keyboard_layouts(socket_path: &str, shared: &SharedState) {
+        let Some(reply) =
+            Self::send_request_static(socket_path, &Value::String("KeyboardLayouts".to_string()))
+        else {
+            debug!("fetch_keyboard_layouts: failed to query from Niri");
+            return;
+        };
+
+        let Some(ok) = reply.get("Ok") else {
+            debug!("fetch_keyboard_layouts: Niri returned error: {:?}", reply);
+            return;
+        };
+
+        let Some(kb_layouts) = ok.get("KeyboardLayouts") else {
+            debug!("fetch_keyboard_layouts: no KeyboardLayouts in response");
+            return;
+        };
+
+        Self::process_keyboard_layouts(shared, kb_layouts);
+    }
+
+    /// Process keyboard layout data from Niri.
+    fn process_keyboard_layouts(shared: &SharedState, kb_layouts: &Value) -> bool {
+        let names = kb_layouts
+            .get("names")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|entry| entry.as_str().map(String::from))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let current_idx = kb_layouts
+            .get("current_idx")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        let layout_count = names.len();
+        let layout_name = names.get(current_idx).cloned().unwrap_or_default();
+
+        debug!(
+            "process_keyboard_layouts: idx={}, layout='{}', count={}",
+            current_idx, layout_name, layout_count
+        );
+
+        *shared.keyboard_layout_names.write() = names;
+        *shared.keyboard_layout_idx.write() = current_idx;
+        *shared.keyboard_layout.write() = Some(KeyboardLayoutInfo {
+            layout_name,
+            short_name: String::new(),
+
+            layout_count: Some(layout_count),
+        });
+
+        true
+    }
+
+    /// Process a keyboard layout switch event.
+    fn process_keyboard_layout_switch(shared: &SharedState, idx: usize) -> bool {
+        let names = shared.keyboard_layout_names.read();
+        let layout_name = names.get(idx).cloned().unwrap_or_default();
+        let layout_count = names.len();
+
+        debug!(
+            "process_keyboard_layout_switch: idx={}, layout='{}'",
+            idx, layout_name
+        );
+
+        *shared.keyboard_layout_idx.write() = idx;
+        *shared.keyboard_layout.write() = Some(KeyboardLayoutInfo {
+            layout_name,
+            short_name: String::new(),
+
+            layout_count: Some(layout_count),
+        });
+
+        true
+    }
+
     /// Handle a Niri event.
-    fn handle_event(shared: &SharedState, event: &Value) -> (bool, bool) {
+    ///
+    /// Returns (workspace_changed, window_changed, keyboard_layout_changed).
+    fn handle_event(shared: &SharedState, event: &Value) -> (bool, bool, bool) {
         let mut workspace_changed = false;
         let mut window_changed = false;
+        let mut keyboard_layout_changed = false;
 
-        if let Some(workspaces_changed) = event.get("WorkspacesChanged") {
+        if let Some(kb_layouts_changed) = event.get("KeyboardLayoutsChanged") {
+            // Full layout list changed (e.g., user reconfigured layouts)
+            if let Some(kb_layouts) = kb_layouts_changed.get("keyboard_layouts") {
+                keyboard_layout_changed = Self::process_keyboard_layouts(shared, kb_layouts);
+            }
+        } else if let Some(kb_switched) = event.get("KeyboardLayoutSwitched") {
+            // Just switched to a different layout by index
+            if let Some(idx) = kb_switched.get("idx").and_then(|v| v.as_u64()) {
+                keyboard_layout_changed =
+                    Self::process_keyboard_layout_switch(shared, idx as usize);
+            }
+        } else if let Some(workspaces_changed) = event.get("WorkspacesChanged") {
             if let Some(workspaces) = workspaces_changed
                 .get("workspaces")
                 .and_then(|v| v.as_array())
@@ -602,7 +711,7 @@ impl NiriBackend {
             }
         }
 
-        (workspace_changed, window_changed)
+        (workspace_changed, window_changed, keyboard_layout_changed)
     }
 
     /// Run the event loop (in background thread).
@@ -611,6 +720,7 @@ impl NiriBackend {
         shared: Arc<SharedState>,
         socket_path: String,
         callbacks: Option<(WorkspaceCallback, WindowCallback)>,
+        kb_callback: Option<KeyboardLayoutCallback>,
     ) {
         // Fetch initial state
         Self::fetch_initial_state(&socket_path, &shared);
@@ -623,6 +733,13 @@ impl NiriBackend {
             for win_info in per_output.values() {
                 win_cb(win_info.clone());
             }
+        }
+
+        // Emit initial keyboard layout
+        if let Some(ref kb_cb) = kb_callback
+            && let Some(ref info) = *shared.keyboard_layout.read()
+        {
+            kb_cb(info.clone());
         }
 
         // Exponential backoff state
@@ -697,7 +814,8 @@ impl NiriBackend {
                                     continue;
                                 }
 
-                                let (ws_changed, win_changed) = Self::handle_event(&shared, &event);
+                                let (ws_changed, win_changed, kb_changed) =
+                                    Self::handle_event(&shared, &event);
 
                                 if let Some((ref ws_cb, ref win_cb)) = callbacks {
                                     if ws_changed {
@@ -710,6 +828,13 @@ impl NiriBackend {
                                             win_cb(win_info.clone());
                                         }
                                     }
+                                }
+
+                                if kb_changed
+                                    && let Some(ref kb_cb) = kb_callback
+                                    && let Some(ref info) = *shared.keyboard_layout.read()
+                                {
+                                    kb_cb(info.clone());
                                 }
                             }
                             Err(e) => {
@@ -765,12 +890,17 @@ impl CompositorBackend for NiriBackend {
         let running = Arc::clone(&self.running);
         let shared = Arc::clone(&self.shared);
         let callbacks = Some((on_workspace_update, on_window_update));
+        let kb_callback = self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
 
         // Start event loop thread
         let handle = thread::Builder::new()
             .name("niri-event-loop".into())
             .spawn(move || {
-                Self::event_loop(running, shared, socket_path, callbacks);
+                Self::event_loop(running, shared, socket_path, callbacks, kb_callback);
             })
             .ok();
 
@@ -860,6 +990,28 @@ impl CompositorBackend for NiriBackend {
 
     fn name(&self) -> &'static str {
         "Niri"
+    }
+
+    fn set_keyboard_layout_callback(&self, callback: KeyboardLayoutCallback) {
+        *self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(callback);
+    }
+
+    fn get_keyboard_layout(&self) -> Option<KeyboardLayoutInfo> {
+        self.shared.keyboard_layout.read().clone()
+    }
+
+    fn switch_keyboard_layout_next(&self) {
+        let request = serde_json::json!({
+            "Action": {
+                "SwitchLayout": {
+                    "layout": "Next"
+                }
+            }
+        });
+        let _ = self.send_request(&request);
     }
 }
 

--- a/crates/vibepanel/src/services/compositor/sway.rs
+++ b/crates/vibepanel/src/services/compositor/sway.rs
@@ -24,8 +24,8 @@ use serde_json::Value;
 use tracing::{debug, error, trace, warn};
 
 use super::{
-    CompositorBackend, WindowCallback, WindowInfo, WorkspaceCallback, WorkspaceMeta,
-    WorkspaceSnapshot,
+    CompositorBackend, KeyboardLayoutCallback, KeyboardLayoutInfo, WindowCallback, WindowInfo,
+    WorkspaceCallback, WorkspaceMeta, WorkspaceSnapshot,
 };
 
 // i3 IPC constants
@@ -37,11 +37,13 @@ const IPC_RUN_COMMAND: u32 = 0;
 const IPC_GET_WORKSPACES: u32 = 1;
 const IPC_SUBSCRIBE: u32 = 2;
 const IPC_GET_TREE: u32 = 4;
+const IPC_GET_INPUTS: u32 = 100;
 
 // Event types have bit 31 set in the response type
 const IPC_EVENT_BIT: u32 = 1 << 31;
 const IPC_EVENT_WORKSPACE: u32 = IPC_EVENT_BIT; // event type 0
 const IPC_EVENT_WINDOW: u32 = IPC_EVENT_BIT | 3;
+const IPC_EVENT_INPUT: u32 = IPC_EVENT_BIT | 21;
 
 const RECONNECT_INITIAL_MS: u64 = 1000;
 const RECONNECT_MAX_MS: u64 = 30000;
@@ -155,6 +157,7 @@ struct SharedState {
     workspace_snapshot: RwLock<WorkspaceSnapshot>,
     focused_window: RwLock<Option<WindowInfo>>,
     workspaces: RwLock<Vec<WorkspaceMeta>>,
+    keyboard_layout: RwLock<Option<KeyboardLayoutInfo>>,
 }
 
 impl Default for SharedState {
@@ -172,6 +175,7 @@ impl Default for SharedState {
                     })
                     .collect(),
             ),
+            keyboard_layout: RwLock::new(None),
         }
     }
 }
@@ -182,6 +186,7 @@ pub struct SwayBackend {
     socket_path: RwLock<Option<String>>,
     shared: Arc<SharedState>,
     callbacks: Mutex<Option<(WorkspaceCallback, WindowCallback)>>,
+    keyboard_layout_callback: Mutex<Option<KeyboardLayoutCallback>>,
     compositor_name: &'static str,
     socket_env_var: &'static str,
 }
@@ -200,6 +205,7 @@ impl SwayBackend {
             socket_path: RwLock::new(None),
             shared: Arc::new(SharedState::default()),
             callbacks: Mutex::new(None),
+            keyboard_layout_callback: Mutex::new(None),
             compositor_name,
             socket_env_var,
         }
@@ -493,15 +499,68 @@ impl SwayBackend {
         Self::fetch_tree(socket_path, shared, wm);
     }
 
+    /// Fetch keyboard layout from Sway's `get_inputs`.
+    fn fetch_keyboard_layout(socket_path: &str, shared: &SharedState, wm: &str) {
+        let Some(inputs) = ipc_request(socket_path, IPC_GET_INPUTS, b"", wm) else {
+            debug!("fetch_keyboard_layout: failed to query inputs from {}", wm);
+            return;
+        };
+
+        let Some(inputs) = inputs.as_array() else {
+            debug!(
+                "fetch_keyboard_layout: {} get_inputs response is not an array",
+                wm
+            );
+            return;
+        };
+
+        // Find the first keyboard input device.
+        let main_kb = inputs
+            .iter()
+            .find(|input| input.get("type").and_then(|v| v.as_str()) == Some("keyboard"));
+
+        let Some(kb) = main_kb else {
+            debug!(
+                "fetch_keyboard_layout: no suitable keyboard found in {}",
+                wm
+            );
+            return;
+        };
+
+        let active_layout = kb
+            .get("xkb_active_layout_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let layout_count = kb
+            .get("xkb_layout_names")
+            .and_then(|v| v.as_array())
+            .map(|names| names.len());
+
+        debug!(
+            "fetch_keyboard_layout: layout='{}', layout_count={:?}",
+            active_layout, layout_count
+        );
+
+        *shared.keyboard_layout.write() = Some(KeyboardLayoutInfo {
+            layout_name: active_layout,
+            short_name: String::new(),
+            layout_count,
+        });
+    }
+
     /// Run the event loop (in background thread).
     fn event_loop(
         running: Arc<AtomicBool>,
         shared: Arc<SharedState>,
         socket_path: String,
         callbacks: Option<(WorkspaceCallback, WindowCallback)>,
+        kb_callback: Option<KeyboardLayoutCallback>,
         wm: &str,
     ) {
         Self::fetch_all(&socket_path, &shared, wm);
+        Self::fetch_keyboard_layout(&socket_path, &shared, wm);
 
         if let Some((ref ws_cb, ref win_cb)) = callbacks {
             ws_cb(shared.workspace_snapshot.read().clone());
@@ -510,6 +569,11 @@ impl SwayBackend {
             } else {
                 win_cb(WindowInfo::default());
             }
+        }
+        if let Some(ref kb_cb) = kb_callback
+            && let Some(ref info) = *shared.keyboard_layout.read()
+        {
+            kb_cb(info.clone());
         }
 
         let mut backoff_ms = RECONNECT_INITIAL_MS;
@@ -535,7 +599,7 @@ impl SwayBackend {
                 }
             };
 
-            let subscribe_payload = b"[\"workspace\", \"window\"]";
+            let subscribe_payload = b"[\"workspace\", \"window\", \"input\"]";
             if let Err(e) = ipc_send(&mut stream, IPC_SUBSCRIBE, subscribe_payload) {
                 if running.load(Ordering::SeqCst) {
                     warn!(
@@ -599,7 +663,7 @@ impl SwayBackend {
                             }
                         };
 
-                        let (ws_changed, win_changed) =
+                        let (ws_changed, win_changed, kb_changed) =
                             Self::handle_event(msg_type, &event, &socket_path, &shared, wm);
 
                         if let Some((ref ws_cb, ref win_cb)) = callbacks {
@@ -613,6 +677,13 @@ impl SwayBackend {
                                     win_cb(WindowInfo::default());
                                 }
                             }
+                        }
+
+                        if kb_changed
+                            && let Some(ref kb_cb) = kb_callback
+                            && let Some(ref info) = *shared.keyboard_layout.read()
+                        {
+                            kb_cb(info.clone());
                         }
                     }
                     Err(e) => {
@@ -634,14 +705,14 @@ impl SwayBackend {
     }
 
     /// Handle a single event.
-    /// Returns (workspace_changed, window_changed).
+    /// Returns (workspace_changed, window_changed, keyboard_layout_changed).
     fn handle_event(
         msg_type: u32,
         event: &Value,
         socket_path: &str,
         shared: &SharedState,
         wm: &str,
-    ) -> (bool, bool) {
+    ) -> (bool, bool, bool) {
         let change = event.get("change").and_then(|v| v.as_str()).unwrap_or("");
 
         trace!("{} event: type=0x{:x}, change={}", wm, msg_type, change);
@@ -649,32 +720,62 @@ impl SwayBackend {
         match msg_type {
             IPC_EVENT_WORKSPACE => {
                 Self::fetch_all(socket_path, shared, wm);
-                (true, true)
+                (true, true, false)
             }
             IPC_EVENT_WINDOW => {
                 match change {
                     "focus" | "title" => {
                         Self::fetch_tree(socket_path, shared, wm);
-                        (false, true)
+                        (false, true, false)
                     }
                     "close" | "new" | "move" => {
                         // Window count / occupancy may have changed
                         Self::fetch_all(socket_path, shared, wm);
-                        (true, true)
+                        (true, true, false)
                     }
                     "urgent" => {
                         Self::fetch_all(socket_path, shared, wm);
-                        (true, false)
+                        (true, false, false)
                     }
                     _ => {
                         trace!("Unhandled {} window change: {}", wm, change);
-                        (false, false)
+                        (false, false, false)
                     }
                 }
             }
+            IPC_EVENT_INPUT => {
+                // Input event — check if it's a keyboard layout change
+                // The event payload contains "input" with "type", "xkb_active_layout_name", etc.
+                if change == "xkb_layout"
+                    && let Some(input) = event.get("input")
+                {
+                    let input_type = input.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    if input_type == "keyboard" {
+                        let active_layout = input
+                            .get("xkb_active_layout_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let layout_count = input
+                            .get("xkb_layout_names")
+                            .and_then(|v| v.as_array())
+                            .map(|names| names.len());
+
+                        trace!("{} keyboard layout changed: '{}'", wm, active_layout);
+
+                        *shared.keyboard_layout.write() = Some(KeyboardLayoutInfo {
+                            layout_name: active_layout,
+                            short_name: String::new(),
+                            layout_count,
+                        });
+                        return (false, false, true);
+                    }
+                }
+                (false, false, false)
+            }
             _ => {
                 trace!("Unhandled {} event type: 0x{:x}", wm, msg_type);
-                (false, false)
+                (false, false, false)
             }
         }
     }
@@ -706,6 +807,11 @@ impl CompositorBackend for SwayBackend {
         let running = Arc::clone(&self.running);
         let shared = Arc::clone(&self.shared);
         let callbacks = Some((on_workspace_update, on_window_update));
+        let kb_callback = self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
 
         let handle = thread::Builder::new()
             .name(format!(
@@ -713,7 +819,7 @@ impl CompositorBackend for SwayBackend {
                 wm.to_lowercase().replace(' ', "-")
             ))
             .spawn(move || {
-                Self::event_loop(running, shared, socket_path, callbacks, wm);
+                Self::event_loop(running, shared, socket_path, callbacks, kb_callback, wm);
             })
             .ok();
 
@@ -811,6 +917,30 @@ impl CompositorBackend for SwayBackend {
 
     fn name(&self) -> &'static str {
         self.compositor_name
+    }
+
+    fn set_keyboard_layout_callback(&self, callback: KeyboardLayoutCallback) {
+        *self
+            .keyboard_layout_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(callback);
+    }
+
+    fn get_keyboard_layout(&self) -> Option<KeyboardLayoutInfo> {
+        self.shared.keyboard_layout.read().clone()
+    }
+
+    fn switch_keyboard_layout_next(&self) {
+        let socket_path = self.socket_path.read();
+        if let Some(ref path) = *socket_path {
+            debug!("Switching keyboard layout on {}", self.compositor_name);
+            let _ = ipc_request(
+                path,
+                IPC_RUN_COMMAND,
+                b"input type:keyboard xkb_switch_layout next",
+                self.compositor_name,
+            );
+        }
     }
 }
 

--- a/crates/vibepanel/src/services/compositor/types.rs
+++ b/crates/vibepanel/src/services/compositor/types.rs
@@ -107,12 +107,26 @@ impl WindowInfo {
     }
 }
 
+/// Information about the current keyboard layout.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct KeyboardLayoutInfo {
+    /// Full layout name (e.g., "English (US)").
+    pub layout_name: String,
+    /// Short layout identifier (e.g., "us"), if available from the backend.
+    pub short_name: String,
+    /// Total number of configured keyboard layouts, if known.
+    pub layout_count: Option<usize>,
+}
+
 /// Callback type for workspace state updates.
 pub type WorkspaceCallback = Arc<dyn Fn(WorkspaceSnapshot) + Send + Sync>;
 
 /// Callback type for focused window updates.
 /// Receives `WindowInfo::default()` when no window is focused.
 pub type WindowCallback = Arc<dyn Fn(WindowInfo) + Send + Sync>;
+
+/// Callback type for keyboard layout updates.
+pub type KeyboardLayoutCallback = Arc<dyn Fn(KeyboardLayoutInfo) + Send + Sync>;
 
 /// Trait for compositor backend implementations.
 ///
@@ -185,6 +199,25 @@ pub trait CompositorBackend: Send + Sync {
     /// Used for logout functionality. Default implementation is a no-op
     /// for compositors that don't support this.
     fn quit_compositor(&self) {
+        // Default no-op
+    }
+
+    /// Register a callback for keyboard layout changes.
+    ///
+    /// Default no-op for backends without keyboard layout support.
+    fn set_keyboard_layout_callback(&self, _callback: KeyboardLayoutCallback) {
+        // Default no-op
+    }
+
+    /// Get the current keyboard layout, if known.
+    fn get_keyboard_layout(&self) -> Option<KeyboardLayoutInfo> {
+        None
+    }
+
+    /// Switch to the next keyboard layout.
+    ///
+    /// Default no-op for backends without keyboard layout support.
+    fn switch_keyboard_layout_next(&self) {
         // Default no-op
     }
 }
@@ -300,5 +333,31 @@ mod tests {
         assert!(snapshot.active_workspace.contains(&3));
         assert!(!snapshot.active_workspace.contains(&2));
         assert_eq!(snapshot.active_workspace.len(), 2);
+    }
+
+    #[test]
+    fn test_keyboard_layout_info_default() {
+        let info = KeyboardLayoutInfo::default();
+        assert!(info.layout_name.is_empty());
+        assert!(info.short_name.is_empty());
+        assert_eq!(info.layout_count, None);
+    }
+
+    #[test]
+    fn test_keyboard_layout_info_equality() {
+        let info1 = KeyboardLayoutInfo {
+            layout_name: "English (US)".to_string(),
+            short_name: "us".to_string(),
+            layout_count: Some(2),
+        };
+        let info2 = info1.clone();
+        assert_eq!(info1, info2);
+
+        let info3 = KeyboardLayoutInfo {
+            layout_name: "German".to_string(),
+            short_name: "de".to_string(),
+            layout_count: Some(2),
+        };
+        assert_ne!(info1, info3);
     }
 }

--- a/crates/vibepanel/src/services/compositor/xkb_names.rs
+++ b/crates/vibepanel/src/services/compositor/xkb_names.rs
@@ -1,0 +1,325 @@
+//! Bidirectional mapping between XKB layout codes and display names.
+//!
+//! Provides lookups for normalizing keyboard layout display across different
+//! compositor backends:
+//!
+//! - **Sway / Hyprland / Niri** report full descriptions like `"English (US)"`.
+//!   After extracting the base language name (e.g., `"Swedish"`), use
+//!   [`short_code_from_language`] to get a 2-letter display code.
+//!
+//! - **MangoWC / DWL** report raw XKB codes like `"swe"` or `"us"`.
+//!   Use [`short_code_from_xkb`] to get a normalized 2-letter display code,
+//!   and [`language_from_xkb`] to get a human-readable name for tooltips.
+
+/// A single entry in the layout mapping table.
+struct LayoutEntry {
+    xkb: &'static str,
+    code: &'static str,
+    language: &'static str,
+}
+
+/// Layout mapping table covering the most common XKB layouts.
+///
+/// Sourced from vibepanel stargazer demographics, common Wayland desktop
+/// layouts, and the XKB rules database. See `evdev.xml` for the full list
+/// of XKB layouts — this table is intentionally kept small.
+const LAYOUTS: &[LayoutEntry] = &[
+    // Nordic
+    LayoutEntry {
+        xkb: "se",
+        code: "SE",
+        language: "Swedish",
+    },
+    LayoutEntry {
+        xkb: "swe",
+        code: "SE",
+        language: "Swedish",
+    },
+    LayoutEntry {
+        xkb: "no",
+        code: "NO",
+        language: "Norwegian",
+    },
+    LayoutEntry {
+        xkb: "dk",
+        code: "DK",
+        language: "Danish",
+    },
+    LayoutEntry {
+        xkb: "fi",
+        code: "FI",
+        language: "Finnish",
+    },
+    // Western Europe
+    LayoutEntry {
+        xkb: "de",
+        code: "DE",
+        language: "German",
+    },
+    LayoutEntry {
+        xkb: "fr",
+        code: "FR",
+        language: "French",
+    },
+    LayoutEntry {
+        xkb: "gb",
+        code: "GB",
+        language: "English",
+    },
+    LayoutEntry {
+        xkb: "us",
+        code: "US",
+        language: "English",
+    },
+    LayoutEntry {
+        xkb: "es",
+        code: "ES",
+        language: "Spanish",
+    },
+    LayoutEntry {
+        xkb: "it",
+        code: "IT",
+        language: "Italian",
+    },
+    LayoutEntry {
+        xkb: "pt",
+        code: "PT",
+        language: "Portuguese",
+    },
+    LayoutEntry {
+        xkb: "nl",
+        code: "NL",
+        language: "Dutch",
+    },
+    LayoutEntry {
+        xkb: "be",
+        code: "BE",
+        language: "Belgian",
+    },
+    LayoutEntry {
+        xkb: "ch",
+        code: "CH",
+        language: "Swiss",
+    },
+    LayoutEntry {
+        xkb: "at",
+        code: "AT",
+        language: "Austrian",
+    },
+    // Eastern Europe
+    LayoutEntry {
+        xkb: "pl",
+        code: "PL",
+        language: "Polish",
+    },
+    LayoutEntry {
+        xkb: "cz",
+        code: "CZ",
+        language: "Czech",
+    },
+    LayoutEntry {
+        xkb: "hu",
+        code: "HU",
+        language: "Hungarian",
+    },
+    LayoutEntry {
+        xkb: "ro",
+        code: "RO",
+        language: "Romanian",
+    },
+    LayoutEntry {
+        xkb: "ua",
+        code: "UA",
+        language: "Ukrainian",
+    },
+    LayoutEntry {
+        xkb: "ru",
+        code: "RU",
+        language: "Russian",
+    },
+    // Americas
+    LayoutEntry {
+        xkb: "br",
+        code: "BR",
+        language: "Portuguese",
+    },
+    LayoutEntry {
+        xkb: "latam",
+        code: "LA",
+        language: "Spanish",
+    },
+    LayoutEntry {
+        xkb: "ca",
+        code: "CA",
+        language: "Canadian",
+    },
+    // Middle East
+    LayoutEntry {
+        xkb: "tr",
+        code: "TR",
+        language: "Turkish",
+    },
+    LayoutEntry {
+        xkb: "il",
+        code: "IL",
+        language: "Hebrew",
+    },
+    LayoutEntry {
+        xkb: "ara",
+        code: "AR",
+        language: "Arabic",
+    },
+    // Asia
+    LayoutEntry {
+        xkb: "jp",
+        code: "JP",
+        language: "Japanese",
+    },
+    LayoutEntry {
+        xkb: "kr",
+        code: "KR",
+        language: "Korean",
+    },
+    LayoutEntry {
+        xkb: "cn",
+        code: "CN",
+        language: "Chinese",
+    },
+    LayoutEntry {
+        xkb: "id",
+        code: "ID",
+        language: "Indonesian",
+    },
+    // Central Asia
+    LayoutEntry {
+        xkb: "uz",
+        code: "UZ",
+        language: "Uzbek",
+    },
+];
+
+/// Look up a short display code from an XKB layout code.
+///
+/// ```text
+/// "swe" → Some("SE")
+/// "us"  → Some("US")
+/// "xyz" → None
+/// ```
+pub fn short_code_from_xkb(xkb: &str) -> Option<&'static str> {
+    let xkb_lower = xkb.to_lowercase();
+    LAYOUTS.iter().find(|e| e.xkb == xkb_lower).map(|e| e.code)
+}
+
+/// Look up a short display code from an English language name (case-insensitive).
+///
+/// Returns the first match — for ambiguous names like `"English"` (which maps
+/// to both `us` and `gb`), callers should prefer parenthesized codes when available.
+///
+/// ```text
+/// "Swedish" → Some("SE")
+/// "German"  → Some("DE")
+/// "Klingon" → None
+/// ```
+pub fn short_code_from_language(name: &str) -> Option<&'static str> {
+    let name_lower = name.to_lowercase();
+    LAYOUTS
+        .iter()
+        .find(|e| e.language.to_lowercase() == name_lower)
+        .map(|e| e.code)
+}
+
+/// Look up a human-readable language name from an XKB layout code.
+///
+/// ```text
+/// "swe" → Some("Swedish")
+/// "us"  → Some("English")
+/// "xyz" → None
+/// ```
+pub fn language_from_xkb(xkb: &str) -> Option<&'static str> {
+    let xkb_lower = xkb.to_lowercase();
+    LAYOUTS
+        .iter()
+        .find(|e| e.xkb == xkb_lower)
+        .map(|e| e.language)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_short_code_from_xkb() {
+        assert_eq!(short_code_from_xkb("swe"), Some("SE"));
+        assert_eq!(short_code_from_xkb("se"), Some("SE"));
+        assert_eq!(short_code_from_xkb("us"), Some("US"));
+        assert_eq!(short_code_from_xkb("de"), Some("DE"));
+        assert_eq!(short_code_from_xkb("latam"), Some("LA"));
+        assert_eq!(short_code_from_xkb("ara"), Some("AR"));
+        assert_eq!(short_code_from_xkb("xyz"), None);
+    }
+
+    #[test]
+    fn test_short_code_from_xkb_case_insensitive() {
+        assert_eq!(short_code_from_xkb("SWE"), Some("SE"));
+        assert_eq!(short_code_from_xkb("Us"), Some("US"));
+    }
+
+    #[test]
+    fn test_short_code_from_language() {
+        assert_eq!(short_code_from_language("Swedish"), Some("SE"));
+        assert_eq!(short_code_from_language("German"), Some("DE"));
+        assert_eq!(short_code_from_language("Japanese"), Some("JP"));
+        assert_eq!(short_code_from_language("Klingon"), None);
+    }
+
+    #[test]
+    fn test_short_code_from_language_case_insensitive() {
+        assert_eq!(short_code_from_language("swedish"), Some("SE"));
+        assert_eq!(short_code_from_language("GERMAN"), Some("DE"));
+    }
+
+    #[test]
+    fn test_language_from_xkb() {
+        assert_eq!(language_from_xkb("swe"), Some("Swedish"));
+        assert_eq!(language_from_xkb("se"), Some("Swedish"));
+        assert_eq!(language_from_xkb("us"), Some("English"));
+        assert_eq!(language_from_xkb("de"), Some("German"));
+        assert_eq!(language_from_xkb("xyz"), None);
+    }
+
+    #[test]
+    fn test_all_entries_have_uppercase_codes() {
+        for entry in LAYOUTS {
+            assert_eq!(
+                entry.code,
+                entry.code.to_uppercase(),
+                "code for xkb '{}' should be uppercase",
+                entry.xkb
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_entries_have_lowercase_xkb() {
+        for entry in LAYOUTS {
+            assert_eq!(
+                entry.xkb,
+                entry.xkb.to_lowercase(),
+                "xkb code '{}' should be lowercase",
+                entry.xkb
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_entries_have_capitalized_language() {
+        for entry in LAYOUTS {
+            assert!(
+                entry.language.starts_with(|c: char| c.is_uppercase()),
+                "language '{}' for xkb '{}' should be capitalized",
+                entry.language,
+                entry.xkb
+            );
+        }
+    }
+}

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -638,6 +638,16 @@ pub mod widget {
     /// Custom widget prefix (`.custom-<name>`).
     /// Each instance gets a dynamic `custom-{id}` class built from this prefix.
     pub const CUSTOM_PREFIX: &str = "custom-";
+
+    // Keyboard layout
+    /// Keyboard layout widget (`.keyboard-layout`).
+    pub const KEYBOARD_LAYOUT: &str = "keyboard-layout";
+
+    /// Keyboard layout icon (`.keyboard-layout-icon`).
+    pub const KEYBOARD_LAYOUT_ICON: &str = "keyboard-layout-icon";
+
+    /// Keyboard layout label (`.keyboard-layout-label`).
+    pub const KEYBOARD_LAYOUT_LABEL: &str = "keyboard-layout-label";
 }
 
 /// Surface and popover classes.

--- a/crates/vibepanel/src/widgets/keyboard_layout.rs
+++ b/crates/vibepanel/src/widgets/keyboard_layout.rs
@@ -1,0 +1,335 @@
+//! Keyboard Layout widget — displays the active keyboard layout.
+//!
+//! Shows a short code or full name with optional icon. Click to cycle layouts.
+
+use gtk4::prelude::*;
+use gtk4::{GestureClick, Label};
+use tracing::debug;
+use vibepanel_core::config::WidgetEntry;
+
+use crate::services::callbacks::CallbackId;
+use crate::services::compositor::CompositorManager;
+use crate::services::compositor::KeyboardLayoutInfo;
+use crate::services::compositor::xkb_names;
+use crate::services::tooltip::TooltipManager;
+use crate::styles::{class, state, widget};
+use crate::widgets::base::BaseWidget;
+use crate::widgets::{WidgetConfig, warn_unknown_options};
+
+/// Default configuration values.
+const DEFAULT_SHOW_ICON: bool = true;
+const DEFAULT_SHOW_LABEL: bool = true;
+
+/// Layout label format options.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum LayoutFormat {
+    /// Short code extracted from the layout name: "English (US)" -> "US"
+    #[default]
+    Short,
+    /// Full layout name as reported by the compositor.
+    Long,
+}
+
+impl LayoutFormat {
+    fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "long" => Self::Long,
+            _ => Self::Short,
+        }
+    }
+}
+
+/// Configuration for the keyboard layout widget.
+#[derive(Debug, Clone)]
+pub struct KeyboardLayoutConfig {
+    pub show_icon: bool,
+    pub show_label: bool,
+    pub format: LayoutFormat,
+}
+
+impl WidgetConfig for KeyboardLayoutConfig {
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        warn_unknown_options(
+            "keyboard_layout",
+            entry,
+            &["show_icon", "show_label", "format"],
+        );
+
+        let show_icon = entry
+            .options
+            .get("show_icon")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(DEFAULT_SHOW_ICON);
+
+        let show_label = entry
+            .options
+            .get("show_label")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(DEFAULT_SHOW_LABEL);
+
+        let format = entry
+            .options
+            .get("format")
+            .and_then(|v| v.as_str())
+            .map(LayoutFormat::parse)
+            .unwrap_or_default();
+
+        Self {
+            show_icon,
+            show_label,
+            format,
+        }
+    }
+}
+
+impl Default for KeyboardLayoutConfig {
+    fn default() -> Self {
+        Self {
+            show_icon: DEFAULT_SHOW_ICON,
+            show_label: DEFAULT_SHOW_LABEL,
+            format: LayoutFormat::default(),
+        }
+    }
+}
+
+/// Keyboard layout widget that displays the active layout and supports click-to-cycle.
+pub struct KeyboardLayoutWidget {
+    base: BaseWidget,
+    callback_id: CallbackId,
+}
+
+impl KeyboardLayoutWidget {
+    /// Create a new keyboard layout widget with the given configuration.
+    pub fn new(config: KeyboardLayoutConfig) -> Self {
+        let base = BaseWidget::new(&[widget::KEYBOARD_LAYOUT]);
+
+        base.set_tooltip("Keyboard layout");
+
+        let icon_handle = base.add_icon("input-keyboard", &[widget::KEYBOARD_LAYOUT_ICON]);
+        let label = base.add_label(None, &[widget::KEYBOARD_LAYOUT_LABEL, class::VCENTER_CAPS]);
+
+        icon_handle.widget().set_visible(config.show_icon);
+        label.set_visible(config.show_label);
+
+        // Click to cycle layouts
+        {
+            let click = GestureClick::new();
+            let container = base.widget().clone();
+            click.connect_released(move |_, _, _, _| {
+                debug!("Keyboard layout widget clicked, cycling to next layout");
+                CompositorManager::global().switch_keyboard_layout_next();
+            });
+            container.add_controller(click);
+        }
+
+        // Subscribe to keyboard layout changes
+        let manager = CompositorManager::global();
+        let callback_id = {
+            let container = base.widget().clone();
+            let label = label.clone();
+            let format = config.format.clone();
+
+            manager.register_keyboard_layout_callback(move |info: &KeyboardLayoutInfo| {
+                update_keyboard_layout_widget(&container, &label, info, &format);
+            })
+        };
+
+        Self { base, callback_id }
+    }
+
+    /// Get the root GTK widget for embedding in the bar.
+    pub fn widget(&self) -> &gtk4::Box {
+        self.base.widget()
+    }
+}
+
+impl Drop for KeyboardLayoutWidget {
+    fn drop(&mut self) {
+        CompositorManager::global().unregister_keyboard_layout_callback(self.callback_id);
+    }
+}
+
+/// Extract a short display code from a full layout name.
+///
+/// Strategies: parenthesized code (`"English (US)"` → `"US"`), short string
+/// uppercasing (`"us"` → `"US"`), xkb_names lookup (`"Swedish"` → `"SE"`),
+/// or fall back to the full name.
+fn extract_short_name(layout_name: &str) -> String {
+    if layout_name.is_empty() {
+        return "?".to_string();
+    }
+
+    // If there's a parenthesized part, extract it: "English (US)" -> "US"
+    if let Some(start) = layout_name.rfind('(')
+        && let Some(rel_end) = layout_name[start + 1..].find(')')
+    {
+        let inner = layout_name[start + 1..start + 1 + rel_end].trim();
+        if !inner.is_empty() {
+            // Spaces in the paren suggest a variant description ("no dead keys")
+            // rather than a short code ("US") — fall through to use the base name.
+            if !inner.contains(' ') {
+                return inner.to_string();
+            }
+
+            let base = layout_name[..start].trim();
+            if !base.is_empty() {
+                // Try the XKB names table for the base language name
+                if let Some(code) = xkb_names::short_code_from_language(base) {
+                    return code.to_string();
+                }
+                if base.len() <= 3 && base.chars().all(|c| c.is_ascii_alphabetic()) {
+                    return base.to_uppercase();
+                }
+                return base.to_string();
+            }
+        }
+    }
+
+    // Short strings (2-3 chars) are likely already codes — uppercase them
+    if layout_name.len() <= 3 && layout_name.chars().all(|c| c.is_ascii_alphabetic()) {
+        return layout_name.to_uppercase();
+    }
+
+    // Try the XKB names table for bare language names like "Swedish", "German"
+    if let Some(code) = xkb_names::short_code_from_language(layout_name) {
+        return code.to_string();
+    }
+
+    // Fall back to full name
+    layout_name.to_string()
+}
+
+/// Update the keyboard layout widget from a layout info update.
+fn update_keyboard_layout_widget(
+    container: &gtk4::Box,
+    label: &Label,
+    info: &KeyboardLayoutInfo,
+    format: &LayoutFormat,
+) {
+    // Toggle clickable styling based on whether layout cycling is possible
+    let is_cyclable = info.layout_count != Some(1);
+    if is_cyclable {
+        container.add_css_class(state::CLICKABLE);
+    } else {
+        container.remove_css_class(state::CLICKABLE);
+    }
+
+    let display_text = match format {
+        LayoutFormat::Long => {
+            if info.layout_name.is_empty() {
+                "?".to_string()
+            } else {
+                info.layout_name.clone()
+            }
+        }
+        LayoutFormat::Short => {
+            if !info.short_name.is_empty() {
+                // Backend provided an XKB code (e.g. "swe") — look up a
+                // normalized display code, fall back to uppercasing.
+                xkb_names::short_code_from_xkb(&info.short_name)
+                    .map(String::from)
+                    .unwrap_or_else(|| info.short_name.to_uppercase())
+            } else {
+                extract_short_name(&info.layout_name)
+            }
+        }
+    };
+
+    label.set_label(&display_text);
+
+    // Set tooltip to full layout name
+    let tooltip = if info.layout_name.is_empty() {
+        "Keyboard layout: unknown".to_string()
+    } else {
+        format!("Keyboard layout: {}", info.layout_name)
+    };
+    let tooltip_manager = TooltipManager::global();
+    tooltip_manager.set_styled_tooltip(container, &tooltip);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_short_name_parenthesized() {
+        assert_eq!(extract_short_name("English (US)"), "US");
+        assert_eq!(extract_short_name("German (Dvorak)"), "Dvorak");
+        assert_eq!(extract_short_name("Russian (phonetic)"), "phonetic");
+    }
+
+    #[test]
+    fn test_extract_short_name_short_codes() {
+        assert_eq!(extract_short_name("us"), "US");
+        assert_eq!(extract_short_name("de"), "DE");
+        assert_eq!(extract_short_name("fr"), "FR");
+    }
+
+    #[test]
+    fn test_extract_short_name_full_name() {
+        // Known language names now resolve to 2-letter codes via xkb_names
+        assert_eq!(extract_short_name("French"), "FR");
+        assert_eq!(extract_short_name("Japanese"), "JP");
+        assert_eq!(extract_short_name("Swedish"), "SE");
+        assert_eq!(extract_short_name("German"), "DE");
+        // Unknown names pass through unchanged
+        assert_eq!(extract_short_name("Klingon"), "Klingon");
+    }
+
+    #[test]
+    fn test_extract_short_name_empty() {
+        assert_eq!(extract_short_name(""), "?");
+    }
+
+    #[test]
+    fn test_extract_short_name_edge_cases() {
+        // Empty parens
+        assert_eq!(extract_short_name("English ()"), "English ()");
+        // Nested
+        assert_eq!(extract_short_name("Foo (Bar (Baz))"), "Baz");
+    }
+
+    #[test]
+    fn test_extract_short_name_variant_descriptions() {
+        // Variant descriptions with spaces should fall back to the base name,
+        // which then resolves via xkb_names to a 2-letter code
+        assert_eq!(extract_short_name("Swedish (no dead keys)"), "SE");
+        assert_eq!(extract_short_name("German (with AltGr dead keys)"), "DE");
+        assert_eq!(extract_short_name("French (alt.)"), "alt.");
+        // Single-word variants are still treated as short codes
+        assert_eq!(extract_short_name("German (Dvorak)"), "Dvorak");
+        assert_eq!(extract_short_name("Russian (phonetic)"), "phonetic");
+    }
+
+    #[test]
+    fn test_keyboard_layout_config_defaults() {
+        let entry = WidgetEntry {
+            name: "keyboard_layout".to_string(),
+            options: Default::default(),
+        };
+        let config = KeyboardLayoutConfig::from_entry(&entry);
+        assert!(config.show_icon);
+        assert!(config.show_label);
+        assert_eq!(config.format, LayoutFormat::Short);
+    }
+
+    #[test]
+    fn test_keyboard_layout_config_custom() {
+        let mut options = std::collections::HashMap::new();
+        options.insert("show_icon".to_string(), toml::Value::Boolean(false));
+        options.insert("show_label".to_string(), toml::Value::Boolean(true));
+        options.insert(
+            "format".to_string(),
+            toml::Value::String("long".to_string()),
+        );
+
+        let entry = WidgetEntry {
+            name: "keyboard_layout".to_string(),
+            options,
+        };
+        let config = KeyboardLayoutConfig::from_entry(&entry);
+        assert!(!config.show_icon);
+        assert!(config.show_label);
+        assert_eq!(config.format, LayoutFormat::Long);
+    }
+}

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -21,6 +21,7 @@ mod clock;
 mod cpu;
 mod custom;
 mod gpu;
+mod keyboard_layout;
 pub mod layer_shell_popover;
 mod marquee_label;
 mod media;
@@ -68,6 +69,7 @@ pub use workspaces::{WorkspacesConfig, WorkspacesWidget};
 pub use cpu::{CpuConfig, CpuWidget};
 pub use custom::{CustomConfig, CustomWidget};
 pub use gpu::{GpuConfig, GpuWidget};
+pub use keyboard_layout::{KeyboardLayoutConfig, KeyboardLayoutWidget};
 pub use memory::{MemoryConfig, MemoryWidget};
 pub use network_speed::{NetworkSpeedConfig, NetworkSpeedWidget};
 
@@ -315,6 +317,15 @@ impl WidgetFactory {
                 Some(BuiltWidget {
                     widget: root,
                     handle: Box::new(network),
+                })
+            }
+            "keyboard_layout" => {
+                let cfg = KeyboardLayoutConfig::from_entry(entry);
+                let keyboard_layout = KeyboardLayoutWidget::new(cfg);
+                let root = keyboard_layout.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget {
+                    widget: root,
+                    handle: Box::new(keyboard_layout),
                 })
             }
             "media" => {


### PR DESCRIPTION
Keyboard layout widget that displays the active XKB layout and cycles to the next layout on click. Supports Sway, Hyprland, Niri, and MangoWC/DWL.
<table><tr>
<td><img width="127" height="72" alt="image" src="https://github.com/user-attachments/assets/7c6794eb-aa99-4b5b-9ad9-7834ea27f679" /></td>
<td><img width="203" height="70" alt="image" src="https://github.com/user-attachments/assets/e04bc7e5-1f59-4c44-a905-1b45e02a1199" /></td>
</tr></table>

Add to bar:
```toml
[widgets]
left = ["keyboard_layout"]
```
Config options:
```toml
[widgets.keyboard_layout]
show_icon = true  # Whether to display widget icon
format = "short"  # Display format: "short" (e.g. "US") or "long" (e.g. "English (US)")
```