### PR TITLE
fix(css): move user-facing classes to styled surfaces

### DIFF
--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -229,14 +229,7 @@ fn build_widget_or_group(
 
             // Create a shared island container for the group
             let island = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
-            island.add_css_class(class::WIDGET);
-            island.add_css_class(class::WIDGET_GROUP);
-
-            // Add the first widget's name as a CSS class for per-widget CSS variable targeting
-            // Normalize underscores to hyphens for CSS conventions
-            if let Some(first_entry) = group.first() {
-                island.add_css_class(&first_entry.name.replace('_', "-"));
-            }
+            island.add_css_class(class::WIDGET_WRAPPER);
 
             // Create inner content box (matching BaseWidget structure)
             let content = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
@@ -244,12 +237,24 @@ fn build_widget_or_group(
             content.set_vexpand(true);
             content.set_valign(gtk4::Align::Fill);
 
-            // Visual surface for rounded background (see WIDGET_SURFACE doc).
+            // Visual surface — also carries .widget-group so user CSS
+            // targeting either class hits the background element, not the wrapper.
             let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
-            surface.add_css_class(class::WIDGET_SURFACE);
+            surface.add_css_class(class::WIDGET);
+            surface.add_css_class(class::WIDGET_GROUP);
             surface.set_overflow(gtk4::Overflow::Hidden);
             surface.set_hexpand(true);
             surface.set_vexpand(true);
+
+            // Add the first widget's name as a CSS class for per-widget CSS variable
+            // targeting. Added to both wrapper and surface so theme-generated
+            // selectors like `.widget.cpu` match the surface (which carries
+            // .widget) and user CSS targeting `.cpu` on the wrapper also works.
+            if let Some(first_entry) = group.first() {
+                let css_name = first_entry.name.replace('_', "-");
+                island.add_css_class(&css_name);
+                surface.add_css_class(&css_name);
+            }
 
             surface.append(&content);
             island.append(&surface);
@@ -273,20 +278,36 @@ fn build_widget_or_group(
             let mut count = 0;
 
             // Build entries individually (used for singletons and merge fallback).
-            let build_individually =
-                |entries: &[WidgetEntry], content: &gtk4::Box, state: &mut BarState| -> usize {
-                    let mut n = 0;
-                    for entry in entries {
-                        if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id)
-                        {
-                            built.widget.remove_css_class(class::WIDGET);
-                            content.append(&built.widget);
-                            state.add_handle(built.handle);
-                            n += 1;
+            let build_individually = |entries: &[WidgetEntry],
+                                      content: &gtk4::Box,
+                                      state: &mut BarState|
+             -> usize {
+                let mut n = 0;
+                for entry in entries {
+                    if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id) {
+                        // Group surface owns the background, so strip the
+                        // standalone wrapper class and force the inner .widget
+                        // surface transparent.  .widget is kept for border-radius
+                        // (ripple clipping); a scoped provider at transient
+                        // priority beats user CSS that also targets .widget.
+                        built.widget.remove_css_class(class::WIDGET_WRAPPER);
+                        if let Some(surface) = built.widget.first_child() {
+                            let provider = gtk4::CssProvider::new();
+                            provider.load_from_string(
+                                    ".widget { background-color: transparent; background-image: none; }",
+                                );
+                            #[allow(deprecated)]
+                            surface
+                                .style_context()
+                                .add_provider(&provider, TRANSIENT_CSS_PRIORITY);
                         }
+                        content.append(&built.widget);
+                        state.add_handle(built.handle);
+                        n += 1;
                     }
-                    n
-                };
+                }
+                n
+            };
 
             for (kind, start, end) in &runs {
                 let run_entries = &group[*start..*end];

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -246,13 +246,12 @@ fn build_widget_or_group(
             surface.set_hexpand(true);
             surface.set_vexpand(true);
 
-            // Add the first widget's name as a CSS class for per-widget CSS variable
-            // targeting. Added to both wrapper and surface so theme-generated
-            // selectors like `.widget.cpu` match the surface (which carries
-            // .widget) and user CSS targeting `.cpu` on the wrapper also works.
+            // Add the first widget's name as a CSS class on the surface for
+            // per-widget CSS variable targeting.  Theme-generated selectors
+            // like `.widget.cpu` and user CSS like `.cpu { ... }` both hit
+            // the painted surface — not the transparent wrapper.
             if let Some(first_entry) = group.first() {
                 let css_name = first_entry.name.replace('_', "-");
-                island.add_css_class(&css_name);
                 surface.add_css_class(&css_name);
             }
 

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -449,7 +449,14 @@ popover.widget-menu.background * {{
             let selector = if has_menu_content_class {
                 format!(".{}", surface::WIDGET_MENU_CONTENT)
             } else {
-                css_name.to_string()
+                // Use the widget's first CSS class so the rule only targets
+                // the styled surface, not every descendant GtkBox.
+                let classes = widget.css_classes();
+                if let Some(first) = classes.first() {
+                    format!(".{}", first.as_str())
+                } else {
+                    css_name.to_string()
+                }
             };
 
             // Inner popover panels (.widget-menu-content) don't need shadow -

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -15,7 +15,12 @@
 
 /// Core structural/layout CSS classes.
 pub mod class {
-    /// Base widget container class (`.widget`).
+    /// Outer widget wrapper (`.widget-wrapper`).
+    /// Rectangular hit target so clicks register in rounded corners.
+    pub const WIDGET_WRAPPER: &str = "widget-wrapper";
+
+    /// Widget visual surface (`.widget`).
+    /// Carries background and border-radius; the class users target in custom CSS.
     pub const WIDGET: &str = "widget";
 
     /// Widget item class (`.widget-item`).
@@ -36,12 +41,6 @@ pub mod class {
 
     /// Passive widget marker (`.passive`).
     pub const PASSIVE: &str = "passive";
-
-    /// Widget visual surface class (`.widget-surface`).
-    /// Applied to a GtkBox that carries the widget's background-color and
-    /// border-radius. Separated from `.widget` so the click target remains
-    /// rectangular (Fitts's Law) while the visual appearance is rounded.
-    pub const WIDGET_SURFACE: &str = "widget-surface";
 
     /// Widget content inner box (`.content`).
     pub const CONTENT: &str = "content";

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -3,6 +3,20 @@
 //! This module centralizes all CSS class names used across the codebase,
 //! making them discoverable, avoiding typos, and enabling IDE autocompletion.
 //!
+//! # Naming Convention
+//!
+//! - **`vp-` prefix**: Generic names that collide with GTK4/Adwaita CSS
+//!   classes (e.g., `card` → `vp-card`, `row` → `vp-row`, `primary` → `vp-primary`).
+//! - **No prefix**: Domain-specific names unlikely to collide
+//!   (e.g., `widget`, `clock`, `bar`, `popover`, `notification-toast`).
+//! - **Widget prefix**: Sub-element classes namespaced by widget name
+//!   (e.g., `media-*`, `notification-*`, `qs-*`, `battery-popover-*`).
+//! - **State modifiers**: Short names used only in compound selectors
+//!   (e.g., `.active`, `.expanded`, `.clickable`).
+//!
+//! When adding a new class, check if the name exists in GTK4 or Adwaita
+//! theme CSS. If it does, use the `vp-` prefix.
+//!
 //! # Usage
 //!
 //! ```ignore

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -647,6 +647,9 @@ pub mod surface {
     /// Widget menu popover (`.widget-menu`).
     pub const WIDGET_MENU: &str = "widget-menu";
 
+    /// Outer transparent wrapper around a layer-shell popover (`.widget-menu-wrapper`).
+    pub const WIDGET_MENU_WRAPPER: &str = "widget-menu-wrapper";
+
     /// Widget menu content (`.widget-menu-content`).
     pub const WIDGET_MENU_CONTENT: &str = "widget-menu-content";
 

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -641,16 +641,25 @@ pub mod widget {
 
 /// Surface and popover classes.
 pub mod surface {
-    /// Popover surface style (`.vp-surface-popover`).
-    pub const POPOVER: &str = "vp-surface-popover";
+    /// Layer-shell popover surface (`.popover`). Canonical user-facing class.
+    pub const POPOVER: &str = "popover";
 
-    /// Widget menu popover (`.widget-menu`).
+    /// Outer transparent wrapper around a layer-shell popover (`.popover-wrapper`).
+    pub const POPOVER_WRAPPER: &str = "popover-wrapper";
+
+    /// Deprecated: use [`POPOVER`]. Internal popover surface marker (`.vp-surface-popover`).
+    pub const SURFACE_POPOVER: &str = "vp-surface-popover";
+
+    /// Deprecated: use [`POPOVER`]. Popover styling (`.widget-menu`).
+    ///
+    /// Still applied to native `gtk4::Popover` shells for CSS reset rules
+    /// and to layer-shell surfaces as a deprecated alias.
     pub const WIDGET_MENU: &str = "widget-menu";
 
-    /// Outer transparent wrapper around a layer-shell popover (`.widget-menu-wrapper`).
+    /// Deprecated: use [`POPOVER_WRAPPER`]. Wrapper (`.widget-menu-wrapper`).
     pub const WIDGET_MENU_WRAPPER: &str = "widget-menu-wrapper";
 
-    /// Widget menu content (`.widget-menu-content`).
+    /// Widget menu content (`.widget-menu-content`). Internal.
     pub const WIDGET_MENU_CONTENT: &str = "widget-menu-content";
 
     /// No focus outline container (`.vp-no-focus`).
@@ -784,8 +793,11 @@ pub mod notification {
     pub const ROW_DISMISSING: &str = "notification-row-dismissing";
 
     // Toast
-    /// Toast window (`.notification-toast`).
+    /// Toast surface (`.notification-toast`). User-facing, on the styled container.
     pub const TOAST: &str = "notification-toast";
+
+    /// Toast transparent window (`.notification-toast-wrapper`).
+    pub const TOAST_WRAPPER: &str = "notification-toast-wrapper";
 
     /// Toast container (`.notification-toast-container`).
     pub const TOAST_CONTAINER: &str = "notification-toast-container";
@@ -826,8 +838,11 @@ pub mod notification {
 
 /// On-Screen Display (OSD) classes.
 pub mod osd {
-    /// OSD window (`.osd-window`).
-    pub const WINDOW: &str = "osd-window";
+    /// OSD surface (`.osd`). User-facing, on the styled container.
+    pub const OSD: &str = "osd";
+
+    /// OSD transparent window (`.osd-wrapper`).
+    pub const WRAPPER: &str = "osd-wrapper";
 
     /// OSD widget container (`.osd-widget`).
     pub const WIDGET: &str = "osd-widget";

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -511,8 +511,14 @@ impl BaseWidget {
             container.add_css_class(class::PASSIVE);
         }
         container.set_hexpand(false);
-        for cls in extra_classes {
-            container.add_css_class(cls);
+
+        // Widget-specific classes (e.g. "clock", "battery") are added to the
+        // surface, not the wrapper.  Passive widgets have no surface so they
+        // keep the classes on the container directly.
+        if passive {
+            for cls in extra_classes {
+                container.add_css_class(cls);
+            }
         }
 
         // First extra class is the widget name (e.g., "clock", "battery")
@@ -551,11 +557,10 @@ impl BaseWidget {
         // Must be a GtkBox (not Overlay) — Overlay doesn't clip background to border-radius.
         let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
         surface.add_css_class(class::WIDGET);
-        // Add widget name to the surface so theme-generated selectors like
-        // `.widget.battery` match. The name is already on the wrapper for
-        // user CSS targeting the outer element.
-        if let Some(css_name) = extra_classes.first() {
-            surface.add_css_class(css_name);
+        // Widget-specific classes live on the surface so user CSS like
+        // `.clock { background: ... }` targets the painted element only.
+        for cls in extra_classes {
+            surface.add_css_class(cls);
         }
         surface.set_overflow(gtk4::Overflow::Hidden);
         surface.set_hexpand(true);

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -505,7 +505,7 @@ impl BaseWidget {
 
     fn new_inner(extra_classes: &[&str], passive: bool) -> Self {
         let container = GtkBox::new(Orientation::Horizontal, 0);
-        container.add_css_class(class::WIDGET);
+        container.add_css_class(class::WIDGET_WRAPPER);
         container.add_css_class(class::WIDGET_ITEM);
         if passive {
             container.add_css_class(class::PASSIVE);
@@ -550,15 +550,24 @@ impl BaseWidget {
         // Visual surface: rounded background + overflow clipping.
         // Must be a GtkBox (not Overlay) — Overlay doesn't clip background to border-radius.
         let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
-        surface.add_css_class(class::WIDGET_SURFACE);
+        surface.add_css_class(class::WIDGET);
+        // Add widget name to the surface so theme-generated selectors like
+        // `.widget.battery` match. The name is already on the wrapper for
+        // user CSS targeting the outer element.
+        if let Some(css_name) = extra_classes.first() {
+            surface.add_css_class(css_name);
+        }
         surface.set_overflow(gtk4::Overflow::Hidden);
         surface.set_hexpand(true);
         surface.set_vexpand(true);
 
         // Wrap content in an Overlay so the ripple effect can sit on top
         // without affecting the widget background or content opacity.
+        // overflow:hidden + inherited border-radius clips the ripple to
+        // rounded corners (GtkBox parent overflow alone doesn't suffice).
         let overlay = Overlay::new();
         overlay.set_child(Some(&content));
+        overlay.set_overflow(gtk4::Overflow::Hidden);
         overlay.set_hexpand(true);
         overlay.set_vexpand(true);
 
@@ -877,7 +886,7 @@ impl BaseWidget {
 
     /// Get the root GTK container for this widget.
     ///
-    /// This is the outermost box with the `widget` CSS class.
+    /// This is the outermost box (`.widget-wrapper`).
     /// Most widgets should use `content()` to add children instead.
     pub fn widget(&self) -> &GtkBox {
         &self.container

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -60,21 +60,25 @@ sectioned-bar.bar {{
     color: var(--color-foreground-primary);
 }}
 
-/* Widget - individual widget containers */
-.widget {{
+/* Widget wrapper — transparent so only .widget paints a background layer */
+.widget-wrapper {{
     min-height: var(--widget-height);
+    background: transparent;
 }}
 
-/* Widget visual surface — rounded background, rectangular click target */
-.widget-surface {{
+/* Widget — visual surface */
+.widget {{
     background-color: {widget_bg};
     border-radius: var(--radius-widget);
 }}
 
 /* Padding on .content (not the container) so the ripple overlay
-   fills the entire widget background area edge-to-edge */
+   fills the entire widget background area edge-to-edge.
+   Passive widgets (merge groups) have no .widget surface — target
+   their .content directly via the third selector. */
 .widget:not(.widget-group) .content,
-.widget-group .content > .widget-item .content {{
+.widget-group > .content > .widget-item .content,
+.widget-item.passive > .content {{
     padding: var(--widget-padding-y) 10px;
 }}
 
@@ -83,13 +87,16 @@ sectioned-bar.bar {{
     padding: 0;
 }}
 
-/* Widget hover — :hover on rectangular .widget, visual on rounded .widget-surface */
-.widget.clickable:not(.widget-group):hover > .widget-surface {{
+/* Hover targets the wrapper but paints on the surface child */
+.widget-wrapper.clickable:hover > .widget:not(.widget-group) {{
     background-color: {widget_bg_hover};
 }}
 
-/* Pull non-first items left to overlap adjacent .content padding (2 × 10px) */
-.widget-group .content > .widget-item:not(:first-child) {{
+/* Pull non-first items left to overlap adjacent .content padding (2 × 10px).
+   Merge groups (.widget-merge-group) are also direct children of .content,
+   so they need the same treatment when they follow another item. */
+.widget-group .content > .widget-item:not(:first-child),
+.widget-group .content > .widget-merge-group:not(:first-child) {{
     margin-left: -20px;
 }}
 
@@ -99,16 +106,15 @@ sectioned-bar.bar {{
     border-radius: var(--radius-widget);
 }}
 
-/* Reset nested surface: group already provides background.
-   Keep border-radius: inherit so overflow:hidden still clips the ripple. */
-.widget-group .widget-surface .widget-surface {{
+/* Nested surfaces transparent — theme-priority fallback for grouped active
+   widgets.  The primary suppression is a scoped CSS provider in bar.rs
+   (transient priority), but this catches edge cases at theme priority. */
+.widget.widget-group .widget {{
     background-color: transparent;
     border-radius: inherit;
 }}
 
-/* Widget items inside groups - individual clickable hover targets.
-   Use only the tint overlay (not the full hover color) because the
-   parent .widget-group already provides the base widget background. */
+/* Grouped item hover — tint only (group surface provides base background) */
 .widget-group .content > .widget-item.clickable:hover {{
     background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
 }}
@@ -127,9 +133,7 @@ sectioned-bar.bar {{
     background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
 }}
 
-/* Passive widgets inside a merge group must not show their own
-   hover — the wrapper provides it. Background is already transparent
-   via .widget-group .widget-surface .widget-surface rule. */
+/* Passive items in merge groups don't show their own hover */
 .merge-group-content > .widget-item.passive:hover {{
     background-color: transparent;
 }}

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -258,7 +258,7 @@ popover.widget-menu.background > contents {{
 }}
 
 /* Inherit border-radius so the ripple clips to the rounded shape */
-.widget-surface > overlay,
+.widget > overlay,
 .widget-item overlay {{
     border-radius: inherit;
 }}
@@ -285,7 +285,7 @@ button:hover {{
     {hover_transition}
 }}
 
-.widget-surface {{
+.widget {{
     {hover_transition}
 }}
 

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -131,6 +131,7 @@ label link:active {{
 }}
 
 popover.widget-menu,
+box.popover-wrapper,
 box.widget-menu-wrapper {{
     background: transparent;
     border: none;
@@ -152,6 +153,7 @@ popover.widget-menu.background > contents {{
 /* When GTK's 3 s focus_visible timeout fires, the focused widget keeps :focus
    but loses :focus-visible.  Suppress Adwaita's residual :focus outline so no
    faint ring lingers after keyboard nav times out. */
+.popover *:focus:not(:focus-visible),
 .vp-surface-popover *:focus:not(:focus-visible) {{
     outline: none;
     box-shadow: none;

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -130,7 +130,8 @@ label link:active {{
     color: var(--color-foreground-primary);
 }}
 
-popover.widget-menu {{
+popover.widget-menu,
+box.widget-menu-wrapper {{
     background: transparent;
     border: none;
     box-shadow: none;

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -195,8 +195,8 @@ button.notification-action-btn label {{
 
 /* === Toast-specific === */
 
-window.notification-toast,
-.notification-toast {{
+window.notification-toast-wrapper,
+.notification-toast-wrapper {{
     background: transparent;
 }}
 

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -120,18 +120,26 @@ pub fn css(animations: bool) -> String {
 
 /* === Popover-specific === */
 
-/* Note: padding comes from apply_surface_styles() in base.rs */
+/* Remove right padding from the surface so the overlay scrollbar sits at the
+   popover edge instead of overlapping dismiss buttons. The header and list
+   add their own right padding to keep content inset. */
 .notification-popover {{
+    padding-right: 0;
 }}
 
 .notification-header {{
-    padding: 0 0 8px 0;
+    padding: 0 16px 8px 0;
     margin: 0;
 }}
 
-/* Header icon sizing */
+.notification-header .vp-popover-icon-btn {{
+    margin-top: -4px;
+}}
+
 .notification-header-icon {{
     font-size: calc(var(--icon-size) * 1.15);
+    margin-top: 1px;
+    margin-left: 1px;
 }}
 
 .notification-clear-label {{
@@ -139,7 +147,7 @@ pub fn css(animations: bool) -> String {
 }}
 
 .notification-list {{
-    padding: 8px 0 0 0;
+    padding: 8px 16px 0 0;
 }}
 
 /* Empty state */

--- a/crates/vibepanel/src/widgets/css/osd.rs
+++ b/crates/vibepanel/src/widgets/css/osd.rs
@@ -6,7 +6,7 @@ pub fn css() -> &'static str {
 /* ===== OSD ===== */
 
 /* Window must be transparent so container shows properly */
-.osd-window {
+.osd-wrapper {
     background: transparent;
 }
 

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -688,6 +688,7 @@ impl LayerShellPopover {
 
         let content = (self.builder)();
         content.add_css_class(surface::POPOVER);
+        content.add_css_class(surface::WIDGET_MENU);
         let popover_class = format!("{}-popover", self.widget_name);
         content.add_css_class(&popover_class);
 
@@ -790,6 +791,7 @@ impl LayerShellPopover {
             } else {
                 let fresh = (self.builder)();
                 fresh.add_css_class(surface::POPOVER);
+                fresh.add_css_class(surface::WIDGET_MENU);
                 let popover_class = format!("{}-popover", self.widget_name);
                 fresh.add_css_class(&popover_class);
                 *self.cached_content.borrow_mut() = Some(fresh.clone());
@@ -798,6 +800,7 @@ impl LayerShellPopover {
         } else {
             let fresh = (self.builder)();
             fresh.add_css_class(surface::POPOVER);
+            fresh.add_css_class(surface::WIDGET_MENU);
             let popover_class = format!("{}-popover", self.widget_name);
             fresh.add_css_class(&popover_class);
             fresh
@@ -823,7 +826,7 @@ impl LayerShellPopover {
         // Ensure the outer wrapper is set as the window's child (persists).
         if window.child().is_none() {
             let outer = GtkBox::new(Orientation::Vertical, 0);
-            outer.add_css_class(surface::WIDGET_MENU);
+            outer.add_css_class(surface::WIDGET_MENU_WRAPPER);
             outer.add_css_class(surface::NO_FOCUS);
             SurfaceStyleManager::global().apply_shadow_margins(&outer, POPOVER_SHADOW_MARGIN);
             outer.append(&anim_shell);

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -688,6 +688,7 @@ impl LayerShellPopover {
 
         let content = (self.builder)();
         content.add_css_class(surface::POPOVER);
+        content.add_css_class(surface::SURFACE_POPOVER);
         content.add_css_class(surface::WIDGET_MENU);
         let popover_class = format!("{}-popover", self.widget_name);
         content.add_css_class(&popover_class);
@@ -791,6 +792,7 @@ impl LayerShellPopover {
             } else {
                 let fresh = (self.builder)();
                 fresh.add_css_class(surface::POPOVER);
+                fresh.add_css_class(surface::SURFACE_POPOVER);
                 fresh.add_css_class(surface::WIDGET_MENU);
                 let popover_class = format!("{}-popover", self.widget_name);
                 fresh.add_css_class(&popover_class);
@@ -800,6 +802,7 @@ impl LayerShellPopover {
         } else {
             let fresh = (self.builder)();
             fresh.add_css_class(surface::POPOVER);
+            fresh.add_css_class(surface::SURFACE_POPOVER);
             fresh.add_css_class(surface::WIDGET_MENU);
             let popover_class = format!("{}-popover", self.widget_name);
             fresh.add_css_class(&popover_class);
@@ -826,6 +829,7 @@ impl LayerShellPopover {
         // Ensure the outer wrapper is set as the window's child (persists).
         if window.child().is_none() {
             let outer = GtkBox::new(Orientation::Vertical, 0);
+            outer.add_css_class(surface::POPOVER_WRAPPER);
             outer.add_css_class(surface::WIDGET_MENU_WRAPPER);
             outer.add_css_class(surface::NO_FOCUS);
             SurfaceStyleManager::global().apply_shadow_margins(&outer, POPOVER_SHADOW_MARGIN);

--- a/crates/vibepanel/src/widgets/media_popover.rs
+++ b/crates/vibepanel/src/widgets/media_popover.rs
@@ -167,6 +167,8 @@ fn show_player_menu(parent: &Button) {
 
     // Outer panel for surface styling
     let panel = GtkBox::new(Orientation::Vertical, 0);
+    panel.add_css_class(surface::POPOVER);
+    panel.add_css_class(surface::SURFACE_POPOVER);
     panel.add_css_class(surface::WIDGET_MENU_CONTENT);
     panel.add_css_class(media::PLAYER_MENU);
 

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -62,7 +62,7 @@ impl NotificationToast {
             .default_width(POPOVER_WIDTH)
             .build();
 
-        window.add_css_class(notif::TOAST);
+        window.add_css_class(notif::TOAST_WRAPPER);
 
         // Determine bar position for toast anchoring
         let is_bottom = ConfigManager::global().bar_is_bottom();
@@ -174,6 +174,7 @@ impl NotificationToast {
     ) {
         let outer = GtkBox::new(Orientation::Vertical, 0);
         outer.add_css_class(notif::TOAST_CONTAINER);
+        outer.add_css_class(notif::TOAST);
 
         // Apply surface styling
         SurfaceStyleManager::global().apply_surface_styles(&outer, false);

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -204,7 +204,7 @@ impl OsdOverlay {
             .resizable(false)
             .build();
 
-        window.add_css_class(osd::WINDOW);
+        window.add_css_class(osd::WRAPPER);
 
         // Set up layer shell defaults.
         Self::setup_layer_shell_defaults(&window);
@@ -220,6 +220,7 @@ impl OsdOverlay {
         // Content container with surface styling.
         let container = GtkBox::new(Orientation::Vertical, 0);
         container.add_css_class(osd::CONTAINER);
+        container.add_css_class(osd::OSD);
         if is_vertical {
             container.add_css_class(osd::VERTICAL);
         } else {

--- a/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
@@ -355,6 +355,8 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
         configure_popover(&popover);
 
         let panel = GtkBox::new(Orientation::Vertical, 0);
+        panel.add_css_class(surface::POPOVER);
+        panel.add_css_class(surface::SURFACE_POPOVER);
         panel.add_css_class(surface::WIDGET_MENU_CONTENT);
 
         let content_box = GtkBox::new(Orientation::Vertical, 2);

--- a/crates/vibepanel/src/widgets/quick_settings/network_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/network_card.rs
@@ -1299,6 +1299,8 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
         configure_popover(&popover);
 
         let panel = GtkBox::new(Orientation::Vertical, 0);
+        panel.add_css_class(surface::POPOVER);
+        panel.add_css_class(surface::SURFACE_POPOVER);
         panel.add_css_class(surface::WIDGET_MENU_CONTENT);
 
         let content_box = GtkBox::new(Orientation::Vertical, 2);

--- a/crates/vibepanel/src/widgets/quick_settings/power_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/power_card.rs
@@ -27,7 +27,7 @@ use tracing::{debug, warn};
 use crate::services::compositor::CompositorManager;
 use crate::services::config_manager::ConfigManager;
 use crate::services::icons::{IconHandle, IconsService};
-use crate::styles::{button, card, color, qs, row};
+use crate::styles::{button, card, color, qs, row, surface};
 use crate::widgets::base::configure_popover;
 
 use super::components::{CardLabel, ToggleCard};
@@ -483,6 +483,9 @@ fn show_power_popover(parent: &Button) {
     configure_popover(&popover);
 
     let content = GtkBox::new(Orientation::Vertical, 2);
+    content.add_css_class(surface::POPOVER);
+    content.add_css_class(surface::SURFACE_POPOVER);
+    content.add_css_class(surface::WIDGET_MENU_CONTENT);
     content.add_css_class(qs::ROW_MENU_CONTENT);
     content.set_margin_top(4);
     content.set_margin_bottom(4);

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -227,6 +227,7 @@ impl QuickSettingsWindow {
         // Margin wrapper sits between window and anim_shell, providing
         // transparent padding so the ScaleBox clip animation is visible.
         let margin_wrapper = GtkBox::new(Orientation::Vertical, 0);
+        margin_wrapper.add_css_class(surface::POPOVER_WRAPPER);
         margin_wrapper.add_css_class(surface::WIDGET_MENU_WRAPPER);
         margin_wrapper.add_css_class(surface::NO_FOCUS);
         SurfaceStyleManager::global()
@@ -420,6 +421,7 @@ impl QuickSettingsWindow {
         // Apply surface styles - background now controlled via CSS variables
         outer.add_css_class("quick-settings-popover");
         outer.add_css_class(surface::POPOVER);
+        outer.add_css_class(surface::SURFACE_POPOVER);
         outer.add_css_class(surface::WIDGET_MENU);
         SurfaceStyleManager::global().apply_surface_styles(&outer, true);
 

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -227,7 +227,7 @@ impl QuickSettingsWindow {
         // Margin wrapper sits between window and anim_shell, providing
         // transparent padding so the ScaleBox clip animation is visible.
         let margin_wrapper = GtkBox::new(Orientation::Vertical, 0);
-        margin_wrapper.add_css_class(surface::WIDGET_MENU);
+        margin_wrapper.add_css_class(surface::WIDGET_MENU_WRAPPER);
         margin_wrapper.add_css_class(surface::NO_FOCUS);
         SurfaceStyleManager::global()
             .apply_shadow_margins(&margin_wrapper, QUICK_SETTINGS_OUTER_MARGIN);
@@ -420,6 +420,7 @@ impl QuickSettingsWindow {
         // Apply surface styles - background now controlled via CSS variables
         outer.add_css_class("quick-settings-popover");
         outer.add_css_class(surface::POPOVER);
+        outer.add_css_class(surface::WIDGET_MENU);
         SurfaceStyleManager::global().apply_surface_styles(&outer, true);
 
         let content = GtkBox::new(Orientation::Vertical, 0);

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -51,6 +51,14 @@ mod imp {
     }
 
     impl WidgetImpl for ScaleBox {
+        fn request_mode(&self) -> gtk4::SizeRequestMode {
+            if let Some(child) = self.child.upgrade() {
+                child.request_mode()
+            } else {
+                gtk4::SizeRequestMode::ConstantSize
+            }
+        }
+
         fn measure(&self, orientation: gtk4::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
             if let Some(child) = self.child.upgrade() {
                 child.measure(orientation, for_size)

--- a/crates/vibepanel/src/widgets/tray.rs
+++ b/crates/vibepanel/src/widgets/tray.rs
@@ -797,6 +797,7 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
         let container = GtkBox::new(Orientation::Vertical, 2);
         container.add_css_class(widget::TRAY_MENU);
         container.add_css_class(surface::POPOVER);
+        container.add_css_class(surface::SURFACE_POPOVER);
         container.add_css_class(surface::WIDGET_MENU_CONTENT);
 
         // Add tray-specific popover class for CSS variable-based styling


### PR DESCRIPTION
Fixes CSS class regressions introduced after v0.12.1 where user-facing classes (`.widget`, `.clock`, `.notification-toast`, etc.) ended up on transparent wrappers/windows instead of the painted surfaces.

- Rename `.widget-surface` back to `.widget`, outer click targetbecomes `.widget-wrapper`
- Move widget-specific classes (`.clock`, `.cpu`, etc.) from wrapper to surface so user CSS like `.clock { background: ... }` works again
- Add `.popover` as canonical popover class. Keep `.vp-surface-popover` and `.widget-menu` as deprecated aliases
- Add `.osd` for OSD styling, window becomes `.osd-wrapper`
- Apply the same wrapper/surface split to popovers and toasts

Fixes #90 