### PR TITLE
feat(theme): derive scheme from wallpaper luminance in auto mode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -73,6 +73,7 @@ mode = "dark" # "auto", "dark", "light", "gtk"
 #               "auto" = wallpaper-adaptive theming
 #               (detects from hyprpaper, awww/swww, wpaperd, waypaper)
 #scheme = "dark"         # Material You polarity: "dark" or "light" (auto mode only)
+#               Omit to auto-derive from wallpaper luminance (bright → light, dark → dark)
 #wallpaper = "/path/to/image.png"  # Explicit wallpaper for auto mode (default: auto-detect)
 #accent = "#adabe0" # "gtk", "none", or hex color (overrides wallpaper accent in auto mode)
 #animations = true  # Enable/disable all CSS transitions and animations

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -21,8 +21,16 @@ const VALID_COMPOSITORS: &[&str] = &[
 /// Known valid values for theme.mode.
 const VALID_THEME_MODES: &[&str] = &["auto", "dark", "light", "gtk"];
 
-/// Known valid values for theme.scheme.
-const VALID_THEME_SCHEMES: &[&str] = &["dark", "light"];
+/// Light or dark polarity for the Material You color scheme.
+///
+/// Used as `theme.scheme` in config — omit to auto-derive from wallpaper luminance
+/// when `mode = "auto"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemePolarity {
+    Dark,
+    Light,
+}
 
 /// Known valid values for theme.popover.
 const VALID_POPOVER_MODES: &[&str] = &["dark", "light"];
@@ -251,15 +259,6 @@ impl Config {
             ));
         }
 
-        // Validate theme.scheme
-        if !VALID_THEME_SCHEMES.contains(&self.theme.scheme.as_str()) {
-            errors.push(format!(
-                "theme.scheme: invalid value '{}', expected one of: {}",
-                self.theme.scheme,
-                VALID_THEME_SCHEMES.join(", ")
-            ));
-        }
-
         // Validate theme.popover
         if let Some(ref popover) = self.theme.popover
             && !VALID_POPOVER_MODES.contains(&popover.as_str())
@@ -381,7 +380,7 @@ impl Config {
 
         // Warn about auto-mode-only fields set when mode != "auto"
         if self.theme.mode != "auto" {
-            if self.theme.scheme != "dark" {
+            if self.theme.scheme.is_some() {
                 warnings.push("theme.scheme: has no effect when mode is not \"auto\"".to_string());
             }
             if self.theme.wallpaper.is_some() {
@@ -398,12 +397,18 @@ impl Config {
             );
         }
 
-        // Warn about popover set to the same polarity as the current mode
+        // Warn about popover set to the same polarity as the current mode.
+        // When mode = "auto" and scheme is omitted, the effective polarity depends on
+        // wallpaper luminance which is only known at runtime — skip the warning in that case
+        // to avoid false positives.
         if let Some(ref popover) = self.theme.popover {
             let effective_mode = match self.theme.mode.as_str() {
                 "dark" => Some("dark"),
                 "light" => Some("light"),
-                "auto" => Some(self.theme.scheme.as_str()),
+                "auto" => self.theme.scheme.map(|s| match s {
+                    SchemePolarity::Dark => "dark",
+                    SchemePolarity::Light => "light",
+                }),
                 _ => None,
             };
             if effective_mode == Some(popover.as_str()) {
@@ -1096,8 +1101,13 @@ pub struct ThemeConfig {
 
     /// Material You color scheme polarity: "dark" or "light".
     ///
-    /// Only meaningful when `mode = "auto"`. Default is "dark".
-    pub scheme: String,
+    /// Only meaningful when `mode = "auto"`. When omitted, the polarity is
+    /// automatically derived from the wallpaper's average WCAG relative
+    /// luminance, using the perceptual midpoint (CIELAB L*=50, linear ≈ 0.184)
+    /// as the threshold: bright wallpaper → light scheme, dark wallpaper →
+    /// dark scheme. Set explicitly to override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<SchemePolarity>,
 
     /// Explicit wallpaper image path for auto mode.
     ///
@@ -1162,7 +1172,7 @@ impl Default for ThemeConfig {
         Self {
             // "auto" here; the shipped config.toml overrides to "dark" via deep-merge
             mode: "auto".to_string(),
-            scheme: "dark".to_string(),
+            scheme: None,
             wallpaper: None,
             popover: None,
             accent: None,

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -8,6 +8,7 @@ use material_colors::scheme::Scheme;
 use tracing::warn;
 
 use crate::Config;
+use crate::config::SchemePolarity;
 
 // Overlay opacities: base values for card backgrounds.
 // Dark mode uses lower opacity (0.06) since white overlays on dark are more visible.
@@ -51,6 +52,13 @@ const FOREGROUND_FAINT_OPACITY: f64 = 0.3;
 
 // Toast critical background blend weight
 const TOAST_CRITICAL_URGENT_WEIGHT: f64 = 0.35;
+
+/// Perceptual dark/light boundary in WCAG linear relative luminance.
+///
+/// CIELAB L*=50 (perceptual midpoint) ⇒ Y = ((50+16)/116)³ ≈ 0.184187.
+/// Aligned with Material You's HCT tone axis (CIELAB-derived), which the
+/// rest of the theme pipeline already uses.
+const PERCEPTUAL_LIGHT_DARK_THRESHOLD: f64 = 0.184_187;
 
 // Default colors (based on typical dark/light theme surface colors)
 const DEFAULT_BAR_BG_DARK: &str = "#1a1a1f";
@@ -126,9 +134,29 @@ pub fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
     0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
 }
 
+/// Resolve the effective scheme polarity for `mode = "auto"`.
+///
+/// Returns `true` if light mode should be used. When `scheme` is `None`, derives
+/// polarity from average wallpaper luminance using the perceptual midpoint
+/// threshold (`PERCEPTUAL_LIGHT_DARK_THRESHOLD` ≈ CIELAB L*=50):
+/// `>= threshold` → light, `< threshold` → dark.
+pub(crate) fn effective_scheme(scheme: Option<SchemePolarity>, luminance: Option<f64>) -> bool {
+    match scheme {
+        Some(SchemePolarity::Light) => true,
+        Some(SchemePolarity::Dark) => false,
+        None => luminance
+            .map(|l| l >= PERCEPTUAL_LIGHT_DARK_THRESHOLD)
+            .unwrap_or(false),
+    }
+}
+
 /// Return true if the color is considered dark (low luminance).
+///
+/// Uses the perceptual light/dark midpoint (`PERCEPTUAL_LIGHT_DARK_THRESHOLD`).
+/// Returns `true` for unparseable color strings (conservative fallback — the
+/// caller treats the color as dark and reacts accordingly).
 pub fn is_dark_color(color: &str) -> bool {
-    is_dark_color_with_threshold(color, 0.179)
+    is_dark_color_with_threshold(color, PERCEPTUAL_LIGHT_DARK_THRESHOLD)
 }
 
 /// Return true if the color is considered dark, with custom threshold.
@@ -263,7 +291,7 @@ pub struct SurfaceStyles {
 
 /// Single source of truth for all theme values.
 ///
-/// Constructed via `ThemePalette::from_config(&config, None)`.
+/// Constructed via `ThemePalette::from_config(&config, None, None)`.
 #[derive(Debug, Clone)]
 pub struct ThemePalette {
     // Mode
@@ -368,9 +396,10 @@ impl ThemePalette {
     pub fn from_config(
         config: &Config,
         material_theme: Option<&material_colors::theme::Theme>,
+        luminance: Option<f64>,
     ) -> Self {
         let mut palette = Self::default();
-        palette.parse_config(config, material_theme);
+        palette.parse_config(config, material_theme, luminance);
         palette.compute_derived_values();
         palette
     }
@@ -387,6 +416,7 @@ impl ThemePalette {
     pub fn popover_palette(
         config: &Config,
         material_theme: Option<&material_colors::theme::Theme>,
+        luminance: Option<f64>,
     ) -> Option<Self> {
         let popover_mode = config.theme.popover.as_deref()?;
 
@@ -398,7 +428,7 @@ impl ThemePalette {
         // Check if the popover polarity actually differs from the bar's
         let bar_is_dark = match config.theme.mode.as_str() {
             "light" => false,
-            "auto" => config.theme.scheme != "light",
+            "auto" => !effective_scheme(config.theme.scheme, luminance),
             _ => true,
         };
         if bar_is_dark == (popover_mode == "dark") {
@@ -409,12 +439,20 @@ impl ThemePalette {
         let mut popover_config = config.clone();
 
         if config.theme.mode == "auto" {
-            popover_config.theme.scheme = popover_mode.to_string();
+            popover_config.theme.scheme = Some(if popover_mode == "light" {
+                SchemePolarity::Light
+            } else {
+                SchemePolarity::Dark
+            });
         } else {
             popover_config.theme.mode = popover_mode.to_string();
         }
 
-        Some(Self::from_config(&popover_config, material_theme))
+        Some(Self::from_config(
+            &popover_config,
+            material_theme,
+            luminance,
+        ))
     }
 
     /// Generate CSS variable overrides scoped to `.vp-surface-popover`.
@@ -802,6 +840,7 @@ impl ThemePalette {
         &mut self,
         config: &Config,
         material_theme: Option<&material_colors::theme::Theme>,
+        luminance: Option<f64>,
     ) {
         // Check if GTK mode is requested
         self.is_gtk_mode = config.theme.mode == "gtk";
@@ -819,7 +858,7 @@ impl ThemePalette {
         // since it sets backgrounds, foregrounds, accent, and state colors directly.
         if config.theme.mode == "auto" {
             if let Some(theme) = material_theme {
-                let is_light = config.theme.scheme == "light";
+                let is_light = effective_scheme(config.theme.scheme, luminance);
                 let scheme = if is_light {
                     &theme.schemes.light
                 } else {
@@ -843,18 +882,31 @@ impl ThemePalette {
                 // Apply full Material You palette
                 self.apply_wallpaper_theme(scheme, config);
             } else {
-                warn!("Auto mode: no wallpaper theme provided, falling back to dark defaults");
-                self.is_dark_mode = true;
-                self.bar_background = config
-                    .bar
-                    .background_color
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_BAR_BG_DARK.to_string());
-                self.widget_background = config
-                    .widgets
-                    .background_color
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_WIDGET_BG_DARK.to_string());
+                // No material theme available (extraction failed or was skipped).
+                // Still honour config.theme.scheme and derived luminance so that an
+                // explicit `scheme = "light"` or a bright wallpaper that failed
+                // colour-extraction doesn't silently fall back to dark mode.
+                let is_light = effective_scheme(config.theme.scheme, luminance);
+                warn!(
+                    "Auto mode: no wallpaper theme provided, falling back to {} defaults",
+                    if is_light { "light" } else { "dark" }
+                );
+                self.is_dark_mode = !is_light;
+                self.bar_background = config.bar.background_color.clone().unwrap_or_else(|| {
+                    if is_light {
+                        DEFAULT_BAR_BG_LIGHT.to_string()
+                    } else {
+                        DEFAULT_BAR_BG_DARK.to_string()
+                    }
+                });
+                self.widget_background =
+                    config.widgets.background_color.clone().unwrap_or_else(|| {
+                        if is_light {
+                            DEFAULT_WIDGET_BG_LIGHT.to_string()
+                        } else {
+                            DEFAULT_WIDGET_BG_DARK.to_string()
+                        }
+                    });
 
                 self.accent_source = AccentSource::Custom("#adabe0".to_string());
                 self.accent_primary = "#adabe0".to_string();
@@ -1411,6 +1463,31 @@ mod tests {
     }
 
     #[test]
+    fn test_is_dark_color_boundary_near_perceptual_midpoint() {
+        // Concept-anchored: pin the semantics, not the literal value.
+        // Colors whose linear luminance sits just below the perceptual midpoint
+        // (≈0.184187) should read as dark; just above should read as light.
+        //
+        // Mid-grey #757575 has linear luminance ≈ 0.1779 (below threshold).
+        // Mid-grey #787878 has linear luminance ≈ 0.1878 (above threshold).
+        assert!(
+            is_dark_color("#757575"),
+            "#757575 sits below the perceptual midpoint and should read as dark"
+        );
+        assert!(
+            !is_dark_color("#787878"),
+            "#787878 sits above the perceptual midpoint and should read as light"
+        );
+    }
+
+    #[test]
+    fn test_is_dark_color_unparseable_falls_back_to_dark() {
+        // Documented fallback: unparseable color strings are treated as dark.
+        assert!(is_dark_color("not a color"));
+        assert!(is_dark_color(""));
+    }
+
+    #[test]
     fn test_blend_colors() {
         // 50/50 blend of black and white should be gray
         let result = blend_colors("#000000", "#ffffff", 0.5);
@@ -1438,7 +1515,7 @@ mod tests {
     fn test_theme_palette_default_is_dark() {
         let mut config = Config::default();
         config.theme.mode = "dark".to_string();
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
         assert!(palette.is_dark_mode);
     }
 
@@ -1446,7 +1523,7 @@ mod tests {
     fn test_theme_palette_light_mode() {
         let mut config = Config::default();
         config.theme.mode = "light".to_string();
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
         assert!(!palette.is_dark_mode);
         assert_eq!(palette.foreground_primary, "#1a1a1a");
     }
@@ -1454,7 +1531,7 @@ mod tests {
     #[test]
     fn test_theme_palette_css_vars_contains_expected_vars() {
         let config = Config::default();
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
         let css = palette.css_vars_block();
 
         assert!(css.contains("--color-background-bar:"));
@@ -1541,7 +1618,7 @@ mod tests {
         let mut config = Config::default();
         config.bar.size = 48;
         // bar_height is the content height (bar.size), CSS padding adds the visual padding
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.sizes.bar_height, 48);
         assert!(palette.sizes.widget_height > 0);
@@ -1553,7 +1630,7 @@ mod tests {
         // Default accent = None with mode = "dark" means use "#adabe0" as custom hex color
         let mut config = Config::default();
         config.theme.mode = "dark".to_string();
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1568,7 +1645,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         // accent remains None
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.accent_source, AccentSource::Gtk);
         // Verify derived values for GTK accent in GTK mode
@@ -1594,7 +1671,7 @@ mod tests {
         config.theme.mode = "dark".to_string();
         config.theme.accent = Some("#ff0000".to_string());
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1613,7 +1690,7 @@ mod tests {
         config.theme.mode = "dark".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         // In dark mode, monochrome uses foreground color
@@ -1627,7 +1704,7 @@ mod tests {
         config.theme.mode = "light".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         // In light mode, monochrome uses foreground color
@@ -1640,7 +1717,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert!(palette.is_gtk_mode);
         // is_dark_mode remains true as a fallback for shadow opacity etc.
@@ -1652,7 +1729,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.foreground_primary, "@window_fg_color");
         // Verify exact computed value to catch arithmetic bugs
@@ -1677,7 +1754,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
         let css = palette.css_vars_block();
 
         // Foreground should reference GTK theme color
@@ -1704,7 +1781,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         // Borders
         assert!(
@@ -1767,7 +1844,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.accent = Some("none".to_string());
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(palette.accent_source, AccentSource::None);
         assert!(
@@ -1787,13 +1864,13 @@ mod tests {
         // Verify that dark/light modes still use hardcoded colors (no regression)
         let mut dark_config = Config::default();
         dark_config.theme.mode = "dark".to_string();
-        let dark = ThemePalette::from_config(&dark_config, None);
+        let dark = ThemePalette::from_config(&dark_config, None, None);
         assert_eq!(dark.foreground_primary, "#ffffff");
         assert!(!dark.foreground_muted.contains("@window_fg_color"));
 
         let mut light_config = Config::default();
         light_config.theme.mode = "light".to_string();
-        let light = ThemePalette::from_config(&light_config, None);
+        let light = ThemePalette::from_config(&light_config, None, None);
         assert_eq!(light.foreground_primary, "#1a1a1a");
         assert!(!light.foreground_muted.contains("@window_fg_color"));
     }
@@ -1806,7 +1883,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.shadows = false;
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert!(
             palette.border_subtle.contains("@window_fg_color"),
@@ -1825,7 +1902,7 @@ mod tests {
         config.theme.mode = "gtk".to_string();
         config.theme.accent = Some("#ff0000".to_string());
 
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert_eq!(
             palette.accent_source,
@@ -1845,11 +1922,11 @@ mod tests {
         // Test that sizes scale up proportionally with bar size
         let mut config_small = Config::default();
         config_small.bar.size = 24;
-        let palette_small = ThemePalette::from_config(&config_small, None);
+        let palette_small = ThemePalette::from_config(&config_small, None, None);
 
         let mut config_large = Config::default();
         config_large.bar.size = 48;
-        let palette_large = ThemePalette::from_config(&config_large, None);
+        let palette_large = ThemePalette::from_config(&config_large, None, None);
 
         // Larger bar should have proportionally larger sizes
         assert!(palette_large.sizes.widget_height > palette_small.sizes.widget_height);
@@ -1865,7 +1942,7 @@ mod tests {
         for bar_size in [36, 48, 60, 72] {
             let mut config = Config::default();
             config.bar.size = bar_size;
-            let palette = ThemePalette::from_config(&config, None);
+            let palette = ThemePalette::from_config(&config, None, None);
 
             // widget_height + 2*padding + 2*margin = widget_height + 4*widget_padding_y
             let total_widget_footprint =
@@ -1887,7 +1964,7 @@ mod tests {
         // Even with small bar, sizes should have sensible minimums
         let mut config = Config::default();
         config.bar.size = 16; // Very small bar
-        let palette = ThemePalette::from_config(&config, None);
+        let palette = ThemePalette::from_config(&config, None, None);
 
         assert!(
             palette.sizes.widget_padding_y >= 1,
@@ -1906,7 +1983,7 @@ mod tests {
             let mut config = Config::default();
             config.bar.size = bar_size;
             config.bar.border_radius = 100; // Request maximum radius
-            let palette = ThemePalette::from_config(&config, None);
+            let palette = ThemePalette::from_config(&config, None, None);
 
             // Bar radius is computed from rendered height (bar_size + 2*padding config)
             // With default padding=4, max radius = (bar_size + 8) / 2
@@ -1938,7 +2015,7 @@ mod tests {
     #[test]
     fn test_popover_palette_none_when_not_configured() {
         let config = Config::default(); // popover = None
-        assert!(ThemePalette::popover_palette(&config, None).is_none());
+        assert!(ThemePalette::popover_palette(&config, None, None).is_none());
     }
 
     #[test]
@@ -1946,7 +2023,7 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "gtk".to_string();
         config.theme.popover = Some("light".to_string());
-        assert!(ThemePalette::popover_palette(&config, None).is_none());
+        assert!(ThemePalette::popover_palette(&config, None, None).is_none());
     }
 
     #[test]
@@ -1955,12 +2032,12 @@ mod tests {
         let mut config = Config::default();
         config.theme.mode = "dark".to_string();
         config.theme.popover = Some("dark".to_string());
-        assert!(ThemePalette::popover_palette(&config, None).is_none());
+        assert!(ThemePalette::popover_palette(&config, None, None).is_none());
 
         // Light mode with light popover = no-op
         config.theme.mode = "light".to_string();
         config.theme.popover = Some("light".to_string());
-        assert!(ThemePalette::popover_palette(&config, None).is_none());
+        assert!(ThemePalette::popover_palette(&config, None, None).is_none());
     }
 
     #[test]
@@ -1969,13 +2046,13 @@ mod tests {
         config.theme.mode = "dark".to_string();
         config.theme.popover = Some("light".to_string());
 
-        let popover = ThemePalette::popover_palette(&config, None);
+        let popover = ThemePalette::popover_palette(&config, None, None);
         assert!(popover.is_some(), "should produce a light popover palette");
         let popover = popover.unwrap();
         assert!(!popover.is_dark_mode, "popover should be light mode");
 
         // Bar palette should be dark
-        let bar = ThemePalette::from_config(&config, None);
+        let bar = ThemePalette::from_config(&config, None, None);
         assert!(bar.is_dark_mode, "bar should be dark mode");
     }
 
@@ -1985,13 +2062,13 @@ mod tests {
         config.theme.mode = "light".to_string();
         config.theme.popover = Some("dark".to_string());
 
-        let popover = ThemePalette::popover_palette(&config, None);
+        let popover = ThemePalette::popover_palette(&config, None, None);
         assert!(popover.is_some(), "should produce a dark popover palette");
         let popover = popover.unwrap();
         assert!(popover.is_dark_mode, "popover should be dark mode");
 
         // Bar palette should be light
-        let bar = ThemePalette::from_config(&config, None);
+        let bar = ThemePalette::from_config(&config, None, None);
         assert!(!bar.is_dark_mode, "bar should be light mode");
     }
 
@@ -2005,10 +2082,10 @@ mod tests {
 
         let mut config = Config::default();
         config.theme.mode = "auto".to_string();
-        config.theme.scheme = "dark".to_string();
+        config.theme.scheme = Some(SchemePolarity::Dark);
         config.theme.popover = Some("light".to_string());
 
-        let popover = ThemePalette::popover_palette(&config, Some(&material_theme));
+        let popover = ThemePalette::popover_palette(&config, Some(&material_theme), None);
         assert!(
             popover.is_some(),
             "auto mode should produce popover palette"
@@ -2019,7 +2096,7 @@ mod tests {
             "popover should be light (scheme flipped)"
         );
 
-        let bar = ThemePalette::from_config(&config, Some(&material_theme));
+        let bar = ThemePalette::from_config(&config, Some(&material_theme), None);
         assert!(bar.is_dark_mode, "bar should be dark (scheme=dark)");
     }
 
@@ -2029,7 +2106,7 @@ mod tests {
         config.theme.mode = "dark".to_string();
         config.theme.popover = Some("light".to_string());
 
-        let popover = ThemePalette::popover_palette(&config, None).unwrap();
+        let popover = ThemePalette::popover_palette(&config, None, None).unwrap();
         let css = popover.css_popover_vars_block();
 
         // Should be scoped under .vp-surface-popover
@@ -2051,5 +2128,122 @@ mod tests {
         assert!(!css.contains("--font-size:"));
         assert!(!css.contains("--spacing:"));
         assert!(!css.contains("--border-radius:"));
+    }
+
+    // -------------------------------------------------------------------------
+    // effective_scheme() tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_effective_scheme_explicit_light_wins_regardless_of_luminance() {
+        // Explicit light override — luminance is dark but scheme wins
+        assert!(effective_scheme(
+            Some(crate::config::SchemePolarity::Light),
+            Some(0.1)
+        ));
+    }
+
+    #[test]
+    fn test_effective_scheme_explicit_dark_wins_regardless_of_luminance() {
+        // Explicit dark override — luminance is bright but scheme wins
+        assert!(!effective_scheme(
+            Some(crate::config::SchemePolarity::Dark),
+            Some(0.9)
+        ));
+    }
+
+    #[test]
+    fn test_effective_scheme_none_derives_light_from_high_luminance() {
+        // No override — luminance >= perceptual midpoint → light
+        assert!(effective_scheme(None, Some(0.7)));
+    }
+
+    #[test]
+    fn test_effective_scheme_none_derives_dark_from_low_luminance() {
+        // No override — luminance < perceptual midpoint → dark
+        assert!(!effective_scheme(None, Some(0.1)));
+    }
+
+    #[test]
+    fn test_effective_scheme_boundary_at_threshold_is_light() {
+        // Boundary: exactly at threshold → light (>= rule)
+        assert!(effective_scheme(
+            None,
+            Some(PERCEPTUAL_LIGHT_DARK_THRESHOLD)
+        ));
+    }
+
+    #[test]
+    fn test_effective_scheme_just_below_boundary_is_dark() {
+        // Just below threshold → dark
+        assert!(!effective_scheme(
+            None,
+            Some(PERCEPTUAL_LIGHT_DARK_THRESHOLD - 0.001)
+        ));
+    }
+
+    #[test]
+    fn test_effective_scheme_no_luminance_falls_back_to_dark() {
+        // No override, no luminance → fallback dark
+        assert!(!effective_scheme(None, None));
+    }
+
+    #[test]
+    fn test_from_config_auto_mode_derives_light_from_high_luminance() {
+        use material_colors::theme::ThemeBuilder;
+
+        // Build a real Material You theme so the auto branch has schemes to select from
+        let source_color = Argb::new(255, 53, 132, 228); // blue-ish
+        let material_theme = ThemeBuilder::with_source(source_color).build();
+
+        let mut config = Config::default();
+        config.theme.mode = "auto".to_string();
+        config.theme.scheme = None; // rely on luminance auto-derivation
+
+        // High luminance (0.8) → light scheme → is_dark_mode should be false
+        let palette = ThemePalette::from_config(&config, Some(&material_theme), Some(0.8));
+        assert!(
+            !palette.is_dark_mode,
+            "high luminance wallpaper should auto-select light scheme"
+        );
+
+        // Low luminance (0.1) → dark scheme → is_dark_mode should be true
+        let palette = ThemePalette::from_config(&config, Some(&material_theme), Some(0.1));
+        assert!(
+            palette.is_dark_mode,
+            "low luminance wallpaper should auto-select dark scheme"
+        );
+    }
+
+    #[test]
+    fn test_auto_mode_fallback_respects_scheme_and_luminance_when_no_material_theme() {
+        // material_theme = None simulates wallpaper extraction failure.
+        // effective_scheme should still be consulted for the fallback branch.
+
+        let mut config = Config::default();
+        config.theme.mode = "auto".to_string();
+
+        // Explicit scheme = Light → light fallback, even with no material theme
+        config.theme.scheme = Some(SchemePolarity::Light);
+        let palette = ThemePalette::from_config(&config, None, None);
+        assert!(
+            !palette.is_dark_mode,
+            "explicit scheme=light should produce light fallback when material_theme is None"
+        );
+
+        // High luminance + no explicit scheme → light fallback
+        config.theme.scheme = None;
+        let palette = ThemePalette::from_config(&config, None, Some(0.8));
+        assert!(
+            !palette.is_dark_mode,
+            "high luminance should produce light fallback when material_theme is None"
+        );
+
+        // Low luminance + no explicit scheme → dark fallback
+        let palette = ThemePalette::from_config(&config, None, Some(0.1));
+        assert!(
+            palette.is_dark_mode,
+            "low luminance should produce dark fallback when material_theme is None"
+        );
     }
 }

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -123,6 +123,9 @@ pub struct ConfigManager {
     /// `material_colors::theme::Theme` from the source color is cheap (pure math);
     /// the expensive part is image I/O + quantization, which this cache avoids.
     cached_source_color: Cell<Option<material_colors::color::Argb>>,
+    /// Average relative luminance of the last extracted wallpaper image (0.0–1.0).
+    /// Used to auto-derive light/dark polarity when `theme.scheme` is not set.
+    cached_luminance: Cell<Option<f64>>,
     /// Source ID for the wallpaper polling timer (so we can cancel it).
     wallpaper_poll_source: RefCell<Option<glib::SourceId>>,
     /// Guard against overlapping wallpaper polls (IPC + image processing is async).
@@ -138,26 +141,32 @@ impl ConfigManager {
     fn new(config: Config, config_path: Option<PathBuf>) -> Rc<Self> {
         // Detect wallpaper and extract Material You theme if in auto mode
         let monitor_hint = config.bar.outputs.first().map(|s| s.as_str());
-        let (initial_wallpaper, material_theme) =
+        let (initial_wallpaper, material_theme, initial_luminance) =
             if config.theme.mode == "auto" && config.theme.wallpaper.is_none() {
                 let wp = detect_wallpaper(monitor_hint);
-                let theme = wp.as_deref().and_then(extract_theme_from_image);
-                (wp, theme)
+                let result = wp.as_deref().and_then(extract_theme_from_image);
+                let luminance = result.as_ref().map(|(_, l)| *l);
+                let theme = result.and_then(|(t, _)| t);
+                (wp, theme, luminance)
             } else if config.theme.mode == "auto" {
                 // Explicit wallpaper path set
-                let theme = config
+                let result = config
                     .theme
                     .wallpaper
                     .as_deref()
                     .and_then(extract_theme_from_image);
-                (None, theme)
+                let luminance = result.as_ref().map(|(_, l)| *l);
+                let theme = result.and_then(|(t, _)| t);
+                (None, theme, luminance)
             } else {
-                (None, None)
+                (None, None, None)
             };
 
         let source_color = material_theme.as_ref().map(|t| t.source);
-        let palette = ThemePalette::from_config(&config, material_theme.as_ref());
-        let popover_palette = ThemePalette::popover_palette(&config, material_theme.as_ref());
+        let palette =
+            ThemePalette::from_config(&config, material_theme.as_ref(), initial_luminance);
+        let popover_palette =
+            ThemePalette::popover_palette(&config, material_theme.as_ref(), initial_luminance);
 
         Rc::new(Self {
             config: RefCell::new(config),
@@ -168,6 +177,7 @@ impl ConfigManager {
             theme_callbacks: Callbacks::new(),
             wallpaper_path: RefCell::new(initial_wallpaper),
             cached_source_color: Cell::new(source_color),
+            cached_luminance: Cell::new(initial_luminance),
             wallpaper_poll_source: RefCell::new(None),
             poll_in_progress: Cell::new(false),
         })
@@ -664,14 +674,17 @@ impl ConfigManager {
                     || old_config.theme.wallpaper != new_config.theme.wallpaper;
 
                 if wallpaper_source_changed {
-                    let theme = new_config
+                    let result = new_config
                         .theme
                         .wallpaper
                         .as_deref()
                         .or(self.wallpaper_path.borrow().as_deref())
                         .and_then(extract_theme_from_image);
+                    let luminance = result.as_ref().map(|(_, l)| *l);
+                    let theme = result.and_then(|(t, _)| t);
                     self.cached_source_color
                         .set(theme.as_ref().map(|t| t.source));
+                    self.cached_luminance.set(luminance);
                     theme
                 } else {
                     self.cached_source_color.get().map(theme_from_source_color)
@@ -680,10 +693,12 @@ impl ConfigManager {
                 None
             };
 
+            let luminance = self.cached_luminance.get();
             // Rebuild the cached palette once
-            let palette = ThemePalette::from_config(&new_config, material_theme.as_ref());
+            let palette =
+                ThemePalette::from_config(&new_config, material_theme.as_ref(), luminance);
             let popover_palette =
-                ThemePalette::popover_palette(&new_config, material_theme.as_ref());
+                ThemePalette::popover_palette(&new_config, material_theme.as_ref(), luminance);
             let surface_styles = palette.surface_styles();
 
             // Update surface style manager
@@ -808,7 +823,9 @@ impl ConfigManager {
             );
 
             // Heavy work: image I/O + quantization on background thread
-            let material_theme = new_path.as_deref().and_then(extract_theme_from_image);
+            let result = new_path.as_deref().and_then(extract_theme_from_image);
+            let new_luminance = result.as_ref().map(|(_, l)| *l);
+            let material_theme = result.and_then(|(t, _)| t);
             let source_color = material_theme.as_ref().map(|t| t.source);
 
             // Palette construction uses live config on the main thread
@@ -826,10 +843,12 @@ impl ConfigManager {
 
                 *mgr.wallpaper_path.borrow_mut() = new_path;
                 mgr.cached_source_color.set(source_color);
+                mgr.cached_luminance.set(new_luminance);
 
-                let palette = ThemePalette::from_config(&config, material_theme.as_ref());
+                let palette =
+                    ThemePalette::from_config(&config, material_theme.as_ref(), new_luminance);
                 let popover_palette =
-                    ThemePalette::popover_palette(&config, material_theme.as_ref());
+                    ThemePalette::popover_palette(&config, material_theme.as_ref(), new_luminance);
                 let surface_styles = palette.surface_styles();
 
                 SurfaceStyleManager::global()

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -72,7 +72,7 @@ impl SurfaceStyleManager {
     ///
     /// Should be called during application startup after loading config:
     /// ```ignore
-    /// let palette = ThemePalette::from_config(&config);
+    /// let palette = ThemePalette::from_config(&config, None, None);
     /// SurfaceStyleManager::init_global(palette.surface_styles());
     /// ```
     #[allow(dead_code)]
@@ -84,7 +84,7 @@ impl SurfaceStyleManager {
     ///
     /// Should be called during application startup after loading config:
     /// ```ignore
-    /// let palette = ThemePalette::from_config(&config);
+    /// let palette = ThemePalette::from_config(&config, None, None);
     /// SurfaceStyleManager::init_global_with_config(
     ///     palette.surface_styles(),
     ///     config.advanced.pango_font_rendering,

--- a/crates/vibepanel/src/services/tooltip.rs
+++ b/crates/vibepanel/src/services/tooltip.rs
@@ -242,7 +242,7 @@ impl TooltipManager {
     ///
     /// Should be called during application startup after loading config:
     /// ```ignore
-    /// let palette = ThemePalette::from_config(&config);
+    /// let palette = ThemePalette::from_config(&config, None, None);
     /// TooltipManager::init_global(palette.surface_styles());
     /// ```
     pub fn init_global(styles: SurfaceStyles) {

--- a/crates/vibepanel/src/services/wallpaper.rs
+++ b/crates/vibepanel/src/services/wallpaper.rs
@@ -15,7 +15,7 @@ use material_colors::quantize::{Quantizer, QuantizerCelebi};
 use material_colors::score::Score;
 use material_colors::theme::ThemeBuilder;
 use tracing::{debug, warn};
-use vibepanel_core::expand_tilde;
+use vibepanel_core::{expand_tilde, theme::relative_luminance};
 
 /// Reject wallpaper images larger than this to avoid excessive memory use.
 const MAX_WALLPAPER_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
@@ -244,11 +244,20 @@ pub fn theme_from_source_color(source: Argb) -> material_colors::theme::Theme {
     ThemeBuilder::with_source(source).build()
 }
 
-/// Extract a Material You theme from a wallpaper image.
+/// Extract a Material You theme and average relative luminance from a wallpaper image.
 ///
-/// Returns the full `Theme` (with light/dark schemes, tonal palettes, and source color)
-/// using the default Material variant, or `None` on failure.
-pub fn extract_theme_from_image(path: &str) -> Option<material_colors::theme::Theme> {
+/// Returns `(Theme, luminance)` where:
+/// - `Theme` has light/dark schemes, tonal palettes, and source color
+/// - `luminance` is the average relative luminance of the image (0.0 = black, 1.0 = white),
+///   used to auto-derive the light/dark scheme polarity when `scheme` is not set in config.
+///
+/// Returns `None` on failure (file too large, I/O error, decode error).
+/// On success, the inner `Option<Theme>` is `None` when no high-chroma colour
+/// survived quantisation (e.g. a fully-greyscale wallpaper), but luminance is
+/// still returned so auto-scheme derivation works correctly in that case.
+pub fn extract_theme_from_image(
+    path: &str,
+) -> Option<(Option<material_colors::theme::Theme>, f64)> {
     let file_size = std::fs::metadata(path)
         .inspect_err(|e| warn!("Failed to stat wallpaper '{}': {}", path, e))
         .ok()?
@@ -282,20 +291,72 @@ pub fn extract_theme_from_image(path: &str) -> Option<material_colors::theme::Th
         .filter(|argb| argb.alpha == 255)
         .collect();
 
+    // Compute average relative luminance from all opaque pixels for scheme auto-derivation.
+    // Uses the same pixel buffer already loaded for color extraction — no extra I/O.
+    let luminance = if pixels.is_empty() {
+        0.0
+    } else {
+        let total: f64 = pixels
+            .iter()
+            .map(|argb| relative_luminance(argb.red, argb.green, argb.blue))
+            .sum();
+        total / pixels.len() as f64
+    };
+
     let mut result = QuantizerCelebi::quantize(&pixels, 128);
     result
         .color_to_count
         .retain(|&argb, _| Cam16::from(argb).chroma >= 5.0);
 
     let ranked = Score::score(&result.color_to_count, None, None, None);
-    let source_color = *ranked.first()?;
+    let theme = ranked
+        .first()
+        .map(|&source_color| ThemeBuilder::with_source(source_color).build());
 
-    Some(ThemeBuilder::with_source(source_color).build())
+    Some((theme, luminance))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test: a fully-greyscale wallpaper has no high-chroma colours,
+    /// so after the chroma retain filter `color_to_count` is empty. Before the
+    /// fix in `09a36d7`, the `?` on `ranked.first()` caused the whole function
+    /// to return `None`, silently discarding the luminance that had already been
+    /// computed and forcing auto mode to dark regardless of actual brightness.
+    ///
+    /// After the fix the outer `Option` reflects decode success/failure only;
+    /// luminance is always returned when image decode succeeds.
+    #[test]
+    fn test_extract_theme_grayscale_preserves_luminance() {
+        use image::{GrayImage, ImageFormat};
+        use std::io::Cursor;
+
+        // 4×4 mid-gray image — all pixels have chroma ≈ 0, well below the 5.0
+        // retain threshold, so the quantiser colour map will be empty or
+        // produce only Score's built-in fallback colour.
+        let img = GrayImage::from_pixel(4, 4, image::Luma([128u8]));
+        let mut buf = Cursor::new(Vec::new());
+        img.write_to(&mut buf, ImageFormat::Png)
+            .expect("failed to encode test PNG");
+
+        let path = std::env::temp_dir().join("vibepanel_test_grayscale.png");
+        std::fs::write(&path, buf.into_inner()).expect("write tempfile");
+
+        let result = extract_theme_from_image(path.to_str().expect("valid utf-8 path"));
+        let _ = std::fs::remove_file(&path);
+
+        // The outer Option must be Some — a valid image is not a decode failure.
+        // Before the fix this returned None, discarding luminance entirely.
+        let (_theme, luminance) = result.expect("extraction must succeed for a valid image");
+
+        // Luminance must be in (0, 1) — mid-gray luma 128 gives ~0.216.
+        assert!(
+            luminance > 0.0 && luminance < 1.0,
+            "luminance should be in (0, 1), got {luminance}"
+        );
+    }
 
     #[test]
     fn test_extract_awww_image_path_standard() {


### PR DESCRIPTION
When `mode = "auto"` and no explicit `scheme` it's now derived from the wallpapers relative luminance. The threshold is the [CIELAB](https://wikipedia.org/wiki/CIELAB) perceptual midpoint (linear ≈ 0.184) not the linear midpoint (0.5). 

Fixes #104 

