### PR TITLE
feat(theme): dynamic theming from wallpaper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,25 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +127,18 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cairo-rs"
@@ -239,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +405,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -535,6 +594,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -825,6 +896,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "material-colors"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e226ffda362d5bc26bb8f730d637a0851eedfb05e35d92108c9d8b48d2e47941"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1050,6 +1157,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1221,6 +1338,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1391,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -1299,7 +1441,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1472,6 +1614,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1787,8 +1935,10 @@ dependencies = [
  "gdk4-wayland",
  "gtk4",
  "gtk4-layer-shell",
+ "image",
  "libc",
  "libpulse-binding",
+ "material-colors",
  "minreq",
  "notify",
  "notify-debouncer-mini",
@@ -1813,6 +1963,7 @@ dependencies = [
 name = "vibepanel-core"
 version = "0.13.0"
 dependencies = [
+ "material-colors",
  "serde",
  "thiserror",
  "toml 0.8.23",
@@ -1835,6 +1986,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2245,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,7 +2429,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,11 +903,22 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1373,6 +1384,12 @@ name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,5 +63,9 @@ parking_lot = "0.12"
 # HTTP
 minreq = { version = "2.14", default-features = false, features = ["https-rustls"] }
 
+# Color extraction
+material-colors = { version = "0.4.2" }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+
 # Internal crates
 vibepanel-core = { path = "crates/vibepanel-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ minreq = { version = "2.14", default-features = false, features = ["https-rustls
 
 # Color extraction
 material-colors = { version = "0.4.2" }
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 # Internal crates
 vibepanel-core = { path = "crates/vibepanel-core" }

--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@
 # =============================================================================
 
 [bar]
-position = "top" # "top" or "bottom"
+position = "top"         # "top" or "bottom"
 size = 32
 border_radius = 30
 background_opacity = 0.0 # 0.0 = transparent (islands), 1.0 = solid
@@ -70,9 +70,8 @@ background_opacity = 1.0
 
 [theme]
 mode = "dark" # "auto", "dark", "light", "gtk"
-               # "auto" = wallpaper-adaptive Material You theming
-               #          (detects from hyprpaper, awww/swww, wpaperd, waypaper)
-               # Multi-monitor: uses wallpaper from first bar.outputs entry, or first monitor if unset
+#               "auto" = wallpaper-adaptive theming
+#               (detects from hyprpaper, awww/swww, wpaperd, waypaper)
 #scheme = "dark"         # Material You polarity: "dark" or "light" (auto mode only)
 #wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect)
 #accent = "#adabe0" # "gtk", "none", or hex color (ignored in auto mode)

--- a/config.toml
+++ b/config.toml
@@ -70,10 +70,11 @@ background_opacity = 1.0
 
 [theme]
 mode = "dark" # "auto", "dark", "light", "gtk"
-               # "auto" = wallpaper-adaptive Material You theming (detects from hyprpaper)
+               # "auto" = wallpaper-adaptive Material You theming
+               #          (detects from hyprpaper, awww/swww, wpaperd, waypaper)
                # Multi-monitor: uses wallpaper from first bar.outputs entry, or first monitor if unset
 #light = false           # Use light Material You scheme in auto mode (default: false/dark)
-#wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect from hyprpaper)
+#wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect)
 #accent = "#adabe0" # "gtk", "none", or hex color (ignored in auto mode)
 #animations = true  # Enable/disable all CSS transitions and animations
 #ripple = true      # Enable/disable Material Design ripple effect on click

--- a/config.toml
+++ b/config.toml
@@ -70,7 +70,11 @@ background_opacity = 1.0
 
 [theme]
 mode = "dark" # "auto", "dark", "light", "gtk"
-#accent = "#adabe0" # "gtk", "none", or hex color
+               # "auto" = wallpaper-adaptive Material You theming (detects from hyprpaper)
+               # Multi-monitor: uses wallpaper from first bar.outputs entry, or first monitor if unset
+#light = false           # Use light Material You scheme in auto mode (default: false/dark)
+#wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect from hyprpaper)
+#accent = "#adabe0" # "gtk", "none", or hex color (ignored in auto mode)
 #animations = true  # Enable/disable all CSS transitions and animations
 #ripple = true      # Enable/disable Material Design ripple effect on click
 

--- a/config.toml
+++ b/config.toml
@@ -73,7 +73,7 @@ mode = "dark" # "auto", "dark", "light", "gtk"
                # "auto" = wallpaper-adaptive Material You theming
                #          (detects from hyprpaper, awww/swww, wpaperd, waypaper)
                # Multi-monitor: uses wallpaper from first bar.outputs entry, or first monitor if unset
-#light = false           # Use light Material You scheme in auto mode (default: false/dark)
+#scheme = "dark"         # Material You polarity: "dark" or "light" (auto mode only)
 #wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect)
 #accent = "#adabe0" # "gtk", "none", or hex color (ignored in auto mode)
 #animations = true  # Enable/disable all CSS transitions and animations

--- a/crates/vibepanel-core/Cargo.toml
+++ b/crates/vibepanel-core/Cargo.toml
@@ -12,3 +12,4 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
+material-colors = { workspace = true }

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -225,6 +225,7 @@ impl Config {
         }
 
         // Validate theme.accent: must be "gtk", "none", or a valid hex color (if specified)
+        // Note: accent is ignored when mode = "auto" (colors derived from wallpaper)
         if let Some(ref accent) = self.theme.accent
             && accent != "gtk"
             && accent != "none"
@@ -997,11 +998,23 @@ impl Default for ThemeIconsConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct ThemeConfig {
     /// Theme mode: "auto", "dark", "light", "gtk".
-    /// - "auto": detects from widget background luminance
+    /// - "auto": wallpaper-adaptive Material You theming (auto-detects from hyprpaper)
     /// - "dark": forces dark mode (light text on dark backgrounds)
     /// - "light": forces light mode (dark text on light backgrounds)
     /// - "gtk": derive colors from GTK theme where possible
     pub mode: String,
+
+    /// Use the light Material You color scheme in auto mode.
+    ///
+    /// Only meaningful when `mode = "auto"`. Default is false (dark scheme).
+    pub light: bool,
+
+    /// Explicit wallpaper image path for auto mode.
+    ///
+    /// Only meaningful when `mode = "auto"`. When set, uses this image instead
+    /// of auto-detecting from hyprpaper. Supports PNG and JPEG.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wallpaper: Option<String>,
 
     /// Accent color configuration: "gtk", "none", or a hex color like "#3584e4".
     /// - "gtk": use the GTK theme's accent color (don't override @accent_color)
@@ -1009,6 +1022,7 @@ pub struct ThemeConfig {
     /// - "#rrggbb": use this specific color as the accent
     ///
     /// When not specified, defaults to "gtk" if mode is "gtk", otherwise "#adabe0".
+    /// Ignored when mode is "auto" (accent is derived from wallpaper).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accent: Option<String>,
 
@@ -1045,7 +1059,10 @@ pub struct ThemeConfig {
 impl Default for ThemeConfig {
     fn default() -> Self {
         Self {
+            // "auto" here; the shipped config.toml overrides to "dark" via deep-merge
             mode: "auto".to_string(),
+            light: false,
+            wallpaper: None,
             accent: None,
             animations: true,
             ripple: true,

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -33,6 +33,21 @@ const VALID_OSD_POSITIONS: &[&str] = &["bottom", "left", "right", "top"];
 /// Embedded default configuration TOML, compiled into the binary.
 pub const DEFAULT_CONFIG_TOML: &str = include_str!("../../../config.toml");
 
+/// Expand a leading `~` to `$HOME` in a path string.
+fn expand_tilde(path: &str) -> String {
+    let home = match env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => return path.to_string(),
+    };
+    if let Some(rest) = path.strip_prefix("~/") {
+        format!("{}/{}", home, rest)
+    } else if path == "~" {
+        home
+    } else {
+        path.to_string()
+    }
+}
+
 /// Result of loading a configuration file.
 #[derive(Debug)]
 pub struct ConfigLoadResult {
@@ -108,7 +123,8 @@ impl Config {
 
         deep_merge_toml(&mut base, user);
 
-        let config: Config = base.try_into()?;
+        let mut config: Config = base.try_into()?;
+        config.normalize_paths();
         Ok(config)
     }
 
@@ -192,6 +208,13 @@ impl Config {
         paths.push(PathBuf::from("config.toml"));
 
         paths
+    }
+
+    /// Expand `~` in config fields that accept file paths.
+    fn normalize_paths(&mut self) {
+        if let Some(ref mut wallpaper) = self.theme.wallpaper {
+            *wallpaper = expand_tilde(wallpaper);
+        }
     }
 
     /// Validate the configuration, returning errors for invalid values.
@@ -2215,6 +2238,60 @@ mod tests {
             !warnings.iter().any(|w| w.contains("show_if_interval")),
             "unexpected warning: {:?}",
             warnings
+        );
+    }
+
+    #[test]
+    fn test_expand_tilde_with_subpath() {
+        let home = env::var("HOME").unwrap();
+        assert_eq!(
+            expand_tilde("~/Pictures/wall.png"),
+            format!("{}/Pictures/wall.png", home)
+        );
+    }
+
+    #[test]
+    fn test_expand_tilde_bare() {
+        let home = env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~"), home);
+    }
+
+    #[test]
+    fn test_expand_tilde_absolute_unchanged() {
+        assert_eq!(expand_tilde("/usr/share/wall.png"), "/usr/share/wall.png");
+    }
+
+    #[test]
+    fn test_expand_tilde_no_slash_unchanged() {
+        assert_eq!(expand_tilde("~foo"), "~foo");
+    }
+
+    #[test]
+    fn test_normalize_wallpaper_tilde() {
+        let toml = r#"
+            [theme]
+            mode = "auto"
+            wallpaper = "~/Pictures/wall.png"
+        "#;
+        let config = Config::load_with_defaults(toml).unwrap();
+        let home = env::var("HOME").unwrap();
+        assert_eq!(
+            config.theme.wallpaper,
+            Some(format!("{}/Pictures/wall.png", home))
+        );
+    }
+
+    #[test]
+    fn test_normalize_wallpaper_absolute_unchanged() {
+        let toml = r#"
+            [theme]
+            mode = "auto"
+            wallpaper = "/home/user/wall.png"
+        "#;
+        let config = Config::load_with_defaults(toml).unwrap();
+        assert_eq!(
+            config.theme.wallpaper,
+            Some("/home/user/wall.png".to_string())
         );
     }
 }

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -33,16 +33,12 @@ const VALID_OSD_POSITIONS: &[&str] = &["bottom", "left", "right", "top"];
 /// Embedded default configuration TOML, compiled into the binary.
 pub const DEFAULT_CONFIG_TOML: &str = include_str!("../../../config.toml");
 
-/// Expand a leading `~` to `$HOME` in a path string.
-fn expand_tilde(path: &str) -> String {
-    let home = match env::var("HOME") {
-        Ok(h) => h,
-        Err(_) => return path.to_string(),
-    };
+/// Expand a leading `~` to `home` in a path string.
+pub fn expand_tilde(path: &str, home: &str) -> String {
     if let Some(rest) = path.strip_prefix("~/") {
         format!("{}/{}", home, rest)
     } else if path == "~" {
-        home
+        home.to_string()
     } else {
         path.to_string()
     }
@@ -212,8 +208,10 @@ impl Config {
 
     /// Expand `~` in config fields that accept file paths.
     fn normalize_paths(&mut self) {
-        if let Some(ref mut wallpaper) = self.theme.wallpaper {
-            *wallpaper = expand_tilde(wallpaper);
+        if let Some(ref mut wallpaper) = self.theme.wallpaper
+            && let Ok(home) = env::var("HOME")
+        {
+            *wallpaper = expand_tilde(wallpaper, &home);
         }
     }
 
@@ -2243,27 +2241,28 @@ mod tests {
 
     #[test]
     fn test_expand_tilde_with_subpath() {
-        let home = env::var("HOME").unwrap();
         assert_eq!(
-            expand_tilde("~/Pictures/wall.png"),
-            format!("{}/Pictures/wall.png", home)
+            expand_tilde("~/Pictures/wall.png", "/home/user"),
+            "/home/user/Pictures/wall.png"
         );
     }
 
     #[test]
     fn test_expand_tilde_bare() {
-        let home = env::var("HOME").unwrap();
-        assert_eq!(expand_tilde("~"), home);
+        assert_eq!(expand_tilde("~", "/home/user"), "/home/user");
     }
 
     #[test]
     fn test_expand_tilde_absolute_unchanged() {
-        assert_eq!(expand_tilde("/usr/share/wall.png"), "/usr/share/wall.png");
+        assert_eq!(
+            expand_tilde("/usr/share/wall.png", "/home/user"),
+            "/usr/share/wall.png"
+        );
     }
 
     #[test]
     fn test_expand_tilde_no_slash_unchanged() {
-        assert_eq!(expand_tilde("~foo"), "~foo");
+        assert_eq!(expand_tilde("~foo", "/home/user"), "~foo");
     }
 
     #[test]

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -332,6 +332,17 @@ impl Config {
             }
         }
 
+        // Warn about auto-mode-only fields set when mode != "auto"
+        if self.theme.mode != "auto" {
+            if self.theme.light {
+                warnings.push("theme.light: has no effect when mode is not \"auto\"".to_string());
+            }
+            if self.theme.wallpaper.is_some() {
+                warnings
+                    .push("theme.wallpaper: has no effect when mode is not \"auto\"".to_string());
+            }
+        }
+
         warnings
     }
 
@@ -998,7 +1009,8 @@ impl Default for ThemeIconsConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct ThemeConfig {
     /// Theme mode: "auto", "dark", "light", "gtk".
-    /// - "auto": wallpaper-adaptive Material You theming (auto-detects from hyprpaper)
+    /// - "auto": wallpaper-adaptive Material You theming
+    ///   (detects from hyprpaper, awww/swww, wpaperd, or waypaper)
     /// - "dark": forces dark mode (light text on dark backgrounds)
     /// - "light": forces light mode (dark text on light backgrounds)
     /// - "gtk": derive colors from GTK theme where possible
@@ -1012,7 +1024,7 @@ pub struct ThemeConfig {
     /// Explicit wallpaper image path for auto mode.
     ///
     /// Only meaningful when `mode = "auto"`. When set, uses this image instead
-    /// of auto-detecting from hyprpaper. Supports PNG and JPEG.
+    /// of auto-detecting from wallpaper daemons. Supports PNG and JPEG.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wallpaper: Option<String>,
 

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -21,6 +21,9 @@ const VALID_COMPOSITORS: &[&str] = &[
 /// Known valid values for theme.mode.
 const VALID_THEME_MODES: &[&str] = &["auto", "dark", "light", "gtk"];
 
+/// Known valid values for theme.scheme.
+const VALID_THEME_SCHEMES: &[&str] = &["dark", "light"];
+
 /// Known valid values for bar.position.
 const VALID_BAR_POSITIONS: &[&str] = &["top", "bottom"];
 
@@ -224,6 +227,15 @@ impl Config {
             ));
         }
 
+        // Validate theme.scheme
+        if !VALID_THEME_SCHEMES.contains(&self.theme.scheme.as_str()) {
+            errors.push(format!(
+                "theme.scheme: invalid value '{}', expected one of: {}",
+                self.theme.scheme,
+                VALID_THEME_SCHEMES.join(", ")
+            ));
+        }
+
         // Validate theme.accent: must be "gtk", "none", or a valid hex color (if specified)
         // Note: accent is ignored when mode = "auto" (colors derived from wallpaper)
         if let Some(ref accent) = self.theme.accent
@@ -334,8 +346,8 @@ impl Config {
 
         // Warn about auto-mode-only fields set when mode != "auto"
         if self.theme.mode != "auto" {
-            if self.theme.light {
-                warnings.push("theme.light: has no effect when mode is not \"auto\"".to_string());
+            if self.theme.scheme != "dark" {
+                warnings.push("theme.scheme: has no effect when mode is not \"auto\"".to_string());
             }
             if self.theme.wallpaper.is_some() {
                 warnings
@@ -1016,10 +1028,10 @@ pub struct ThemeConfig {
     /// - "gtk": derive colors from GTK theme where possible
     pub mode: String,
 
-    /// Use the light Material You color scheme in auto mode.
+    /// Material You color scheme polarity: "dark" or "light".
     ///
-    /// Only meaningful when `mode = "auto"`. Default is false (dark scheme).
-    pub light: bool,
+    /// Only meaningful when `mode = "auto"`. Default is "dark".
+    pub scheme: String,
 
     /// Explicit wallpaper image path for auto mode.
     ///
@@ -1073,7 +1085,7 @@ impl Default for ThemeConfig {
         Self {
             // "auto" here; the shipped config.toml overrides to "dark" via deep-merge
             mode: "auto".to_string(),
-            light: false,
+            scheme: "dark".to_string(),
             wallpaper: None,
             accent: None,
             animations: true,

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -355,6 +355,13 @@ impl Config {
             }
         }
 
+        // Warn if explicit wallpaper path doesn't exist
+        if let Some(ref wallpaper) = self.theme.wallpaper
+            && !std::path::Path::new(wallpaper).exists()
+        {
+            warnings.push(format!("theme.wallpaper: file '{}' not found", wallpaper));
+        }
+
         warnings
     }
 

--- a/crates/vibepanel-core/src/lib.rs
+++ b/crates/vibepanel-core/src/lib.rs
@@ -11,6 +11,6 @@ pub mod error;
 pub mod logging;
 pub mod theme;
 
-pub use config::{Config, ConfigLoadResult, DEFAULT_CONFIG_TOML};
+pub use config::{Config, ConfigLoadResult, DEFAULT_CONFIG_TOML, expand_tilde};
 pub use error::{Error, Result};
 pub use theme::{AccentSource, SurfaceStyles, ThemePalette, ThemeSizes, parse_hex_color};

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -690,22 +690,22 @@ impl ThemePalette {
         // since it sets backgrounds, foregrounds, accent, and state colors directly.
         if config.theme.mode == "auto" {
             if let Some(theme) = material_theme {
-                // Pick light or dark scheme based on the `light` config field
-                let scheme = if config.theme.light {
+                let is_light = config.theme.scheme == "light";
+                let scheme = if is_light {
                     &theme.schemes.light
                 } else {
                     &theme.schemes.dark
                 };
-                self.is_dark_mode = !config.theme.light;
+                self.is_dark_mode = !is_light;
                 self.is_wallpaper_mode = true;
 
                 // Set defaults before apply_wallpaper_theme (which may override backgrounds)
-                self.bar_background = if config.theme.light {
+                self.bar_background = if is_light {
                     DEFAULT_BAR_BG_LIGHT.to_string()
                 } else {
                     DEFAULT_BAR_BG_DARK.to_string()
                 };
-                self.widget_background = if config.theme.light {
+                self.widget_background = if is_light {
                     DEFAULT_WIDGET_BG_LIGHT.to_string()
                 } else {
                     DEFAULT_WIDGET_BG_DARK.to_string()

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -3,6 +3,10 @@
 //! `ThemePalette` is the single source of truth for all theme-related values.
 //! It parses config, computes derived values, and generates CSS variables.
 
+use material_colors::color::Argb;
+use material_colors::scheme::Scheme;
+use tracing::warn;
+
 use crate::Config;
 
 // Overlay opacities: base values for card backgrounds.
@@ -160,6 +164,47 @@ pub fn rgba_str(r: u8, g: u8, b: u8, a: f64) -> String {
     format!("rgba({}, {}, {}, {:.2})", r, g, b, a)
 }
 
+/// Format layered shadow CSS values (tight + diffuse) for a given color and opacity.
+///
+/// Returns `(shadow_soft, shadow_strong)` using the shared shadow geometry constants.
+fn format_shadows(r: u8, g: u8, b: u8, shadow_opacity: f64) -> (String, String) {
+    let tight_opacity = shadow_opacity * SHADOW_TIGHT_OPACITY_FACTOR;
+    let diffuse_opacity = shadow_opacity * SHADOW_DIFFUSE_OPACITY_FACTOR;
+
+    let soft = format!(
+        "0 {}px {}px rgba({}, {}, {}, {:.2}), 0 {}px {}px rgba({}, {}, {}, {:.2})",
+        SHADOW_TIGHT_OFFSET_Y,
+        SHADOW_TIGHT_BLUR,
+        r,
+        g,
+        b,
+        tight_opacity,
+        SHADOW_DIFFUSE_OFFSET_Y,
+        SHADOW_DIFFUSE_BLUR_SOFT,
+        r,
+        g,
+        b,
+        diffuse_opacity
+    );
+    let strong = format!(
+        "0 {}px {}px rgba({}, {}, {}, {:.2}), 0 {}px {}px rgba({}, {}, {}, {:.2})",
+        SHADOW_TIGHT_OFFSET_Y,
+        SHADOW_TIGHT_BLUR,
+        r,
+        g,
+        b,
+        tight_opacity,
+        SHADOW_DIFFUSE_OFFSET_Y,
+        SHADOW_DIFFUSE_BLUR_STRONG,
+        r,
+        g,
+        b,
+        diffuse_opacity
+    );
+
+    (soft, strong)
+}
+
 /// Build a `color-mix()` expression that blends `@window_fg_color` at the given
 /// percentage with `transparent`.  Used throughout GTK mode to derive
 /// foreground-based colors that adapt to the active GTK theme at runtime.
@@ -218,13 +263,15 @@ pub struct SurfaceStyles {
 
 /// Single source of truth for all theme values.
 ///
-/// Constructed via `ThemePalette::from_config(&config)`.
+/// Constructed via `ThemePalette::from_config(&config, None)`.
 #[derive(Debug, Clone)]
 pub struct ThemePalette {
     // Mode
     pub is_dark_mode: bool,
     /// Whether mode is "gtk" (derive colors from GTK theme).
     pub is_gtk_mode: bool,
+    /// Whether wallpaper-adaptive theming is active (full Material You scheme).
+    pub is_wallpaper_mode: bool,
 
     // Background colors
     pub bar_background: String,
@@ -299,11 +346,31 @@ pub struct ThemePalette {
     bar_is_bottom: bool,
 }
 
+/// Convert a material-colors `Argb` value to a CSS hex color string.
+fn argb_to_hex(argb: &Argb) -> String {
+    format!("#{:02x}{:02x}{:02x}", argb.red, argb.green, argb.blue)
+}
+
+/// Convert a material-colors `Argb` value to an rgba string at the given opacity.
+fn argb_to_rgba(argb: &Argb, alpha: f64) -> String {
+    format!(
+        "rgba({}, {}, {}, {:.2})",
+        argb.red, argb.green, argb.blue, alpha
+    )
+}
+
 impl ThemePalette {
     /// Create a ThemePalette from configuration.
-    pub fn from_config(config: &Config) -> Self {
+    ///
+    /// When `mode = "auto"`, pass the pre-extracted Material You theme from
+    /// the wallpaper. The caller (app crate) handles wallpaper detection and
+    /// image processing; core stays I/O-free.
+    pub fn from_config(
+        config: &Config,
+        material_theme: Option<&material_colors::theme::Theme>,
+    ) -> Self {
         let mut palette = Self::default();
-        palette.parse_config(config);
+        palette.parse_config(config, material_theme);
         palette.compute_derived_values();
         palette
     }
@@ -602,99 +669,141 @@ impl ThemePalette {
         css
     }
 
-    fn parse_config(&mut self, config: &Config) {
+    fn parse_config(
+        &mut self,
+        config: &Config,
+        material_theme: Option<&material_colors::theme::Theme>,
+    ) {
         // Check if GTK mode is requested
         self.is_gtk_mode = config.theme.mode == "gtk";
 
-        // Determine which default backgrounds to use based on explicit mode
-        // For "gtk" mode, we reference GTK CSS variables instead of hardcoded colors
-        let (default_bar_bg, default_widget_bg) = if self.is_gtk_mode {
-            // Reference GTK theme's colors - these will be resolved by GTK at runtime
-            ("@window_bg_color".to_string(), "@view_bg_color".to_string())
-        } else if config.theme.mode == "light" {
-            (
-                DEFAULT_BAR_BG_LIGHT.to_string(),
-                DEFAULT_WIDGET_BG_LIGHT.to_string(),
-            )
-        } else {
-            (
-                DEFAULT_BAR_BG_DARK.to_string(),
-                DEFAULT_WIDGET_BG_DARK.to_string(),
-            )
-        };
-
-        // Bar background - user can override with explicit color in bar.background_color
-        self.bar_background = config
-            .bar
-            .background_color
-            .clone()
-            .unwrap_or(default_bar_bg);
-
-        // Widget background - user can override with explicit color in widgets.background_color
-        self.widget_background = config
-            .widgets
-            .background_color
-            .clone()
-            .unwrap_or(default_widget_bg);
-
-        // Opacities from bar/widgets config
+        // Common setup — these are the same in every mode
         self.bar_opacity = config.bar.background_opacity;
         self.widget_opacity = config.widgets.background_opacity;
         self.popover_opacity = config.widgets.popover_background_opacity;
-
-        // Shadows config
         self.shadows_enabled = config.theme.shadows;
-
-        // Resolve is_dark_mode
-        // For GTK mode, we assume dark for overlay calculations since we can't query GTK's actual colors at build time
-        self.is_dark_mode = match config.theme.mode.as_str() {
-            "dark" => true,
-            "light" => false,
-            "gtk" => true, // Default to dark for overlays/borders; GTK handles actual background colors
-            _ => is_dark_color(&self.widget_background), // "auto"
-        };
-
-        // Parse accent configuration from the single `theme.accent` field.
-        // Smart default: if mode is "gtk" and accent is not specified, default to "gtk".
-        let accent_str = config.theme.accent.as_deref().unwrap_or_else(|| {
-            if config.theme.mode == "gtk" {
-                "gtk"
-            } else {
-                "#adabe0"
-            }
-        });
-        self.accent_source = match accent_str {
-            "gtk" => AccentSource::Gtk,
-            "none" => AccentSource::None,
-            color => AccentSource::Custom(color.to_string()),
-        };
-
-        // Set accent colors based on source
-        match &self.accent_source {
-            AccentSource::Custom(color) => {
-                self.accent_primary = color.clone();
-            }
-            AccentSource::None => {
-                // Monochrome mode - use mode-appropriate colors
-                if self.is_gtk_mode {
-                    self.accent_primary = gtk_fg_mix(25.0);
-                } else if self.is_dark_mode {
-                    self.accent_primary = "rgba(255, 255, 255, 0.25)".to_string();
-                } else {
-                    self.accent_primary = "rgba(0, 0, 0, 0.20)".to_string();
-                }
-            }
-            AccentSource::Gtk => {
-                // For GTK accent, we'll reference @accent_color in CSS.
-                // Store a fallback value here for any code that reads accent_primary directly.
-                self.accent_primary = "@accent_color".to_string();
-            }
-        }
-
-        // State colors
         self.state_success = config.theme.states.success.clone();
         self.state_warning = config.theme.states.warning.clone();
         self.state_urgent = config.theme.states.urgent.clone();
+
+        // Handle auto mode (wallpaper-adaptive Material You theming) first,
+        // since it sets backgrounds, foregrounds, accent, and state colors directly.
+        if config.theme.mode == "auto" {
+            if let Some(theme) = material_theme {
+                // Pick light or dark scheme based on the `light` config field
+                let scheme = if config.theme.light {
+                    &theme.schemes.light
+                } else {
+                    &theme.schemes.dark
+                };
+                self.is_dark_mode = !config.theme.light;
+                self.is_wallpaper_mode = true;
+
+                // Set defaults before apply_wallpaper_theme (which may override backgrounds)
+                self.bar_background = if config.theme.light {
+                    DEFAULT_BAR_BG_LIGHT.to_string()
+                } else {
+                    DEFAULT_BAR_BG_DARK.to_string()
+                };
+                self.widget_background = if config.theme.light {
+                    DEFAULT_WIDGET_BG_LIGHT.to_string()
+                } else {
+                    DEFAULT_WIDGET_BG_DARK.to_string()
+                };
+
+                // Apply full Material You palette
+                self.apply_wallpaper_theme(scheme, config);
+            } else {
+                warn!("Auto mode: no wallpaper theme provided, falling back to dark defaults");
+                self.is_dark_mode = true;
+                self.bar_background = config
+                    .bar
+                    .background_color
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_BAR_BG_DARK.to_string());
+                self.widget_background = config
+                    .widgets
+                    .background_color
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_WIDGET_BG_DARK.to_string());
+
+                self.accent_source = AccentSource::Custom("#adabe0".to_string());
+                self.accent_primary = "#adabe0".to_string();
+            }
+        } else {
+            // Non-auto modes: dark, light, gtk
+
+            // Determine which default backgrounds to use based on explicit mode
+            // For "gtk" mode, we reference GTK CSS variables instead of hardcoded colors
+            let (default_bar_bg, default_widget_bg) = if self.is_gtk_mode {
+                ("@window_bg_color".to_string(), "@view_bg_color".to_string())
+            } else if config.theme.mode == "light" {
+                (
+                    DEFAULT_BAR_BG_LIGHT.to_string(),
+                    DEFAULT_WIDGET_BG_LIGHT.to_string(),
+                )
+            } else {
+                (
+                    DEFAULT_BAR_BG_DARK.to_string(),
+                    DEFAULT_WIDGET_BG_DARK.to_string(),
+                )
+            };
+
+            self.bar_background = config
+                .bar
+                .background_color
+                .clone()
+                .unwrap_or(default_bar_bg);
+
+            self.widget_background = config
+                .widgets
+                .background_color
+                .clone()
+                .unwrap_or(default_widget_bg);
+
+            // Resolve is_dark_mode
+            // For GTK mode, we assume dark for overlay calculations since we can't query GTK's actual colors at build time
+            self.is_dark_mode = match config.theme.mode.as_str() {
+                "light" => false,
+                "gtk" => true, // Default to dark for overlays/borders; GTK handles actual background colors
+                _ => true,     // "dark" and any unknown mode
+            };
+
+            // Parse accent configuration from the `theme.accent` field.
+            // Smart default: if mode is "gtk" and accent is not specified, default to "gtk".
+            let accent_str = config.theme.accent.as_deref().unwrap_or_else(|| {
+                if config.theme.mode == "gtk" {
+                    "gtk"
+                } else {
+                    "#adabe0"
+                }
+            });
+            self.accent_source = match accent_str {
+                "gtk" => AccentSource::Gtk,
+                "none" => AccentSource::None,
+                color => AccentSource::Custom(color.to_string()),
+            };
+
+            // Set accent colors based on source
+            match &self.accent_source {
+                AccentSource::Custom(color) => {
+                    self.accent_primary = color.clone();
+                }
+                AccentSource::None => {
+                    // Monochrome mode - use mode-appropriate colors
+                    if self.is_gtk_mode {
+                        self.accent_primary = gtk_fg_mix(25.0);
+                    } else if self.is_dark_mode {
+                        self.accent_primary = "rgba(255, 255, 255, 0.25)".to_string();
+                    } else {
+                        self.accent_primary = "rgba(0, 0, 0, 0.20)".to_string();
+                    }
+                }
+                AccentSource::Gtk => {
+                    self.accent_primary = "@accent_color".to_string();
+                }
+            }
+        }
 
         // Typography - use "inherit" for empty font_family to use system font
         self.font_family = if config.theme.typography.font_family.is_empty() {
@@ -714,12 +823,16 @@ impl ThemePalette {
     }
 
     fn compute_derived_values(&mut self) {
-        self.compute_foreground_colors();
-        self.compute_accent_derived();
-        self.compute_overlays();
-        self.compute_borders_and_shadows();
-        self.compute_slider_tracks();
-        self.compute_critical_backgrounds();
+        if !self.is_wallpaper_mode {
+            // Normal mode: compute all derived color values from config inputs.
+            // In wallpaper mode, apply_wallpaper_theme() already set all colors directly.
+            self.compute_foreground_colors();
+            self.compute_accent_derived();
+            self.compute_overlays();
+            self.compute_borders_and_shadows();
+            self.compute_slider_tracks();
+            self.compute_critical_backgrounds();
+        }
         self.compute_sizes();
     }
 
@@ -866,28 +979,7 @@ impl ThemePalette {
             SHADOW_OPACITY_LIGHT
         };
 
-        let tight_opacity = shadow_opacity * SHADOW_TIGHT_OPACITY_FACTOR;
-        let diffuse_opacity = shadow_opacity * SHADOW_DIFFUSE_OPACITY_FACTOR;
-
-        self.shadow_soft = format!(
-            "0 {}px {}px rgba(0, 0, 0, {:.2}), 0 {}px {}px rgba(0, 0, 0, {:.2})",
-            SHADOW_TIGHT_OFFSET_Y,
-            SHADOW_TIGHT_BLUR,
-            tight_opacity,
-            SHADOW_DIFFUSE_OFFSET_Y,
-            SHADOW_DIFFUSE_BLUR_SOFT,
-            diffuse_opacity
-        );
-
-        self.shadow_strong = format!(
-            "0 {}px {}px rgba(0, 0, 0, {:.2}), 0 {}px {}px rgba(0, 0, 0, {:.2})",
-            SHADOW_TIGHT_OFFSET_Y,
-            SHADOW_TIGHT_BLUR,
-            tight_opacity,
-            SHADOW_DIFFUSE_OFFSET_Y,
-            SHADOW_DIFFUSE_BLUR_STRONG,
-            diffuse_opacity
-        );
+        (self.shadow_soft, self.shadow_strong) = format_shadows(0, 0, 0, shadow_opacity);
     }
 
     fn compute_slider_tracks(&mut self) {
@@ -938,6 +1030,96 @@ impl ThemePalette {
             match blend_colors(&self.state_urgent, base, TOAST_CRITICAL_URGENT_WEIGHT) {
                 Some((r, g, b)) => rgba_str(r, g, b, 0.95),
                 None => "rgba(40, 20, 20, 0.95)".to_string(),
+            };
+    }
+
+    /// Apply a full Material You color scheme from a wallpaper-extracted theme.
+    ///
+    /// This sets all color fields on the palette directly from the Material You scheme,
+    /// bypassing the normal `compute_*` methods for colors. Non-color fields (opacities,
+    /// radii, sizes, font, shadows_enabled) are left untouched.
+    ///
+    /// If the user explicitly set `bar.background_color` or `widgets.background_color`
+    /// in their config, those values are preserved (not overridden by the Material You palette).
+    fn apply_wallpaper_theme(&mut self, scheme: &Scheme, config: &Config) {
+        // Backgrounds — only override if user didn't explicitly set them
+        if config.bar.background_color.is_none() {
+            self.bar_background = argb_to_hex(&scheme.surface_container);
+        }
+        if config.widgets.background_color.is_none() {
+            self.widget_background = argb_to_hex(&scheme.surface_container_low);
+        }
+
+        // Foregrounds
+        self.foreground_primary = argb_to_hex(&scheme.on_surface);
+        self.foreground_muted = argb_to_hex(&scheme.on_surface_variant);
+        self.foreground_disabled = argb_to_rgba(&scheme.on_surface, FOREGROUND_DISABLED_OPACITY);
+        self.foreground_faint = argb_to_rgba(&scheme.on_surface, FOREGROUND_FAINT_OPACITY);
+
+        // Accent
+        self.accent_source = AccentSource::Custom(argb_to_hex(&scheme.primary));
+        self.accent_primary = argb_to_hex(&scheme.primary);
+        self.accent_subtle = argb_to_rgba(&scheme.primary, 0.20);
+        self.accent_text = argb_to_hex(&scheme.on_primary);
+        self.accent_hover_bg = argb_to_hex(&scheme.primary_container);
+
+        // State colors: only override urgent (error), keep success/warning as user-configured
+        self.state_urgent = argb_to_hex(&scheme.error);
+
+        // Overlays — use surface_tint at varying opacities
+        let base_opacity = if self.is_dark_mode {
+            OVERLAY_OPACITY_DARK
+        } else {
+            OVERLAY_OPACITY_LIGHT
+        };
+        self.card_overlay = argb_to_rgba(&scheme.surface_tint, base_opacity);
+        self.card_overlay_hover =
+            argb_to_rgba(&scheme.surface_tint, base_opacity * HOVER_MULTIPLIER);
+        self.card_overlay_subtle =
+            argb_to_rgba(&scheme.surface_tint, base_opacity * SUBTLE_MULTIPLIER);
+        self.card_overlay_strong =
+            argb_to_rgba(&scheme.surface_tint, base_opacity * ACTIVE_MULTIPLIER);
+        self.click_catcher_overlay = rgba_str(128, 128, 128, CLICK_CATCHER_OPACITY);
+
+        // Borders
+        self.border_subtle = argb_to_hex(&scheme.outline_variant);
+
+        // Shadows — use the scheme's shadow color with existing shadow structure
+        let shadow_opacity = if self.is_dark_mode {
+            SHADOW_OPACITY_DARK
+        } else {
+            SHADOW_OPACITY_LIGHT
+        };
+
+        if self.shadows_enabled {
+            (self.shadow_soft, self.shadow_strong) = format_shadows(
+                scheme.shadow.red,
+                scheme.shadow.green,
+                scheme.shadow.blue,
+                shadow_opacity,
+            );
+        } else {
+            self.shadow_soft = "none".to_string();
+            self.shadow_strong = "none".to_string();
+        }
+
+        // Slider tracks
+        self.slider_track = argb_to_hex(&scheme.surface_container_highest);
+        self.slider_track_disabled = argb_to_rgba(&scheme.surface_container_highest, 0.6);
+
+        // Critical backgrounds
+        let error_hex = argb_to_hex(&scheme.error);
+        let widget_bg_hex = argb_to_hex(&scheme.surface_container_low);
+        self.row_critical_background = match blend_colors(&error_hex, &widget_bg_hex, 0.18) {
+            Some((r, g, b)) => rgba_str(r, g, b, 0.95),
+            None => argb_to_hex(&scheme.error_container),
+        };
+
+        let surface_hex = argb_to_hex(&scheme.surface);
+        self.toast_critical_background =
+            match blend_colors(&error_hex, &surface_hex, TOAST_CRITICAL_URGENT_WEIGHT) {
+                Some((r, g, b)) => rgba_str(r, g, b, 0.95),
+                None => argb_to_hex(&scheme.error_container),
             };
     }
 
@@ -997,6 +1179,7 @@ impl Default for ThemePalette {
         Self {
             is_dark_mode: true,
             is_gtk_mode: false,
+            is_wallpaper_mode: false,
             bar_background: DEFAULT_BAR_BG_DARK.to_string(),
             widget_background: DEFAULT_WIDGET_BG_DARK.to_string(),
             foreground_primary: "#ffffff".to_string(),
@@ -1104,8 +1287,9 @@ mod tests {
 
     #[test]
     fn test_theme_palette_default_is_dark() {
-        let config = Config::default();
-        let palette = ThemePalette::from_config(&config);
+        let mut config = Config::default();
+        config.theme.mode = "dark".to_string();
+        let palette = ThemePalette::from_config(&config, None);
         assert!(palette.is_dark_mode);
     }
 
@@ -1113,7 +1297,7 @@ mod tests {
     fn test_theme_palette_light_mode() {
         let mut config = Config::default();
         config.theme.mode = "light".to_string();
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
         assert!(!palette.is_dark_mode);
         assert_eq!(palette.foreground_primary, "#1a1a1a");
     }
@@ -1121,7 +1305,7 @@ mod tests {
     #[test]
     fn test_theme_palette_css_vars_contains_expected_vars() {
         let config = Config::default();
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
         let css = palette.css_vars_block();
 
         assert!(css.contains("--color-background-bar:"));
@@ -1208,7 +1392,7 @@ mod tests {
         let mut config = Config::default();
         config.bar.size = 48;
         // bar_height is the content height (bar.size), CSS padding adds the visual padding
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.sizes.bar_height, 48);
         assert!(palette.sizes.widget_height > 0);
@@ -1217,9 +1401,10 @@ mod tests {
 
     #[test]
     fn test_accent_default_is_custom() {
-        // Default accent = None with mode = "auto" means use "#adabe0" as custom hex color
-        let config = Config::default();
-        let palette = ThemePalette::from_config(&config);
+        // Default accent = None with mode = "dark" means use "#adabe0" as custom hex color
+        let mut config = Config::default();
+        config.theme.mode = "dark".to_string();
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1234,7 +1419,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         // accent remains None
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.accent_source, AccentSource::Gtk);
         // Verify derived values for GTK accent in GTK mode
@@ -1257,9 +1442,10 @@ mod tests {
     fn test_accent_custom_color() {
         // When accent is a hex color, use it as custom accent
         let mut config = Config::default();
+        config.theme.mode = "dark".to_string();
         config.theme.accent = Some("#ff0000".to_string());
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1275,9 +1461,10 @@ mod tests {
     fn test_accent_none_monochrome() {
         // When accent = "none", use monochrome mode
         let mut config = Config::default();
+        config.theme.mode = "dark".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         // In dark mode, monochrome uses white-based colors
@@ -1291,7 +1478,7 @@ mod tests {
         config.theme.mode = "light".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         // In light mode, monochrome uses black-based colors
@@ -1304,7 +1491,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert!(palette.is_gtk_mode);
         // is_dark_mode remains true as a fallback for shadow opacity etc.
@@ -1316,7 +1503,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.foreground_primary, "@window_fg_color");
         // Verify exact computed value to catch arithmetic bugs
@@ -1341,7 +1528,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
         let css = palette.css_vars_block();
 
         // Foreground should reference GTK theme color
@@ -1368,7 +1555,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         // Borders
         assert!(
@@ -1431,7 +1618,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         assert!(
@@ -1451,13 +1638,13 @@ mod tests {
         // Verify that dark/light modes still use hardcoded colors (no regression)
         let mut dark_config = Config::default();
         dark_config.theme.mode = "dark".to_string();
-        let dark = ThemePalette::from_config(&dark_config);
+        let dark = ThemePalette::from_config(&dark_config, None);
         assert_eq!(dark.foreground_primary, "#ffffff");
         assert!(!dark.foreground_muted.contains("@window_fg_color"));
 
         let mut light_config = Config::default();
         light_config.theme.mode = "light".to_string();
-        let light = ThemePalette::from_config(&light_config);
+        let light = ThemePalette::from_config(&light_config, None);
         assert_eq!(light.foreground_primary, "#1a1a1a");
         assert!(!light.foreground_muted.contains("@window_fg_color"));
     }
@@ -1470,7 +1657,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.shadows = false;
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert!(
             palette.border_subtle.contains("@window_fg_color"),
@@ -1489,7 +1676,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.accent = Some("#ff0000".to_string());
 
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1509,11 +1696,11 @@ mod tests {
         // Test that sizes scale up proportionally with bar size
         let mut config_small = Config::default();
         config_small.bar.size = 24;
-        let palette_small = ThemePalette::from_config(&config_small);
+        let palette_small = ThemePalette::from_config(&config_small, None);
 
         let mut config_large = Config::default();
         config_large.bar.size = 48;
-        let palette_large = ThemePalette::from_config(&config_large);
+        let palette_large = ThemePalette::from_config(&config_large, None);
 
         // Larger bar should have proportionally larger sizes
         assert!(palette_large.sizes.widget_height > palette_small.sizes.widget_height);
@@ -1529,7 +1716,7 @@ mod tests {
         for bar_size in [36, 48, 60, 72] {
             let mut config = Config::default();
             config.bar.size = bar_size;
-            let palette = ThemePalette::from_config(&config);
+            let palette = ThemePalette::from_config(&config, None);
 
             // widget_height + 2*padding + 2*margin = widget_height + 4*widget_padding_y
             let total_widget_footprint =
@@ -1551,7 +1738,7 @@ mod tests {
         // Even with small bar, sizes should have sensible minimums
         let mut config = Config::default();
         config.bar.size = 16; // Very small bar
-        let palette = ThemePalette::from_config(&config);
+        let palette = ThemePalette::from_config(&config, None);
 
         assert!(
             palette.sizes.widget_padding_y >= 1,
@@ -1570,7 +1757,7 @@ mod tests {
             let mut config = Config::default();
             config.bar.size = bar_size;
             config.bar.border_radius = 100; // Request maximum radius
-            let palette = ThemePalette::from_config(&config);
+            let palette = ThemePalette::from_config(&config, None);
 
             // Bar radius is computed from rendered height (bar_size + 2*padding config)
             // With default padding=4, max radius = (bar_size + 8) / 2

--- a/crates/vibepanel/Cargo.toml
+++ b/crates/vibepanel/Cargo.toml
@@ -37,6 +37,8 @@ sysinfo = { workspace = true }
 nvml-wrapper = { workspace = true }
 parking_lot = { workspace = true }
 minreq = { workspace = true }
+material-colors = { workspace = true }
+image = { workspace = true }
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = [

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -536,8 +536,8 @@ fn create_center_section(
 pub fn load_css(config: &Config) {
     let provider = gtk4::CssProvider::new();
 
-    // Create theme palette and generate CSS
-    let palette = ThemePalette::from_config(config);
+    // Use cached palette from ConfigManager (avoids re-reading wallpaper image)
+    let palette = ConfigManager::global().palette();
     let css = generate_css(config, &palette);
 
     // Debug: print theme configuration

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -20,7 +20,7 @@ use gtk4::prelude::*;
 use tracing::{debug, error, info, warn};
 
 use services::bar_manager;
-use vibepanel_core::{Config, ThemePalette, logging};
+use vibepanel_core::{Config, logging};
 
 use crate::services::bar_manager::BarManager;
 use crate::services::compositor::CompositorManager;
@@ -607,7 +607,7 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
         );
 
         // Initialize theming-related services with theme-derived styles
-        let palette = ThemePalette::from_config(&config_for_activate);
+        let palette = ConfigManager::global().palette();
         let surface_styles = palette.surface_styles();
         services::surfaces::SurfaceStyleManager::init_global_with_config(
             surface_styles.clone(),

--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -47,6 +47,7 @@ pub mod tray;
 pub mod updates;
 pub mod vpn;
 pub mod vpn_secret_agent;
+pub mod wallpaper;
 pub mod window_list;
 pub mod window_title;
 pub mod workspace;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -710,7 +710,7 @@ fn per_widget_styles_changed(old: &Config, new: &Config) -> bool {
 /// Check if theme-related config has changed.
 fn config_theme_changed(old: &Config, new: &Config) -> bool {
     old.theme.mode != new.theme.mode
-        || old.theme.light != new.theme.light
+        || old.theme.scheme != new.theme.scheme
         || old.theme.wallpaper != new.theme.wallpaper
         || old.theme.accent != new.theme.accent
         || old.theme.animations != new.theme.animations

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -40,7 +40,7 @@ const FILE_CHANGE_DEBOUNCE_MS: u64 = 300;
 
 /// Polling interval (in seconds) for checking if the wallpaper changed.
 /// Only active when `mode = "auto"` and no explicit wallpaper path is set.
-const WALLPAPER_POLL_INTERVAL_SECS: u32 = 5;
+const WALLPAPER_POLL_INTERVAL_SECS: u32 = 2;
 
 use crate::bar;
 use crate::services::bar_manager::BarManager;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -32,15 +32,13 @@ use tracing::{debug, error, info, warn};
 use vibepanel_core::{Config, ThemePalette, ThemeSizes};
 
 use super::callbacks::{CallbackId, Callbacks};
-use super::wallpaper::{
-    detect_hyprpaper_wallpaper, extract_theme_from_image, theme_from_source_color,
-};
+use super::wallpaper::{detect_wallpaper, extract_theme_from_image, theme_from_source_color};
 
 /// Debounce interval (in ms) for file change events. Editors often trigger
 /// multiple events for a single save; this batches them into one reload.
 const FILE_CHANGE_DEBOUNCE_MS: u64 = 300;
 
-/// Polling interval (in seconds) for checking if hyprpaper's wallpaper changed.
+/// Polling interval (in seconds) for checking if the wallpaper changed.
 /// Only active when `mode = "auto"` and no explicit wallpaper path is set.
 const WALLPAPER_POLL_INTERVAL_SECS: u32 = 5;
 
@@ -89,7 +87,7 @@ pub struct ConfigManager {
     /// Callbacks for theme/style changes (border radius, colors, etc.)
     /// that don't trigger a full bar rebuild.
     theme_callbacks: Callbacks<()>,
-    /// Last wallpaper path detected from hyprpaper (for change detection).
+    /// Last wallpaper path detected from wallpaper daemon (for change detection).
     wallpaper_path: RefCell<Option<String>>,
     /// Cached source color extracted from the wallpaper image. Rebuilding a
     /// `material_colors::theme::Theme` from the source color is cheap (pure math);
@@ -112,7 +110,7 @@ impl ConfigManager {
         let monitor_hint = config.bar.outputs.first().map(|s| s.as_str());
         let (initial_wallpaper, material_theme) =
             if config.theme.mode == "auto" && config.theme.wallpaper.is_none() {
-                let wp = detect_hyprpaper_wallpaper(monitor_hint);
+                let wp = detect_wallpaper(monitor_hint);
                 let theme = wp.as_deref().and_then(extract_theme_from_image);
                 (wp, theme)
             } else if config.theme.mode == "auto" {
@@ -563,7 +561,7 @@ impl ConfigManager {
             // Update the cached wallpaper path for the new mode
             if new_config.theme.mode == "auto" && new_config.theme.wallpaper.is_none() {
                 *self.wallpaper_path.borrow_mut() =
-                    detect_hyprpaper_wallpaper(new_config.bar.outputs.first().map(|s| s.as_str()));
+                    detect_wallpaper(new_config.bar.outputs.first().map(|s| s.as_str()));
             } else {
                 *self.wallpaper_path.borrow_mut() = None;
             }
@@ -587,7 +585,7 @@ impl ConfigManager {
         info!("Configuration applied successfully");
     }
 
-    /// Start polling hyprpaper for wallpaper changes.
+    /// Start polling for wallpaper changes from supported daemons.
     ///
     /// Only active when `mode = "auto"` and no explicit `wallpaper` path is set.
     /// Polls every 5 seconds, compares to the cached path, and triggers a theme
@@ -628,10 +626,10 @@ impl ConfigManager {
         }
     }
 
-    /// Check if the hyprpaper wallpaper path changed and rebuild the theme if so.
+    /// Check if the wallpaper path changed and rebuild the theme if so.
     ///
-    /// The IPC call and image processing run on a background thread to avoid
-    /// blocking the GTK main loop. Results are applied via `glib::idle_add_once`.
+    /// The IPC/detection call and image processing run on a background thread to
+    /// avoid blocking the GTK main loop. Results are applied via `glib::idle_add_once`.
     fn check_wallpaper_changed(&self) {
         if self.poll_in_progress.get() {
             return;
@@ -646,7 +644,7 @@ impl ConfigManager {
         let monitor_hint = config.bar.outputs.first().cloned();
 
         std::thread::spawn(move || {
-            let new_path = detect_hyprpaper_wallpaper(monitor_hint.as_deref());
+            let new_path = detect_wallpaper(monitor_hint.as_deref());
 
             if new_path == old_path {
                 glib::idle_add_once(|| {

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -17,7 +17,7 @@
 //! - Structural changes (widget list, layout, bar size, margins) trigger a full
 //!   bar rebuild with a brief visual flicker.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -32,10 +32,17 @@ use tracing::{debug, error, info, warn};
 use vibepanel_core::{Config, ThemePalette, ThemeSizes};
 
 use super::callbacks::{CallbackId, Callbacks};
+use super::wallpaper::{
+    detect_hyprpaper_wallpaper, extract_theme_from_image, theme_from_source_color,
+};
 
 /// Debounce interval (in ms) for file change events. Editors often trigger
 /// multiple events for a single save; this batches them into one reload.
 const FILE_CHANGE_DEBOUNCE_MS: u64 = 300;
+
+/// Polling interval (in seconds) for checking if hyprpaper's wallpaper changed.
+/// Only active when `mode = "auto"` and no explicit wallpaper path is set.
+const WALLPAPER_POLL_INTERVAL_SECS: u32 = 5;
 
 use crate::bar;
 use crate::services::bar_manager::BarManager;
@@ -71,6 +78,10 @@ fn send_config_message(msg: ConfigMessage) {
 pub struct ConfigManager {
     /// Current configuration.
     config: RefCell<Config>,
+    /// Cached theme palette — computed once per config change, not on every access.
+    /// This avoids re-reading and re-processing the wallpaper image on every call
+    /// to `theme_sizes()`, `surface_border_radius()`, etc.
+    palette: RefCell<ThemePalette>,
     /// Path to the config file being watched (if any).
     config_path: RefCell<Option<PathBuf>>,
     /// Shutdown flag for the file watcher thread.
@@ -78,6 +89,16 @@ pub struct ConfigManager {
     /// Callbacks for theme/style changes (border radius, colors, etc.)
     /// that don't trigger a full bar rebuild.
     theme_callbacks: Callbacks<()>,
+    /// Last wallpaper path detected from hyprpaper (for change detection).
+    wallpaper_path: RefCell<Option<String>>,
+    /// Cached source color extracted from the wallpaper image. Rebuilding a
+    /// `material_colors::theme::Theme` from the source color is cheap (pure math);
+    /// the expensive part is image I/O + quantization, which this cache avoids.
+    cached_source_color: Cell<Option<material_colors::color::Argb>>,
+    /// Source ID for the wallpaper polling timer (so we can cancel it).
+    wallpaper_poll_source: RefCell<Option<glib::SourceId>>,
+    /// Guard against overlapping wallpaper polls (IPC + image processing is async).
+    poll_in_progress: Cell<bool>,
 }
 
 // Thread-local singleton storage
@@ -87,11 +108,38 @@ thread_local! {
 
 impl ConfigManager {
     fn new(config: Config, config_path: Option<PathBuf>) -> Rc<Self> {
+        // Detect wallpaper and extract Material You theme if in auto mode
+        let monitor_hint = config.bar.outputs.first().map(|s| s.as_str());
+        let (initial_wallpaper, material_theme) =
+            if config.theme.mode == "auto" && config.theme.wallpaper.is_none() {
+                let wp = detect_hyprpaper_wallpaper(monitor_hint);
+                let theme = wp.as_deref().and_then(extract_theme_from_image);
+                (wp, theme)
+            } else if config.theme.mode == "auto" {
+                // Explicit wallpaper path set
+                let theme = config
+                    .theme
+                    .wallpaper
+                    .as_deref()
+                    .and_then(extract_theme_from_image);
+                (None, theme)
+            } else {
+                (None, None)
+            };
+
+        let source_color = material_theme.as_ref().map(|t| t.source);
+        let palette = ThemePalette::from_config(&config, material_theme.as_ref());
+
         Rc::new(Self {
             config: RefCell::new(config),
+            palette: RefCell::new(palette),
             config_path: RefCell::new(config_path),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             theme_callbacks: Callbacks::new(),
+            wallpaper_path: RefCell::new(initial_wallpaper),
+            cached_source_color: Cell::new(source_color),
+            wallpaper_poll_source: RefCell::new(None),
+            poll_in_progress: Cell::new(false),
         })
     }
 
@@ -123,19 +171,22 @@ impl ConfigManager {
 
     /// Get the computed theme sizes from the current configuration.
     ///
-    /// This computes sizes based on the current bar size and theme scale constants.
-    /// Widgets can use this to get the default icon sizes, font sizes, etc.
+    /// This returns sizes from the cached palette — no recomputation needed.
     pub fn theme_sizes(&self) -> ThemeSizes {
-        let config = self.config.borrow();
-        let palette = ThemePalette::from_config(&config);
-        palette.sizes.clone()
+        self.palette.borrow().sizes.clone()
+    }
+
+    /// Get the cached theme palette.
+    ///
+    /// The palette is computed once per config change and cached. This avoids
+    /// re-reading and re-processing the wallpaper image on every access.
+    pub fn palette(&self) -> ThemePalette {
+        self.palette.borrow().clone()
     }
 
     /// Get the computed surface border radius in pixels.
     pub fn surface_border_radius(&self) -> u32 {
-        let config = self.config.borrow();
-        let palette = ThemePalette::from_config(&config);
-        palette.surface_border_radius
+        self.palette.borrow().surface_border_radius
     }
 
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).
@@ -144,9 +195,7 @@ impl ConfigManager {
     /// Used by CSS variable generation in ThemePalette.
     #[allow(dead_code)]
     pub fn radius_pill(&self) -> u32 {
-        let config = self.config.borrow();
-        let palette = ThemePalette::from_config(&config);
-        palette.radius_pill
+        self.palette.borrow().radius_pill
     }
 
     /// Get the raw widget border radius percentage (0-100) from config.
@@ -264,13 +313,16 @@ impl ConfigManager {
         self.theme_callbacks.unregister(id)
     }
 
-    /// Start watching the config file for changes.
+    /// Start watching the config file for changes and wallpaper polling.
     ///
     /// This spawns a background thread that monitors the config file. When changes
     /// are detected, the new config is parsed and sent to the GTK main thread.
     ///
-    /// Does nothing if no config file path is set (using defaults).
+    /// Also starts wallpaper polling if `mode = "auto"` (wallpaper-adaptive theming).
     pub fn start_watching(self: &Rc<Self>) {
+        // Start wallpaper polling if in auto-detect mode
+        self.start_wallpaper_polling();
+
         let config_path = self.config_path.borrow().clone();
         let Some(path) = config_path else {
             info!("No config file to watch (using defaults)");
@@ -400,7 +452,7 @@ impl ConfigManager {
 
     /// Handle a config message from the file watcher.
     /// Called via glib::idle_add_once from send_config_message.
-    pub(crate) fn handle_config_message(&self, msg: ConfigMessage) {
+    pub(crate) fn handle_config_message(self: &Rc<Self>, msg: ConfigMessage) {
         match msg {
             ConfigMessage::Reloaded(new_config) => {
                 self.apply_config(*new_config);
@@ -421,7 +473,7 @@ impl ConfigManager {
     ///
     /// This is the central "fan-out" function that coordinates updates across
     /// all services and widgets when the config changes.
-    fn apply_config(&self, new_config: Config) {
+    fn apply_config(self: &Rc<Self>, new_config: Config) {
         let old_config = self.config.borrow().clone();
 
         info!("Applying new configuration...");
@@ -454,8 +506,32 @@ impl ConfigManager {
         if theme_changed {
             info!("Theme configuration changed, updating styles...");
 
-            // Regenerate palette and update services
-            let palette = ThemePalette::from_config(&new_config);
+            // Reuse cached source color unless the wallpaper source changed,
+            // avoiding redundant image I/O + quantization on the main thread.
+            // Rebuilding Theme from source color is cheap (pure math).
+            let material_theme = if new_config.theme.mode == "auto" {
+                let wallpaper_source_changed = old_config.theme.mode != "auto"
+                    || old_config.theme.wallpaper != new_config.theme.wallpaper;
+
+                if wallpaper_source_changed {
+                    let theme = new_config
+                        .theme
+                        .wallpaper
+                        .as_deref()
+                        .or(self.wallpaper_path.borrow().as_deref())
+                        .and_then(extract_theme_from_image);
+                    self.cached_source_color
+                        .set(theme.as_ref().map(|t| t.source));
+                    theme
+                } else {
+                    self.cached_source_color.get().map(theme_from_source_color)
+                }
+            } else {
+                None
+            };
+
+            // Rebuild the cached palette once
+            let palette = ThemePalette::from_config(&new_config, material_theme.as_ref());
             let surface_styles = palette.surface_styles();
 
             // Update surface style manager
@@ -467,6 +543,9 @@ impl ConfigManager {
             // Update tooltip manager
             TooltipManager::global().reconfigure(surface_styles);
 
+            // Update the cached palette before load_css so it's available
+            *self.palette.borrow_mut() = palette;
+
             // Reload CSS with new theme values
             bar::load_css(&new_config);
 
@@ -475,6 +554,20 @@ impl ConfigManager {
 
         // Store the new config BEFORE rebuilding/notifying, so widgets see new values
         *self.config.borrow_mut() = new_config.clone();
+
+        // Restart or stop wallpaper polling if auto mode or wallpaper config changed
+        if old_config.theme.mode != new_config.theme.mode
+            || old_config.theme.wallpaper != new_config.theme.wallpaper
+        {
+            self.start_wallpaper_polling();
+            // Update the cached wallpaper path for the new mode
+            if new_config.theme.mode == "auto" && new_config.theme.wallpaper.is_none() {
+                *self.wallpaper_path.borrow_mut() =
+                    detect_hyprpaper_wallpaper(new_config.bar.outputs.first().map(|s| s.as_str()));
+            } else {
+                *self.wallpaper_path.borrow_mut() = None;
+            }
+        }
 
         if structure_changed {
             // Structural changes require full bar rebuild
@@ -494,10 +587,120 @@ impl ConfigManager {
         info!("Configuration applied successfully");
     }
 
-    /// Stop watching the config file.
+    /// Start polling hyprpaper for wallpaper changes.
+    ///
+    /// Only active when `mode = "auto"` and no explicit `wallpaper` path is set.
+    /// Polls every 5 seconds, compares to the cached path, and triggers a theme
+    /// rebuild if the wallpaper changed.
+    pub fn start_wallpaper_polling(self: &Rc<Self>) {
+        // Stop any existing poll timer first
+        self.stop_wallpaper_polling();
+
+        // Only poll when in auto mode with no explicit wallpaper path
+        let config = self.config.borrow();
+        let should_poll = config.theme.mode == "auto" && config.theme.wallpaper.is_none();
+        drop(config);
+        if !should_poll {
+            return;
+        }
+
+        info!(
+            "Starting wallpaper polling (every {}s)",
+            WALLPAPER_POLL_INTERVAL_SECS
+        );
+
+        let mgr = Rc::downgrade(self);
+        let source_id = glib::timeout_add_seconds_local(WALLPAPER_POLL_INTERVAL_SECS, move || {
+            let Some(mgr) = mgr.upgrade() else {
+                return glib::ControlFlow::Break;
+            };
+            mgr.check_wallpaper_changed();
+            glib::ControlFlow::Continue
+        });
+        *self.wallpaper_poll_source.borrow_mut() = Some(source_id);
+    }
+
+    /// Stop wallpaper polling if active.
+    fn stop_wallpaper_polling(&self) {
+        if let Some(source_id) = self.wallpaper_poll_source.borrow_mut().take() {
+            source_id.remove();
+            debug!("Wallpaper polling stopped");
+        }
+    }
+
+    /// Check if the hyprpaper wallpaper path changed and rebuild the theme if so.
+    ///
+    /// The IPC call and image processing run on a background thread to avoid
+    /// blocking the GTK main loop. Results are applied via `glib::idle_add_once`.
+    fn check_wallpaper_changed(&self) {
+        if self.poll_in_progress.get() {
+            return;
+        }
+        self.poll_in_progress.set(true);
+
+        let old_path = self.wallpaper_path.borrow().clone();
+        let config = self.config.borrow().clone();
+        // Snapshot theme fields to detect stale results when the callback fires
+        let config_mode = config.theme.mode.clone();
+        let config_light = config.theme.light;
+        let monitor_hint = config.bar.outputs.first().cloned();
+
+        std::thread::spawn(move || {
+            let new_path = detect_hyprpaper_wallpaper(monitor_hint.as_deref());
+
+            if new_path == old_path {
+                glib::idle_add_once(|| {
+                    ConfigManager::global().poll_in_progress.set(false);
+                });
+                return;
+            }
+
+            info!(
+                "Wallpaper changed: {:?} -> {:?}, rebuilding theme...",
+                old_path, new_path
+            );
+
+            // Heavy work: extract theme from new wallpaper + rebuild palette
+            let material_theme = new_path.as_deref().and_then(extract_theme_from_image);
+            let source_color = material_theme.as_ref().map(|t| t.source);
+            let palette = ThemePalette::from_config(&config, material_theme.as_ref());
+            let surface_styles = palette.surface_styles();
+            let pango = config.advanced.pango_font_rendering;
+
+            glib::idle_add_once(move || {
+                let mgr = ConfigManager::global();
+                mgr.poll_in_progress.set(false);
+
+                // If config changed while we were processing, skip — the config
+                // change already triggered its own theme rebuild.
+                let current = mgr.config.borrow();
+                if current.theme.mode != config_mode || current.theme.light != config_light {
+                    drop(current);
+                    debug!("Config changed during wallpaper poll, skipping stale result");
+                    return;
+                }
+                drop(current);
+
+                *mgr.wallpaper_path.borrow_mut() = new_path;
+                mgr.cached_source_color.set(source_color);
+
+                SurfaceStyleManager::global().reconfigure(surface_styles.clone(), pango);
+                TooltipManager::global().reconfigure(surface_styles);
+
+                *mgr.palette.borrow_mut() = palette;
+                bar::load_css(&config);
+
+                mgr.theme_callbacks.notify(&());
+                info!("Wallpaper theme updated");
+            });
+        });
+    }
+
+    /// Stop watching the config file and wallpaper polling.
     pub fn stop_watching(&self) {
         // Signal the watcher thread to shut down
         self.shutdown_flag.store(true, Ordering::Relaxed);
+        self.stop_wallpaper_polling();
         debug!("Config watcher stopped");
     }
 }
@@ -513,6 +716,8 @@ fn per_widget_styles_changed(old: &Config, new: &Config) -> bool {
 /// Check if theme-related config has changed.
 fn config_theme_changed(old: &Config, new: &Config) -> bool {
     old.theme.mode != new.theme.mode
+        || old.theme.light != new.theme.light
+        || old.theme.wallpaper != new.theme.wallpaper
         || old.theme.accent != new.theme.accent
         || old.theme.animations != new.theme.animations
         || old.theme.ripple != new.theme.ripple

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -637,11 +637,7 @@ impl ConfigManager {
         self.poll_in_progress.set(true);
 
         let old_path = self.wallpaper_path.borrow().clone();
-        let config = self.config.borrow().clone();
-        // Snapshot theme fields to detect stale results when the callback fires
-        let config_mode = config.theme.mode.clone();
-        let config_light = config.theme.light;
-        let monitor_hint = config.bar.outputs.first().cloned();
+        let monitor_hint = self.config.borrow().bar.outputs.first().cloned();
 
         std::thread::spawn(move || {
             let new_path = detect_wallpaper(monitor_hint.as_deref());
@@ -658,31 +654,31 @@ impl ConfigManager {
                 old_path, new_path
             );
 
-            // Heavy work: extract theme from new wallpaper + rebuild palette
+            // Heavy work: image I/O + quantization on background thread
             let material_theme = new_path.as_deref().and_then(extract_theme_from_image);
             let source_color = material_theme.as_ref().map(|t| t.source);
-            let palette = ThemePalette::from_config(&config, material_theme.as_ref());
-            let surface_styles = palette.surface_styles();
-            let pango = config.advanced.pango_font_rendering;
 
+            // Palette construction uses live config on the main thread
             glib::idle_add_once(move || {
                 let mgr = ConfigManager::global();
                 mgr.poll_in_progress.set(false);
 
-                // If config changed while we were processing, skip — the config
-                // change already triggered its own theme rebuild.
-                let current = mgr.config.borrow();
-                if current.theme.mode != config_mode || current.theme.light != config_light {
-                    drop(current);
-                    debug!("Config changed during wallpaper poll, skipping stale result");
+                // If we're no longer in auto mode, skip — a config change already
+                // triggered its own theme rebuild.
+                let config = mgr.config.borrow().clone();
+                if config.theme.mode != "auto" {
+                    debug!("No longer in auto mode, skipping wallpaper poll result");
                     return;
                 }
-                drop(current);
 
                 *mgr.wallpaper_path.borrow_mut() = new_path;
                 mgr.cached_source_color.set(source_color);
 
-                SurfaceStyleManager::global().reconfigure(surface_styles.clone(), pango);
+                let palette = ThemePalette::from_config(&config, material_theme.as_ref());
+                let surface_styles = palette.surface_styles();
+
+                SurfaceStyleManager::global()
+                    .reconfigure(surface_styles.clone(), config.advanced.pango_font_rendering);
                 TooltipManager::global().reconfigure(surface_styles);
 
                 *mgr.palette.borrow_mut() = palette;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -550,7 +550,8 @@ impl ConfigManager {
             debug!("Theme styles updated");
         }
 
-        // Store the new config BEFORE rebuilding/notifying, so widgets see new values
+        // Store the new config AFTER theme/CSS update but BEFORE widget rebuild,
+        // so widgets see the new values when notified
         *self.config.borrow_mut() = new_config.clone();
 
         // Restart or stop wallpaper polling if auto mode or wallpaper config changed

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -500,6 +500,18 @@ impl ConfigManager {
         let theme_changed = config_theme_changed(&old_config, &new_config);
         let structure_changed = config_structure_changed(&old_config, &new_config);
 
+        // Update detected wallpaper path before theme rebuild so the palette
+        // can use it (e.g. when an explicit wallpaper is removed and we need
+        // to fall back to auto-detection).
+        if new_config.theme.mode == "auto"
+            && new_config.theme.wallpaper.is_none()
+            && (old_config.theme.mode != "auto"
+                || old_config.theme.wallpaper != new_config.theme.wallpaper)
+        {
+            *self.wallpaper_path.borrow_mut() =
+                detect_wallpaper(new_config.bar.outputs.first().map(|s| s.as_str()));
+        }
+
         // Update theme/palette if theme config changed
         if theme_changed {
             info!("Theme configuration changed, updating styles...");
@@ -559,11 +571,8 @@ impl ConfigManager {
             || old_config.theme.wallpaper != new_config.theme.wallpaper
         {
             self.start_wallpaper_polling();
-            // Update the cached wallpaper path for the new mode
-            if new_config.theme.mode == "auto" && new_config.theme.wallpaper.is_none() {
-                *self.wallpaper_path.borrow_mut() =
-                    detect_wallpaper(new_config.bar.outputs.first().map(|s| s.as_str()));
-            } else {
+            // Clear cached path when leaving auto mode or setting an explicit wallpaper
+            if new_config.theme.mode != "auto" || new_config.theme.wallpaper.is_some() {
                 *self.wallpaper_path.borrow_mut() = None;
             }
         }

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -598,7 +598,7 @@ impl ConfigManager {
     /// Start polling for wallpaper changes from supported daemons.
     ///
     /// Only active when `mode = "auto"` and no explicit `wallpaper` path is set.
-    /// Polls every 5 seconds, compares to the cached path, and triggers a theme
+    /// Polls every `WALLPAPER_POLL_INTERVAL_SECS` seconds, compares to the cached path, and triggers a theme
     /// rebuild if the wallpaper changed.
     pub fn start_wallpaper_polling(self: &Rc<Self>) {
         // Stop any existing poll timer first

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -1,11 +1,12 @@
 //! Wallpaper detection and Material You color extraction.
 //!
-//! Handles IPC with wallpaper daemons (hyprpaper) and extracts a
-//! `material_colors::theme::Theme` from a wallpaper image for use by
-//! the theming system in `vibepanel-core`.
+//! Handles IPC with wallpaper daemons (hyprpaper, awww/swww, wpaperd, waypaper)
+//! and extracts a `material_colors::theme::Theme` from a wallpaper image for
+//! use by the theming system in `vibepanel-core`.
 
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
+use std::process::Command;
 use std::time::Duration;
 
 use material_colors::color::Argb;
@@ -71,6 +72,174 @@ pub fn detect_hyprpaper_wallpaper(monitor: Option<&str>) -> Option<String> {
         let path = path.trim().to_string();
         (!path.is_empty()).then_some(path)
     })
+}
+
+/// Detect the current wallpaper path from awww (or legacy swww) via CLI.
+///
+/// Output format: `{namespace}: {output}: {w}x{h}, scale: {s}, currently displaying: image: {path}`
+fn detect_awww_wallpaper(monitor: Option<&str>) -> Option<String> {
+    let output = Command::new("awww")
+        .arg("query")
+        .output()
+        .or_else(|_| Command::new("swww").arg("query").output())
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Try to match the target monitor first
+    if let Some(target) = monitor {
+        for line in stdout.lines() {
+            // Output name is after the first `: ` and before the resolution
+            let after_ns = line.split_once(": ").map(|(_, rest)| rest)?;
+            let (output_name, _) = after_ns.split_once(':')?;
+            if output_name.trim() != target {
+                continue;
+            }
+            return extract_awww_image_path(line);
+        }
+    }
+
+    // Fall back to first line with an image path
+    stdout.lines().find_map(extract_awww_image_path)
+}
+
+/// Extract the image path from a single awww/swww query output line.
+fn extract_awww_image_path(line: &str) -> Option<String> {
+    let marker = "currently displaying: image: ";
+    let idx = line.find(marker)?;
+    let path = line[idx + marker.len()..].trim();
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+/// Detect the current wallpaper path from wpaperd via its state symlinks.
+///
+/// wpaperd creates symlinks at `$XDG_STATE_HOME/wpaperd/wallpapers/<OUTPUT>`
+/// pointing to the current wallpaper image.
+fn detect_wpaperd_wallpaper(monitor: Option<&str>) -> Option<String> {
+    let state_dir = std::env::var("XDG_STATE_HOME").unwrap_or_else(|_| {
+        std::env::var("HOME")
+            .map(|h| format!("{}/.local/state", h))
+            .unwrap_or_default()
+    });
+    if state_dir.is_empty() {
+        return None;
+    }
+
+    let wallpapers_dir = std::path::PathBuf::from(&state_dir).join("wpaperd/wallpapers");
+
+    // Try the target monitor symlink first
+    if let Some(target) = monitor {
+        let symlink = wallpapers_dir.join(target);
+        if let Ok(path) = std::fs::read_link(&symlink) {
+            return Some(path.to_string_lossy().into_owned());
+        }
+    }
+
+    // Fall back to first symlink in the directory
+    let entries = std::fs::read_dir(&wallpapers_dir).ok()?;
+    for entry in entries.flatten() {
+        if let Ok(path) = std::fs::read_link(entry.path()) {
+            return Some(path.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+/// Detect the current wallpaper path from waypaper's INI config.
+///
+/// Parses `wallpaper = ` under `[Settings]` in `~/.config/waypaper/config.ini`.
+/// Handles per-monitor parallel lists and `~` path expansion.
+fn detect_waypaper_wallpaper(monitor: Option<&str>) -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let config_path =
+        std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{}/.config", home));
+    let ini_path = std::path::PathBuf::from(&config_path).join("waypaper/config.ini");
+
+    let content = std::fs::read_to_string(&ini_path).ok()?;
+
+    let mut in_settings = false;
+    let mut wallpaper = None;
+    let mut monitors_line = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_settings = trimmed.eq_ignore_ascii_case("[settings]");
+            continue;
+        }
+        if !in_settings {
+            continue;
+        }
+
+        if let Some((key, value)) = trimmed.split_once('=') {
+            let key = key.trim();
+            let value = value.trim();
+            match key {
+                "wallpaper" => wallpaper = Some(value.to_string()),
+                "monitors" => monitors_line = Some(value.to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    let wallpaper = wallpaper?;
+
+    // waypaper supports per-monitor parallel lists: monitors = eDP-1,DP-1 / wallpaper = path1,path2
+    if let Some(target) = monitor
+        && let Some(ref monitors_csv) = monitors_line
+    {
+        let monitors: Vec<&str> = monitors_csv.split(',').map(|s| s.trim()).collect();
+        let paths: Vec<&str> = wallpaper.split(',').map(|s| s.trim()).collect();
+        if let Some(idx) = monitors.iter().position(|m| *m == target)
+            && let Some(path) = paths.get(idx)
+        {
+            return Some(expand_tilde(path, &home));
+        }
+    }
+
+    // Single wallpaper or no monitor match — use the first (or only) path
+    let first_path = wallpaper.split(',').next()?.trim();
+    Some(expand_tilde(first_path, &home))
+}
+
+/// Expand a leading `~` to `$HOME`.
+fn expand_tilde(path: &str, home: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        format!("{}/{}", home, rest)
+    } else if path == "~" {
+        home.to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Detect the current wallpaper from any supported daemon.
+///
+/// Cascade order: hyprpaper → awww/swww → wpaperd → waypaper.
+pub fn detect_wallpaper(monitor: Option<&str>) -> Option<String> {
+    if let Some(path) = detect_hyprpaper_wallpaper(monitor) {
+        debug!("Wallpaper detected via hyprpaper: {}", path);
+        return Some(path);
+    }
+    if let Some(path) = detect_awww_wallpaper(monitor) {
+        debug!("Wallpaper detected via awww/swww: {}", path);
+        return Some(path);
+    }
+    if let Some(path) = detect_wpaperd_wallpaper(monitor) {
+        debug!("Wallpaper detected via wpaperd: {}", path);
+        return Some(path);
+    }
+    if let Some(path) = detect_waypaper_wallpaper(monitor) {
+        debug!("Wallpaper detected via waypaper: {}", path);
+        return Some(path);
+    }
+
+    debug!("No wallpaper daemon detected");
+    None
 }
 
 /// Rebuild a Material You theme from a previously extracted source color.

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -15,6 +15,7 @@ use material_colors::quantize::{Quantizer, QuantizerCelebi};
 use material_colors::score::Score;
 use material_colors::theme::ThemeBuilder;
 use tracing::{debug, warn};
+use vibepanel_core::expand_tilde;
 
 /// Reject wallpaper images larger than this to avoid excessive memory use.
 const MAX_WALLPAPER_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
@@ -208,17 +209,6 @@ fn detect_waypaper_wallpaper(monitor: Option<&str>) -> Option<String> {
     Some(expand_tilde(first_path, &home))
 }
 
-/// Expand a leading `~` to `$HOME`.
-fn expand_tilde(path: &str, home: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/") {
-        format!("{}/{}", home, rest)
-    } else if path == "~" {
-        home.to_string()
-    } else {
-        path.to_string()
-    }
-}
-
 /// Detect the current wallpaper from any supported daemon.
 ///
 /// Cascade order: hyprpaper → wpaperd → waypaper → awww/swww.
@@ -334,32 +324,5 @@ mod tests {
     fn test_extract_awww_image_path_empty_after_marker() {
         let line = "default: eDP-1: 1920x1080, scale: 1, currently displaying: image:   ";
         assert_eq!(extract_awww_image_path(line), None);
-    }
-
-    #[test]
-    fn test_expand_tilde_home_prefix() {
-        assert_eq!(
-            expand_tilde("~/Pictures/wall.png", "/home/user"),
-            "/home/user/Pictures/wall.png"
-        );
-    }
-
-    #[test]
-    fn test_expand_tilde_bare() {
-        assert_eq!(expand_tilde("~", "/home/user"), "/home/user");
-    }
-
-    #[test]
-    fn test_expand_tilde_absolute_unchanged() {
-        assert_eq!(
-            expand_tilde("/usr/share/wall.png", "/home/user"),
-            "/usr/share/wall.png"
-        );
-    }
-
-    #[test]
-    fn test_expand_tilde_no_slash_unchanged() {
-        // "~foo" is not expanded (only "~/" and bare "~")
-        assert_eq!(expand_tilde("~foo", "/home/user"), "~foo");
     }
 }

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -93,13 +93,15 @@ fn detect_awww_wallpaper(monitor: Option<&str>) -> Option<String> {
     // Try to match the target monitor first
     if let Some(target) = monitor {
         for line in stdout.lines() {
-            // Output name is after the first `: ` and before the resolution
-            let after_ns = line.split_once(": ").map(|(_, rest)| rest)?;
-            let (output_name, _) = after_ns.split_once(':')?;
-            if output_name.trim() != target {
+            let Some(after_ns) = line.split_once(": ").map(|(_, rest)| rest) else {
                 continue;
+            };
+            let Some((output_name, _)) = after_ns.split_once(':') else {
+                continue;
+            };
+            if output_name.trim() == target {
+                return extract_awww_image_path(line);
             }
-            return extract_awww_image_path(line);
         }
     }
 
@@ -279,7 +281,7 @@ pub fn extract_theme_from_image(path: &str) -> Option<material_colors::theme::Th
         .inspect_err(|e| warn!("Failed to decode wallpaper image '{}': {}", path, e))
         .ok()?;
 
-    let resized = img.resize(128, 128, image::imageops::FilterType::Lanczos3);
+    let resized = img.resize(128, 128, image::imageops::FilterType::Triangle);
     let rgba = resized.to_rgba8();
 
     let pixels: Vec<Argb> = rgba

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -299,3 +299,65 @@ pub fn extract_theme_from_image(path: &str) -> Option<material_colors::theme::Th
             .build(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_awww_image_path_standard() {
+        let line =
+            "default: eDP-1: 1920x1080, scale: 1, currently displaying: image: /home/user/wall.png";
+        assert_eq!(
+            extract_awww_image_path(line),
+            Some("/home/user/wall.png".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_awww_image_path_spaces_in_path() {
+        let line = "default: DP-2: 2560x1440, scale: 1, currently displaying: image: /home/user/My Wallpapers/wall.jpg";
+        assert_eq!(
+            extract_awww_image_path(line),
+            Some("/home/user/My Wallpapers/wall.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_awww_image_path_no_marker() {
+        assert_eq!(extract_awww_image_path("some random line"), None);
+    }
+
+    #[test]
+    fn test_extract_awww_image_path_empty_after_marker() {
+        let line = "default: eDP-1: 1920x1080, scale: 1, currently displaying: image:   ";
+        assert_eq!(extract_awww_image_path(line), None);
+    }
+
+    #[test]
+    fn test_expand_tilde_home_prefix() {
+        assert_eq!(
+            expand_tilde("~/Pictures/wall.png", "/home/user"),
+            "/home/user/Pictures/wall.png"
+        );
+    }
+
+    #[test]
+    fn test_expand_tilde_bare() {
+        assert_eq!(expand_tilde("~", "/home/user"), "/home/user");
+    }
+
+    #[test]
+    fn test_expand_tilde_absolute_unchanged() {
+        assert_eq!(
+            expand_tilde("/usr/share/wall.png", "/home/user"),
+            "/usr/share/wall.png"
+        );
+    }
+
+    #[test]
+    fn test_expand_tilde_no_slash_unchanged() {
+        // "~foo" is not expanded (only "~/" and bare "~")
+        assert_eq!(expand_tilde("~foo", "/home/user"), "~foo");
+    }
+}

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -221,14 +221,12 @@ fn expand_tilde(path: &str, home: &str) -> String {
 
 /// Detect the current wallpaper from any supported daemon.
 ///
-/// Cascade order: hyprpaper → awww/swww → wpaperd → waypaper.
+/// Cascade order: hyprpaper → wpaperd → waypaper → awww/swww.
+/// Lightweight checks (socket, filesystem) run first; subprocess-based
+/// detection (awww/swww CLI) is last to avoid unnecessary fork+exec.
 pub fn detect_wallpaper(monitor: Option<&str>) -> Option<String> {
     if let Some(path) = detect_hyprpaper_wallpaper(monitor) {
         debug!("Wallpaper detected via hyprpaper: {}", path);
-        return Some(path);
-    }
-    if let Some(path) = detect_awww_wallpaper(monitor) {
-        debug!("Wallpaper detected via awww/swww: {}", path);
         return Some(path);
     }
     if let Some(path) = detect_wpaperd_wallpaper(monitor) {
@@ -237,6 +235,10 @@ pub fn detect_wallpaper(monitor: Option<&str>) -> Option<String> {
     }
     if let Some(path) = detect_waypaper_wallpaper(monitor) {
         debug!("Wallpaper detected via waypaper: {}", path);
+        return Some(path);
+    }
+    if let Some(path) = detect_awww_wallpaper(monitor) {
+        debug!("Wallpaper detected via awww/swww: {}", path);
         return Some(path);
     }
 

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -1,0 +1,130 @@
+//! Wallpaper detection and Material You color extraction.
+//!
+//! Handles IPC with wallpaper daemons (hyprpaper) and extracts a
+//! `material_colors::theme::Theme` from a wallpaper image for use by
+//! the theming system in `vibepanel-core`.
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use material_colors::color::Argb;
+use material_colors::dynamic_color::Variant;
+use material_colors::quantize::{Quantizer, QuantizerCelebi};
+use material_colors::score::Score;
+use material_colors::theme::ThemeBuilder;
+use tracing::{debug, warn};
+
+/// Reject wallpaper images larger than this to avoid excessive memory use.
+const MAX_WALLPAPER_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
+
+/// Detect the current wallpaper path from hyprpaper via its IPC socket.
+///
+/// Tries the instance-specific path (`hypr/$HYPRLAND_INSTANCE_SIGNATURE/.hyprpaper.sock`)
+/// first, then falls back to the legacy path (`hypr/.hyprpaper.sock`).
+///
+/// If `monitor` is provided, returns that monitor's wallpaper. Falls back to the
+/// first listed monitor if the target isn't found (e.g. unplugged, name mismatch).
+pub fn detect_hyprpaper_wallpaper(monitor: Option<&str>) -> Option<String> {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR").ok()?;
+
+    // Instance-specific path (Hyprland 0.40+), fall back to legacy
+    let socket_path = std::env::var("HYPRLAND_INSTANCE_SIGNATURE")
+        .ok()
+        .map(|sig| format!("{}/hypr/{}/.hyprpaper.sock", runtime_dir, sig))
+        .filter(|p| std::path::Path::new(p).exists())
+        .unwrap_or_else(|| format!("{}/hypr/.hyprpaper.sock", runtime_dir));
+
+    let mut stream = UnixStream::connect(&socket_path).ok()?;
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .ok();
+    stream
+        .set_write_timeout(Some(Duration::from_millis(500)))
+        .ok();
+    stream.write_all(b"listactive").ok()?;
+    stream.shutdown(std::net::Shutdown::Write).ok();
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+
+    // Response format: "eDP-1 = /path/to/image\nMONITOR2 = /path/to/image2\n"
+    // If a target monitor was specified, try to match it first
+    if let Some(target) = monitor {
+        if let Some(path) = response.lines().find_map(|line| {
+            let (name, path) = line.split_once('=')?;
+            (name.trim() == target)
+                .then(|| path.trim().to_string())
+                .filter(|p| !p.is_empty())
+        }) {
+            debug!("Using wallpaper from target monitor '{}'", target);
+            return Some(path);
+        }
+        debug!(
+            "Target monitor '{}' not found in hyprpaper, using first available",
+            target
+        );
+    }
+
+    response.lines().find_map(|line| {
+        let (_, path) = line.split_once('=')?;
+        let path = path.trim().to_string();
+        (!path.is_empty()).then_some(path)
+    })
+}
+
+/// Rebuild a Material You theme from a previously extracted source color.
+///
+/// This is cheap (pure math, no I/O) and used when only the light/dark preference
+/// changes without the wallpaper itself changing.
+pub fn theme_from_source_color(source: Argb) -> material_colors::theme::Theme {
+    ThemeBuilder::with_source(source)
+        .variant(Variant::Content)
+        .build()
+}
+
+/// Extract a Material You theme from a wallpaper image.
+///
+/// Returns the full `Theme` (with light/dark schemes, tonal palettes, and source color)
+/// using the `Content` variant (same as matugen's default), or `None` on failure.
+pub fn extract_theme_from_image(path: &str) -> Option<material_colors::theme::Theme> {
+    let file_size = std::fs::metadata(path)
+        .inspect_err(|e| warn!("Failed to stat wallpaper '{}': {}", path, e))
+        .ok()?
+        .len();
+    if file_size > MAX_WALLPAPER_FILE_SIZE {
+        warn!(
+            "Wallpaper '{}' too large ({} MB, max {} MB)",
+            path,
+            file_size / (1024 * 1024),
+            MAX_WALLPAPER_FILE_SIZE / (1024 * 1024)
+        );
+        return None;
+    }
+
+    let image_bytes = std::fs::read(path)
+        .inspect_err(|e| warn!("Failed to read wallpaper image '{}': {}", path, e))
+        .ok()?;
+
+    let img = image::load_from_memory(&image_bytes)
+        .inspect_err(|e| warn!("Failed to decode wallpaper image '{}': {}", path, e))
+        .ok()?;
+
+    let resized = img.resize(128, 128, image::imageops::FilterType::Lanczos3);
+    let rgba = resized.to_rgba8();
+
+    let pixels: Vec<Argb> = rgba
+        .pixels()
+        .map(|p| Argb::new(p[3], p[0], p[1], p[2]))
+        .collect();
+
+    let result = QuantizerCelebi::quantize(&pixels, 128);
+    let ranked = Score::score(&result.color_to_count, None, None, None);
+    let source_color = *ranked.first()?;
+
+    Some(
+        ThemeBuilder::with_source(source_color)
+            .variant(Variant::Content)
+            .build(),
+    )
+}


### PR DESCRIPTION
Wallpaper-adaptive Material You theming. When`mode = "auto"` we extract the dominant color from the wallpaper and generates a full color scheme  using material-colors.

Auto-detects wallpaper from hyprpaper, awww/swww, wpaperd and waypaper. Polls for wallpaper changes every 2s and rebuilds the theme live.

Config:
```toml
[theme]
mode = "auto"                        # Enables wallpaper-adaptive theming
#scheme = "dark"                     # Material You scheme: "dark" or "light" theme
#wallpaper = "~/Pictures/wall.png"   # Explicit path (default: auto-detect)
```

Multi-monitor: uses wallpaper from the first bar.outputs entry, or the first detected monitor if unset.

Breaking: Repurposes `mode = "auto"` which previously did luminance-based foreground detection. The shipped default is mode = "dark" so this only affects users who explicitly set auto.