### PR TITLE
feat(blur): add wayland ext-background-effect blur support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +571,9 @@ dependencies = [
  "gio",
  "glib",
  "libc",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
 ]
 
 [[package]]
@@ -1524,6 +1536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2085,7 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -2112,6 +2131,8 @@ version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
+ "dlib",
+ "log",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ chrono = "0.4"
 gtk4 = { version = "0.10", features = ["v4_12"] }
 pango = { version = "0.21", features = ["v1_56"] }
 gtk4-layer-shell = "0.7"
-gdk4-wayland = "0.10"
+gdk4-wayland = { version = "0.10", features = ["wayland_crate"] }
 wayland-client = "0.31"
 wayland-backend = "0.3"
-wayland-protocols = { version = "0.32", features = ["client"] }
+wayland-protocols = { version = "0.32", features = ["client", "staging"] }
 wayland-scanner = "0.31"
 
 # File watching

--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,7 @@ mode = "dark" # "auto", "dark", "light", "gtk"
 #accent = "#adabe0" # "gtk", "none", or hex color (overrides wallpaper accent in auto mode)
 #animations = true  # Enable/disable all CSS transitions and animations
 #ripple = true      # Enable/disable Material Design ripple effect on click
+#blur = false       # Enable compositor blur via ext-background-effect-v1 (requires niri with blur)
 
 [theme.icons]
 theme = "material" # "material" or "gtk"

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -1157,6 +1157,20 @@ pub struct ThemeConfig {
     /// Default: true
     pub shadows: bool,
 
+    /// Enable compositor background blur via ext-background-effect-v1.
+    ///
+    /// When true, vibepanel sends blur region hints to the compositor for
+    /// popovers, quick settings, and the bar. Requires a compositor that
+    /// supports the ext-background-effect-v1 protocol (e.g. niri with blur
+    /// enabled). Has no effect on compositors that do not support the protocol.
+    ///
+    /// For the bar: if bar.background_opacity > 0, the entire bar surface is
+    /// blurred. If bar.background_opacity == 0 (transparent/islands mode),
+    /// individual widget island regions are blurred instead.
+    ///
+    /// Default: false
+    pub blur: bool,
+
     /// State colors (success, warning, urgent).
     pub states: ThemeStates,
 
@@ -1179,6 +1193,7 @@ impl Default for ThemeConfig {
             animations: true,
             ripple: true,
             shadows: true,
+            blur: false,
             states: ThemeStates::default(),
             typography: ThemeTypography::default(),
             icons: ThemeIconsConfig::default(),

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -1160,11 +1160,12 @@ pub struct ThemeConfig {
     /// Enable compositor background blur via ext-background-effect-v1.
     ///
     /// When true, vibepanel sends blur region hints to the compositor for
-    /// popovers, quick settings, notification toasts, OSD, and the bar. Requires a compositor that
+    /// the bar, popovers, quick settings, OSD, notification toasts, tray menus,
+    /// and the media pop-out window. Requires a compositor that
     /// supports the ext-background-effect-v1 protocol (e.g. niri with blur
     /// enabled). Has no effect on compositors that do not support the protocol.
     ///
-    /// For the bar: if bar.background_opacity > 0, the entire bar surface is
+    /// For the bar: if bar.background_opacity > 0, the visible bar background region is
     /// blurred. If bar.background_opacity == 0 (transparent/islands mode),
     /// individual widget island regions are blurred instead.
     ///

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -1160,7 +1160,7 @@ pub struct ThemeConfig {
     /// Enable compositor background blur via ext-background-effect-v1.
     ///
     /// When true, vibepanel sends blur region hints to the compositor for
-    /// popovers, quick settings, and the bar. Requires a compositor that
+    /// popovers, quick settings, notification toasts, OSD, and the bar. Requires a compositor that
     /// supports the ext-background-effect-v1 protocol (e.g. niri with blur
     /// enabled). Has no effect on compositors that do not support the protocol.
     ///

--- a/crates/vibepanel/Cargo.toml
+++ b/crates/vibepanel/Cargo.toml
@@ -49,6 +49,3 @@ cargo-husky = { version = "1.5.0", default-features = false, features = [
     "run-cargo-fmt",
 ] }
 toml = { workspace = true }
-
-[build-dependencies]
-wayland-scanner = { workspace = true }

--- a/crates/vibepanel/build.rs
+++ b/crates/vibepanel/build.rs
@@ -1,0 +1,22 @@
+// Ensure gtk4-layer-shell is linked before libwayland-client.
+//
+// gtk4-layer-shell works by shimming libwayland-client symbols (it defines
+// the same symbols and intercepts calls GTK makes to libwayland). For this
+// to work, libgtk4-layer-shell.so must be loaded by the dynamic linker
+// BEFORE libwayland-client.so.
+//
+// Enabling the `wayland_crate` feature on gdk4-wayland adds wayland-client
+// as a direct dependency, which can cause the linker to place
+// libwayland-client.so before libgtk4-layer-shell.so in the binary. This
+// build script forces the correct order by emitting an early link directive.
+//
+// See: https://github.com/wmww/gtk4-layer-shell/blob/main/linking.md
+
+fn main() {
+    // Force gtk4-layer-shell to appear first in the link order.
+    // The `+whole-archive` / `-whole-archive` trick isn't needed here —
+    // we just need the library to be listed before libwayland-client in
+    // the linker command line. Emitting it from the top-level crate's
+    // build script ensures it comes first.
+    println!("cargo:rustc-link-lib=dylib=gtk4-layer-shell");
+}

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -192,12 +192,32 @@ pub fn create_bar_window(
 
         // Apply bar blur region on map (opaque/translucent bar path).
         // The islands path is handled by the layout allocate callback below.
-        if !is_island_mode
-            && ConfigManager::global().blur_enabled()
-            && let Some(blur) =
+        //
+        // Island mode: allocation applies active blur regions. If blur was
+        // disabled while unmapped, clean up the stale protocol object now that
+        // the wl_surface is resolvable again.
+        //
+        // Opaque/translucent mode: apply blur on map.  The else-branch
+        // removes any stale protocol object left from a previous map cycle
+        // (blur enabled on last show, then disabled while bars were hidden).
+        // `remove_blur_region` is idempotent (no-op when no effect exists).
+        if is_island_mode {
+            if !ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.remove_blur_region(win);
+            }
+        } else if ConfigManager::global().blur_enabled() {
+            if let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.apply_bar_blur_region(win, &bar_box_for_blur);
+            }
+        } else if let Some(blur) =
+            crate::services::background_effect::BackgroundEffectManager::global()
         {
-            blur.apply_bar_blur_region(win, &bar_box_for_blur);
+            blur.remove_blur_region(win);
         }
     });
 
@@ -208,26 +228,98 @@ pub fn create_bar_window(
     //
     // We also keep a shared clone of the island-apply closure so the theme-change
     // hot-reload handler can trigger an immediate re-apply when blur is toggled on.
+    //
+    // `prev_bounds` caches the last-applied island bounds to skip redundant
+    // Wayland protocol traffic.  It is hoisted here (rather than inside the
+    // closure) so the theme-change handler can clear it when blur is toggled off
+    // — otherwise the stale cache would short-circuit the next apply.
+    let prev_bounds = Rc::new(RefCell::new(Vec::<(i32, i32, i32, i32)>::new()));
+    // Clone for the theme-change handler so it can invalidate the cache on any
+    // theme change (the original `prev_bounds` is moved into the island closure).
+    let prev_bounds_for_theme = Rc::clone(&prev_bounds);
+
     let island_apply: Option<Rc<dyn Fn()>> = if is_island_mode {
         let win_weak = window.downgrade();
-        let bar_box_clone = bar_box.clone();
+        let bar_box_weak = bar_box.downgrade();
         let closure: Rc<dyn Fn()> = Rc::new(move || {
             if !ConfigManager::global().blur_enabled() {
+                // Clean up any stale blur effect left from before blur was
+                // disabled (e.g. ipc_hide -> blur-off -> ipc_show).
+                // Only do this once: if prev_bounds is already empty we've
+                // either already cleaned up or never had blur applied.
+                if !prev_bounds.borrow().is_empty() {
+                    prev_bounds.borrow_mut().clear();
+                    // Defer the remove out of the GTK allocate pass: it calls
+                    // wl_surface.commit() synchronously, and we'd rather not
+                    // do that mid-layout.  Re-check guard inside idle in case
+                    // a subsequent allocate flipped state back.
+                    let win_weak_idle = win_weak.clone();
+                    let prev_bounds_idle = Rc::clone(&prev_bounds);
+                    gtk4::glib::idle_add_local_once(move || {
+                        if !prev_bounds_idle.borrow().is_empty() {
+                            return;
+                        }
+                        if ConfigManager::global().blur_enabled() {
+                            return;
+                        }
+                        if let Some(win) = win_weak_idle.upgrade()
+                            && let Some(blur) =
+                                crate::services::background_effect::BackgroundEffectManager::global(
+                                )
+                        {
+                            blur.remove_blur_region(&win);
+                        }
+                    });
+                }
                 return;
             }
             let Some(win) = win_weak.upgrade() else {
                 return;
             };
+            // Bar is mapped but opacity-hidden (e.g. hide_all during monitor
+            // hotplug debounce).  Skip blur — it would be applied to an
+            // invisible surface.  reconfigure_all() rebuilds bars and
+            // connect_map re-applies blur when they are shown again.
+            if win.opacity() <= 0.0 {
+                return;
+            }
             let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global()
             else {
                 return;
             };
             let Some(native) = win.native() else { return };
-            let islands = collect_island_bounds(&bar_box_clone, &native);
+            let Some(bar_box) = bar_box_weak.upgrade() else {
+                return;
+            };
+            let islands = collect_island_bounds(&bar_box, &native);
+            // Skip redundant Wayland protocol traffic when bounds haven't changed.
+            // The allocate callback fires on every layout pass (clock tick, tray
+            // icon change, etc.) but most passes produce identical island bounds.
+            if *prev_bounds.borrow() == islands {
+                return;
+            }
+            *prev_bounds.borrow_mut() = islands.clone();
             if !islands.is_empty() {
                 blur.apply_bar_island_blur_regions(&win, &islands);
             } else {
-                blur.remove_blur_region(&win);
+                // Defer the remove out of the GTK allocate pass: it calls
+                // wl_surface.commit() synchronously, and we'd rather not
+                // do that mid-layout.  Re-check inside idle so a fast
+                // allocate-then-allocate sequence can't clear blur that
+                // was just legitimately reapplied.
+                let win_weak_idle = win_weak.clone();
+                let prev_bounds_idle = Rc::clone(&prev_bounds);
+                gtk4::glib::idle_add_local_once(move || {
+                    if !prev_bounds_idle.borrow().is_empty() {
+                        return;
+                    }
+                    if let Some(win) = win_weak_idle.upgrade()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                    {
+                        blur.remove_blur_region(&win);
+                    }
+                });
             }
         });
         if let Some(lm) = bar_box
@@ -245,9 +337,9 @@ pub fn create_bar_window(
     // Hot-reload: re-apply or remove bar blur when the theme config changes
     // (e.g. user toggles `theme.blur` or changes `bar.border_radius`).
     //
-    // Note: `background_opacity` is a startup-time value — it cannot change at
-    // runtime without recreating the bar — so we only need to handle toggling
-    // blur on/off within the same mode (opaque or island).
+    // Note: `background_opacity` changes trigger a structural rebuild
+    // (config_structure_changed), so this callback only needs to handle
+    // toggling blur on/off within the current mode (opaque or island).
     {
         let win_weak = window.downgrade();
         let bar_box_for_theme = bar_box.clone();
@@ -256,6 +348,9 @@ pub fn create_bar_window(
                 return;
             };
             if ConfigManager::global().blur_enabled() {
+                // Invalidate the island-bounds cache so radius/theme changes
+                // force a re-apply (the cache only tracks geometry, not radii).
+                prev_bounds_for_theme.borrow_mut().clear();
                 if let Some(apply) = &island_apply {
                     // Island mode: re-apply per-island regions immediately.
                     apply();

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -180,13 +180,94 @@ pub fn create_bar_window(
     let target_geometry = monitor.geometry();
     let target_width = target_geometry.width();
 
+    let is_island_mode = config.bar.background_opacity == 0.0;
+
     window.connect_map(move |win| {
         win.set_default_size(target_width, bar_height);
         debug!(
             "Set window width to target monitor size: {}px",
             target_width
         );
+
+        // Apply bar blur region on map (opaque/translucent bar path).
+        // The islands path is handled by the layout allocate callback below.
+        if !is_island_mode
+            && ConfigManager::global().blur_enabled()
+            && let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+        {
+            blur.apply_bar_blur_region(win);
+        }
     });
+
+    // Install layout callback for island blur (transparent bar mode).
+    // When bar.background_opacity == 0.0, we blur per-widget-island instead of
+    // the whole surface. The callback fires after every layout pass so the blur
+    // region stays in sync as widgets move or resize (tray changes, title width, etc).
+    //
+    // We also keep a shared clone of the island-apply closure so the theme-change
+    // hot-reload handler can trigger an immediate re-apply when blur is toggled on.
+    let island_apply: Option<Rc<dyn Fn()>> = if is_island_mode {
+        let win_weak = window.downgrade();
+        let bar_box_clone = bar_box.clone();
+        let closure: Rc<dyn Fn()> = Rc::new(move || {
+            if !ConfigManager::global().blur_enabled() {
+                return;
+            }
+            let Some(win) = win_weak.upgrade() else {
+                return;
+            };
+            let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global()
+            else {
+                return;
+            };
+            let Some(native) = win.native() else { return };
+            let islands = collect_island_bounds(&bar_box_clone, &native);
+            if !islands.is_empty() {
+                blur.apply_bar_island_blur_regions(&win, &islands);
+            }
+        });
+        if let Some(lm) = bar_box
+            .layout_manager()
+            .and_downcast::<crate::sectioned_bar::CenterPriorityLayout>()
+        {
+            let closure_clone = Rc::clone(&closure);
+            lm.set_on_allocate(move || closure_clone());
+        }
+        Some(closure)
+    } else {
+        None
+    };
+
+    // Hot-reload: re-apply or remove bar blur when the theme config changes
+    // (e.g. user toggles `theme.blur` or changes `bar.border_radius`).
+    //
+    // Note: `background_opacity` is a startup-time value — it cannot change at
+    // runtime without recreating the bar — so we only need to handle toggling
+    // blur on/off within the same mode (opaque or island).
+    {
+        let win_weak = window.downgrade();
+        ConfigManager::global().on_theme_change(move || {
+            let Some(win) = win_weak.upgrade() else {
+                return;
+            };
+            if ConfigManager::global().blur_enabled() {
+                if let Some(apply) = &island_apply {
+                    // Island mode: re-apply per-island regions immediately.
+                    apply();
+                } else if let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+                {
+                    // Opaque/translucent mode: re-apply whole-bar region.
+                    blur.apply_bar_blur_region(&win);
+                }
+            } else if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.remove_blur_region(&win);
+            }
+        });
+    }
 
     window.set_visible(true);
 
@@ -199,6 +280,47 @@ pub fn create_bar_window(
     );
 
     window
+}
+
+/// Collect the surface-local bounds of every visible widget island in the bar.
+///
+/// Walks the children of each section in the `SectionedBar`, finds all
+/// `.widget-wrapper` boxes that are visible, and returns their
+/// `(x, y, width, height)` in surface-local logical coordinates via
+/// `Widget::compute_bounds()`.
+fn collect_island_bounds(
+    bar_box: &SectionedBar,
+    native: &gtk4::Native,
+) -> Vec<(i32, i32, i32, i32)> {
+    use crate::styles::class;
+    let mut result = Vec::new();
+
+    for section_name in &["left", "center", "right"] {
+        let Some(section) = bar_box.section(section_name) else {
+            continue;
+        };
+        if !section.is_visible() {
+            continue;
+        }
+        let mut child = section.first_child();
+        while let Some(widget) = child {
+            if widget.is_visible()
+                && widget.has_css_class(class::WIDGET_WRAPPER)
+                && let Some(bounds) = widget.compute_bounds(native.upcast_ref::<gtk4::Widget>())
+            {
+                let x = bounds.x().round() as i32;
+                let y = bounds.y().round() as i32;
+                let w = bounds.width().round() as i32;
+                let h = bounds.height().round() as i32;
+                if w > 0 && h > 0 {
+                    result.push((x, y, w, h));
+                }
+            }
+            child = widget.next_sibling();
+        }
+    }
+
+    result
 }
 
 /// Build a single widget or a group of widgets sharing one island.

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -17,7 +17,7 @@ const MERGE_GROUP_SPACING: i32 = 10;
 
 use crate::popover_tracker::PopoverTracker;
 use crate::sectioned_bar::SectionedBar;
-use crate::services::config_manager::ConfigManager;
+use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, state, widget as style_widget};
 use crate::widgets::{
@@ -182,6 +182,7 @@ pub fn create_bar_window(
 
     let is_island_mode = config.bar.background_opacity == 0.0;
 
+    let bar_box_for_blur = bar_box.clone();
     window.connect_map(move |win| {
         win.set_default_size(target_width, bar_height);
         debug!(
@@ -196,7 +197,7 @@ pub fn create_bar_window(
             && let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
         {
-            blur.apply_bar_blur_region(win);
+            blur.apply_bar_blur_region(win, &bar_box_for_blur);
         }
     });
 
@@ -225,6 +226,8 @@ pub fn create_bar_window(
             let islands = collect_island_bounds(&bar_box_clone, &native);
             if !islands.is_empty() {
                 blur.apply_bar_island_blur_regions(&win, &islands);
+            } else {
+                blur.remove_blur_region(&win);
             }
         });
         if let Some(lm) = bar_box
@@ -247,7 +250,8 @@ pub fn create_bar_window(
     // blur on/off within the same mode (opaque or island).
     {
         let win_weak = window.downgrade();
-        ConfigManager::global().on_theme_change(move || {
+        let bar_box_for_theme = bar_box.clone();
+        let theme_cb_id = ConfigManager::global().on_theme_change(move || {
             let Some(win) = win_weak.upgrade() else {
                 return;
             };
@@ -259,7 +263,7 @@ pub fn create_bar_window(
                     crate::services::background_effect::BackgroundEffectManager::global()
                 {
                     // Opaque/translucent mode: re-apply whole-bar region.
-                    blur.apply_bar_blur_region(&win);
+                    blur.apply_bar_blur_region(&win, &bar_box_for_theme);
                 }
             } else if let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
@@ -267,6 +271,7 @@ pub fn create_bar_window(
                 blur.remove_blur_region(&win);
             }
         });
+        state.add_handle(Box::new(ThemeCallbackGuard(theme_cb_id)));
     }
 
     window.set_visible(true);

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -633,6 +633,12 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
             }
         };
 
+        // Initialize background effect (blur) service.
+        // This is a zero-cost hint — if the compositor doesn't support
+        // ext-background-effect-v1, the service becomes inert.
+        services::background_effect::BackgroundEffectManager::init_global();
+        debug!("Background effect (blur) service initialized");
+
         // Initialize bar manager and sync bars to current monitors
         let bar_manager = BarManager::global();
         bar_manager.init(app);

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -633,9 +633,10 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
             }
         };
 
-        // Initialize background effect (blur) service.
-        // This is a zero-cost hint — if the compositor doesn't support
-        // ext-background-effect-v1, the service becomes inert.
+        // Initialize background effect (blur) service unconditionally so that
+        // hot-reloading `theme.blur = true` at runtime works.  The service is
+        // cheap when the compositor lacks ext-background-effect support, and
+        // call-sites already gate on `blur_enabled()`.
         services::background_effect::BackgroundEffectManager::init_global();
         debug!("Background effect (blur) service initialized");
 

--- a/crates/vibepanel/src/sectioned_bar.rs
+++ b/crates/vibepanel/src/sectioned_bar.rs
@@ -18,7 +18,7 @@ use crate::layout_math::{
 
 mod imp {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     #[derive(Default)]
     pub struct CenterPriorityLayout {
@@ -33,6 +33,9 @@ mod imp {
         pub last_center_width: Cell<i32>,
         pub last_right_x: Cell<i32>,
         pub last_right_width: Cell<i32>,
+        /// Optional callback fired after every allocation pass.
+        /// Used by bar blur to recompute island regions when layout changes.
+        pub on_allocate: RefCell<Option<Box<dyn Fn()>>>,
     }
 
     #[glib::object_subclass]
@@ -172,6 +175,11 @@ mod imp {
                         baseline,
                     );
                 }
+
+                // Fire post-allocate callback (used by bar blur).
+                if let Some(cb) = self.on_allocate.borrow().as_ref() {
+                    cb();
+                }
                 return;
             }
 
@@ -242,6 +250,11 @@ mod imp {
                     baseline,
                 );
             }
+
+            // Fire post-allocate callback (used by bar blur).
+            if let Some(cb) = self.on_allocate.borrow().as_ref() {
+                cb();
+            }
         }
 
         fn create_layout_child(&self, widget: &Widget, for_child: &Widget) -> LayoutChild {
@@ -279,6 +292,13 @@ impl CenterPriorityLayout {
 
     pub fn set_right_expand(&self, expand: bool) {
         self.imp().right_expand.set(expand);
+    }
+
+    /// Set a callback to be fired after every layout allocation pass.
+    ///
+    /// Used by bar blur to recompute island regions when layout changes.
+    pub fn set_on_allocate<F: Fn() + 'static>(&self, cb: F) {
+        *self.imp().on_allocate.borrow_mut() = Some(Box::new(cb));
     }
 }
 

--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -22,6 +22,7 @@
 //! - **media**: MPRIS media player control and monitoring
 
 pub mod audio;
+pub mod background_effect;
 pub mod bar_manager;
 pub mod battery;
 pub mod bluetooth;

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -7,23 +7,11 @@
 //!
 //! ## Surface scope
 //!
-//! Covers all vibepanel-managed surfaces with visible backgrounds:
-//! bar (opaque and island modes), layer-shell popovers, Quick Settings,
-//! notification toasts, OSD, tray menus, and the media pop-out window.
-//!
-//! Intentionally excluded:
-//! - **Quick Settings row sub-menus** (`gtk4::Popover` / `xdg_popup`) — wifi,
-//!   bluetooth, and power card context menus.  These are subordinate menus
-//!   inside an already-blurred layer-shell surface; the visual benefit is
-//!   negligible and they are not "top-level" surfaces in the user's view.
-//! - **Tooltips** (`services/tooltip.rs`) — layer-shell surfaces but tiny and
-//!   ephemeral; blur would not be visible behind a single-line label.
-//!
-//! Note: tray menus and the media pop-out are `xdg_popup` / XDG-toplevel
-//! surfaces respectively.  Whether the compositor actually renders blur for
-//! them depends on compositor support.  niri supports both as of PR #3483
-//! (`wip/branch`).  On compositors without support the hints are silently
-//! ignored — no harm done.
+//! Covers vibepanel-managed surfaces with visible backgrounds: bar, layer-shell
+//! popovers, Quick Settings, notification toasts, OSD, tray menus, and the media
+//! pop-out window. Child popovers inside already-blurred surfaces and tiny
+//! tooltips are intentionally excluded because the visual benefit is negligible.
+//! On compositors without support for a surface role, the hint is ignored.
 //!
 //! ## Architecture
 //!
@@ -33,6 +21,65 @@
 //!
 //! Per-surface `ExtBackgroundEffectSurfaceV1` objects are cached by
 //! `ObjectId` to avoid the protocol error raised when creating duplicates.
+//!
+//! **Fragile dependency:** `connection_from_gdk_display()` reconstructs
+//! GDK's internal `wayland_client::Connection` via proxy backend
+//! extraction.  This is the only viable approach (a second
+//! `Backend::from_foreign_display()` would steal events from GDK), but
+//! it depends on `gdk4-wayland` internals — see that function for details.
+//!
+//! ## Blur lifecycle
+//!
+//! Each consumer surface manages its own blur lifecycle.  The correct
+//! approach depends on two orthogonal axes:
+//!
+//! **Axis 1 — hide mechanism:**
+//!
+//! | Mechanism | What happens to blur | Consumer action |
+//! |-----------|---------------------|-----------------|
+//! | **Opacity-hide** (`set_opacity(0.0)`) | Surface stays mapped; compositor continues rendering blur behind an invisible surface | Must call `remove_blur_region()` before hiding |
+//! | **Reusable unmap** (`set_visible(false)`) | Surface is unmapped; compositor suspends blur rendering but the protocol object persists | Usually preserve the object and clean stale state on the next `connect_map` |
+//! | **Transient unmap / destroy** | Surface is short-lived or cheap to reapply | Clean up on `connect_unmap`; keep `connect_destroy` as a safety net |
+//!
+//! **Axis 2 — surface identity:**
+//!
+//! | Identity | Re-apply strategy | Theme hot-reload |
+//! |----------|-------------------|-----------------|
+//! | **Reusable** (surface persists across show/hide) | `connect_map` applies blur if enabled, removes stale objects if not | Optional — `on_theme_change` if surface may be visible during config edit |
+//! | **Transient/standalone** (one-shot or cheap to recreate blur) | `connect_map` applies blur; `connect_unmap` removes it | `on_theme_change` if surface may remain visible long enough for live config edits |
+//!
+//! **Animation caveat:** if a close path fades opacity *before* unmapping
+//! (e.g. popovers, Quick Settings), blur must be removed at fade start.
+//! Compositor-side blur renders independently of widget opacity — without
+//! removal, a blur rectangle remains visible through the fading surface.
+//!
+//! ### Terminology
+//!
+//! - **Protocol object**: the `ExtBackgroundEffectSurfaceV1` entry cached in
+//!   the manager's `effects` HashMap.  Created by `get_or_create_effect()`,
+//!   destroyed by `remove_blur_region()`.  Persists across unmap/remap.
+//! - **Compositor-side blur**: the visual blur effect rendered by the
+//!   compositor.  Only drawn while the surface is mapped.  Suspended (not
+//!   destroyed) on unmap; restored on remap if the protocol object persists.
+//!
+//! ### Known constraints
+//!
+//! - **`remove_blur_region` requires a mapped surface.**
+//!   `SurfaceInfo::from_widget()` calls `widget.native()?.surface()?`,
+//!   which returns `None` for unmapped layer-shell surfaces.  Therefore
+//!   `on_theme_change` callbacks cannot clean up blur on hidden windows.
+//!   For reusable surfaces that may be unmapped when blur is toggled off,
+//!   `connect_map` is the earliest reliable cleanup point — it fires when
+//!   the surface becomes available again.
+//!
+//! ### Shared lifecycle pattern (OSD, toast, media)
+//!
+//! These three standalone-window consumers share a near-identical lifecycle:
+//! `connect_map` (apply blur) + `connect_unmap` (primary cleanup) +
+//! `connect_destroy` (safety net) + `on_theme_change` (re-apply/remove) +
+//! `ThemeCallbackGuard`.  The only variations are the content widget
+//! resolution and the radius source, so
+//! [`attach_blur_surface_lifecycle`] centralizes that wiring.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -47,9 +94,79 @@ use wayland_client::protocol::wl_compositor::WlCompositor;
 use wayland_client::protocol::wl_registry;
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
 use wayland_protocols::ext::background_effect::v1::client::{
-    ext_background_effect_manager_v1::{self, ExtBackgroundEffectManagerV1},
+    ext_background_effect_manager_v1::{self, Capability, ExtBackgroundEffectManagerV1},
     ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
 };
+
+const BLUR_REGION_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-resize-watched";
+const BLUR_SURFACE_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-surface-watched";
+
+/// Attach the standard blur lifecycle for standalone GTK windows.
+///
+/// Used by OSD, notification toasts, and the media pop-out: apply on map,
+/// remove on unmap while the wl_surface is still resolvable, keep destroy as a
+/// safety net, and live-update on theme changes. Reusable animated surfaces
+/// (bar, popovers, Quick Settings) have bespoke lifecycles and should not use
+/// this helper.
+pub fn attach_blur_surface_lifecycle<W, C, R>(
+    window: &W,
+    content_resolver: C,
+    radius_fn: R,
+) -> crate::services::config_manager::ThemeCallbackGuard
+where
+    W: IsA<gtk4::Window> + IsA<gtk4::Widget> + Clone + 'static,
+    C: Fn(&W) -> Option<gtk4::Widget> + Clone + 'static,
+    R: Fn() -> i32 + Clone + 'static,
+{
+    use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
+
+    let content_for_map = content_resolver.clone();
+    let radius_for_map = radius_fn.clone();
+    window.connect_map(move |win| {
+        if ConfigManager::global().blur_enabled() {
+            if let Some(blur) = BackgroundEffectManager::global()
+                && let Some(content) = content_for_map(win)
+            {
+                blur.apply_blur_surface(win, &content, radius_for_map.clone());
+            }
+        } else if let Some(blur) = BackgroundEffectManager::global() {
+            // Remove any stale effect from a previous map cycle when blur was
+            // toggled off while the surface was unmapped — the unmap and
+            // theme-change cleanup paths are best-effort on an unmapped surface.
+            blur.remove_blur_region(win);
+        }
+    });
+
+    window.connect_unmap(|win| {
+        if let Some(blur) = BackgroundEffectManager::global() {
+            blur.remove_blur_region(win);
+        }
+    });
+
+    window.connect_destroy(|win| {
+        if let Some(blur) = BackgroundEffectManager::global() {
+            blur.remove_blur_region(win);
+        }
+    });
+
+    let win_weak = window.downgrade();
+    let id = ConfigManager::global().on_theme_change(move || {
+        let Some(win) = win_weak.upgrade() else {
+            return;
+        };
+        if ConfigManager::global().blur_enabled() {
+            if let Some(blur) = BackgroundEffectManager::global()
+                && let Some(content) = content_resolver(&win)
+            {
+                blur.apply_blur_surface(&win, &content, radius_fn.clone());
+            }
+        } else if let Some(blur) = BackgroundEffectManager::global() {
+            blur.remove_blur_region(&win);
+        }
+    });
+
+    ThemeCallbackGuard(id)
+}
 
 // ── Dispatch state ──────────────────────────────────────────────────────────
 
@@ -63,6 +180,9 @@ struct BlurState {
     compositor: Option<WlCompositor>,
     /// Cached per-surface effect objects, keyed by `wl_surface` ObjectId.
     effects: HashMap<wayland_client::backend::ObjectId, ExtBackgroundEffectSurfaceV1>,
+    /// Whether the compositor advertises blur. Mutable at runtime per spec —
+    /// compositor stops applying blur on revocation regardless of client state.
+    blur_capable: bool,
 }
 
 impl BlurState {
@@ -71,6 +191,7 @@ impl BlurState {
             manager: None,
             compositor: None,
             effects: HashMap::new(),
+            blur_capable: false,
         }
     }
 }
@@ -86,6 +207,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for BlurState {
         _conn: &Connection,
         qh: &QueueHandle<Self>,
     ) {
+        // Only Global is handled; GlobalRemove is intentionally ignored.
+        // wl_compositor and ext_background_effect_manager_v1 are core
+        // globals that are never removed during a session.
         if let wl_registry::Event::Global {
             name,
             interface,
@@ -111,14 +235,36 @@ impl Dispatch<wl_registry::WlRegistry, ()> for BlurState {
 
 impl Dispatch<ExtBackgroundEffectManagerV1, ()> for BlurState {
     fn event(
-        _state: &mut Self,
+        state: &mut Self,
         _proxy: &ExtBackgroundEffectManagerV1,
-        _event: ext_background_effect_manager_v1::Event,
+        event: ext_background_effect_manager_v1::Event,
         _data: &(),
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        // No events we need to handle.
+        // `capabilities` is sent on bind and on change. Empty bitfield = no blur.
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            let now_capable = flags
+                .into_result()
+                .map(|f| f.contains(Capability::Blur))
+                .unwrap_or(false);
+            let was_capable = state.blur_capable;
+            state.blur_capable = now_capable;
+            if was_capable && !now_capable {
+                // Revoked — drop bookkeeping; compositor already stopped drawing.
+                debug!(
+                    "Blur capability revoked; destroying {} effect object(s)",
+                    state.effects.len()
+                );
+                for (_id, effect) in state.effects.drain() {
+                    effect.destroy();
+                }
+            } else if !was_capable && now_capable {
+                // Internal state updated; visible surfaces re-apply on next
+                // map/resize/theme event (no live walk of mapped surfaces).
+                debug!("Blur capability advertised");
+            }
+        }
     }
 }
 
@@ -163,7 +309,11 @@ impl Dispatch<wayland_client::protocol::wl_region::WlRegion, ()> for BlurState {
 
 // ── Rounded-rect scanline rasterization ─────────────────────────────────────
 
-/// Add a rounded rectangle to a `wl_region` using scanline rasterization.
+/// Compute the set of axis-aligned rectangles that tile a rounded rectangle.
+///
+/// Returns a `Vec<(x, y, width, height)>` in surface-local logical coordinates.
+/// The rectangles are non-overlapping and together cover exactly the filled
+/// rounded rectangle.
 ///
 /// Uses `round(exact_inset)` per row — nearest-integer assignment minimises
 /// total error and max adjacent delta compared to ceil, floor, or Bresenham
@@ -173,35 +323,36 @@ impl Dispatch<wayland_client::protocol::wl_region::WlRegion, ()> for BlurState {
 ///
 /// If `radius` is zero or the dimensions are too small to accommodate it,
 /// clamps to a pill shape or falls back to a plain rectangle.
-/// Non-positive `width` or `height` are silently ignored (no `wl_region.add`
-/// call is made — per Wayland protocol, non-positive dimensions are invalid).
-fn add_rounded_rect_to_region(
-    region: &wayland_client::protocol::wl_region::WlRegion,
+/// Non-positive `width` or `height` return an empty vec (per Wayland protocol,
+/// non-positive dimensions are invalid for `wl_region.add`).
+fn compute_rounded_rect_rects(
     x: i32,
     y: i32,
     width: i32,
     height: i32,
     radius: i32,
-) {
+) -> Vec<(i32, i32, i32, i32)> {
     if width <= 0 || height <= 0 {
-        return;
+        return Vec::new();
     }
     if radius <= 0 {
-        region.add(x, y, width, height);
-        return;
+        return vec![(x, y, width, height)];
     }
     // Clamp to half the smallest dimension so oversized radii produce a
     // pill shape instead of a plain rectangle.
     let radius = radius.min(width / 2).min(height / 2);
     if radius <= 0 {
-        region.add(x, y, width, height);
-        return;
+        return vec![(x, y, width, height)];
     }
+
+    // Capacity: central rect (if present) + 2 rows per radius scanline.
+    let has_center = height > 2 * radius;
+    let mut rects = Vec::with_capacity(if has_center { 1 } else { 0 } + 2 * radius as usize);
 
     // Central rectangle spanning the full width, excluding the top and bottom
     // radius strips.
-    if height > 2 * radius {
-        region.add(x, y + radius, width, height - 2 * radius);
+    if has_center {
+        rects.push((x, y + radius, width, height - 2 * radius));
     }
 
     let r = radius as f64;
@@ -213,8 +364,27 @@ fn add_rounded_rect_to_region(
             (r - (r * r - dy * dy).sqrt()).round() as i32
         };
         let row_w = (width - 2 * inset).max(1);
-        region.add(x + inset, y + i as i32, row_w, 1);
-        region.add(x + inset, y + height - 1 - i as i32, row_w, 1);
+        rects.push((x + inset, y + i as i32, row_w, 1));
+        rects.push((x + inset, y + height - 1 - i as i32, row_w, 1));
+    }
+
+    rects
+}
+
+/// Add a rounded rectangle to a `wl_region` using scanline rasterization.
+///
+/// Delegates to [`compute_rounded_rect_rects`] for the geometry, then feeds
+/// each rectangle to `region.add()`.
+fn add_rounded_rect_to_region(
+    region: &wayland_client::protocol::wl_region::WlRegion,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    radius: i32,
+) {
+    for (rx, ry, rw, rh) in compute_rounded_rect_rects(x, y, width, height, radius) {
+        region.add(rx, ry, rw, rh);
     }
 }
 
@@ -397,9 +567,26 @@ impl BackgroundEffectManager {
             return None;
         }
 
+        // Second roundtrip: the bind from the first roundtrip's Global dispatch
+        // triggers a `capabilities` event that won't arrive until we round-trip
+        // again. We don't *require* blur to be advertised here — keeping the
+        // manager alive lets the fd watcher pick up a later `Capabilities`
+        // event (false → true transitions). `get_or_create_effect` gates on
+        // `blur_capable`, so consumers no-op until then.
+        //
+        // Note: a later false→true capability gain updates internal state but
+        // does NOT walk currently-mapped surfaces. Re-apply happens on the next
+        // natural surface event (map, resize, theme change). No real compositor
+        // exhibits runtime capability gain today; revisit if that changes.
+        if let Err(e) = event_queue.roundtrip(&mut state) {
+            warn!("Failed blur service capability roundtrip: {e}");
+            return None;
+        }
+
         debug!(
-            "Blur service initialized (compositor={:?})",
-            state.compositor.is_some()
+            "Blur service initialized (compositor={:?}, blur_capable={})",
+            state.compositor.is_some(),
+            state.blur_capable
         );
 
         let mgr = Self {
@@ -433,6 +620,8 @@ impl BackgroundEffectManager {
 
                 if let Err(e) = eq.dispatch_pending(&mut *st) {
                     warn!("Blur event dispatch error: {e}");
+                    // Continue: blur is cosmetic, protocol failures must not
+                    // destabilise the panel.
                     return glib::ControlFlow::Continue;
                 }
 
@@ -465,6 +654,9 @@ impl BackgroundEffectManager {
         info: &SurfaceInfo,
     ) -> Option<(ExtBackgroundEffectSurfaceV1, WlCompositor)> {
         let mut state = self.state.borrow_mut();
+        if !state.blur_capable {
+            return None; // Capability revoked or never advertised.
+        }
         let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
             return None;
         };
@@ -492,26 +684,82 @@ impl BackgroundEffectManager {
 
     /// Install a one-shot resize watcher on a window's GDK surface.
     ///
-    /// We watch only `width`, which is sufficient: GDK's internal
-    /// `_gdk_surface_update_size()` emits both `notify::width` and
-    /// `notify::height` whenever *any* dimension changes, so height-only
-    /// configures still fire `notify::width`.
+    /// Watches both `width` and `height`; either dimension may change
+    /// independently. Handler is idempotent.
     ///
-    /// The watcher is installed at most once per `key` per window.
+    /// The watcher is installed at most once per window.
     fn install_resize_watcher(
         window: &gtk4::ApplicationWindow,
-        key: &'static str,
-        on_resize: impl Fn() + 'static,
+        on_resize: impl Fn() + 'static + Clone,
     ) {
         unsafe {
-            if window.data::<bool>(key).is_some() {
+            if window
+                .data::<bool>(BLUR_REGION_RESIZE_WATCHED_KEY)
+                .is_some()
+            {
                 return;
             }
-            window.set_data(key, true);
+            window.set_data(BLUR_REGION_RESIZE_WATCHED_KEY, true);
         }
         if let Some(gdk_surface) = window.native().and_then(|n| n.surface()) {
-            gdk_surface.connect_notify_local(Some("width"), move |_, _| on_resize());
+            let on_resize_w = on_resize.clone();
+            gdk_surface.connect_notify_local(Some("width"), move |_, _| on_resize_w());
+            gdk_surface.connect_notify_local(Some("height"), move |_, _| on_resize());
         }
+    }
+
+    /// Install a resize watcher for [`apply_blur_surface`](Self::apply_blur_surface)
+    /// on a generic widget's GDK surface.
+    ///
+    /// Watches both `width` and `height`. On change, an idle callback re-invokes
+    /// `apply_blur_surface` so the blur region tracks content size; this also
+    /// serves as the readiness trigger for the deferred path (surface not yet
+    /// sized on first call). The guard key is stored on the `GdkSurface` (not
+    /// the widget) because generic widgets don't support `set_data`.
+    ///
+    /// Installed at most once per surface.
+    fn install_surface_resize_watcher(
+        surface_root: &gtk4::Widget,
+        content: &gtk4::Widget,
+        radius_fn: impl Fn() -> i32 + Clone + 'static,
+    ) {
+        let Some(gdk_surface) = surface_root.native().and_then(|n| n.surface()) else {
+            return;
+        };
+        unsafe {
+            if gdk_surface
+                .data::<bool>(BLUR_SURFACE_RESIZE_WATCHED_KEY)
+                .is_some()
+            {
+                return; // watcher already installed
+            }
+            gdk_surface.set_data(BLUR_SURFACE_RESIZE_WATCHED_KEY, true);
+        }
+        // Use weak refs to avoid a GObject ref cycle
+        // (GdkSurface → closure → Widget → GdkSurface).
+        let root_weak = surface_root.downgrade();
+        let content_weak = content.downgrade();
+        let make_handler = || {
+            let root_weak = root_weak.clone();
+            let content_weak = content_weak.clone();
+            let radius_fn = radius_fn.clone();
+            move |_: &gdk4_wayland::gdk::Surface, _: &glib::ParamSpec| {
+                let root_weak = root_weak.clone();
+                let content_weak = content_weak.clone();
+                let radius_fn = radius_fn.clone();
+                glib::idle_add_local_once(move || {
+                    if let Some(rc) = root_weak.upgrade()
+                        && let Some(cc) = content_weak.upgrade()
+                        && crate::services::config_manager::ConfigManager::global().blur_enabled()
+                        && let Some(blur) = Self::global()
+                    {
+                        blur.apply_blur_surface(&rc, &cc, radius_fn);
+                    }
+                });
+            }
+        };
+        gdk_surface.connect_notify_local(Some("width"), make_handler());
+        gdk_surface.connect_notify_local(Some("height"), make_handler());
     }
 
     /// Apply a blur region hint to the given window's surface.
@@ -525,8 +773,9 @@ impl BackgroundEffectManager {
     /// If the surface has no size yet (first map), this schedules a one-shot idle
     /// retry so the blur region is applied once GTK has committed dimensions.
     ///
-    /// This is fire-and-forget: the region is double-buffered and applied on
-    /// GTK's next `wl_surface.commit`.
+    /// Commits the surface explicitly so the double-buffered blur region takes
+    /// effect even when this runs from a deferred idle or resize callback with
+    /// no guaranteed subsequent GTK frame commit.
     pub fn apply_blur_region(&self, window: &gtk4::ApplicationWindow, shadow_margin: i32) {
         let Some(info) = SurfaceInfo::from_widget(window) else {
             trace!("No wl_surface for window, skipping blur");
@@ -577,6 +826,7 @@ impl BackgroundEffectManager {
 
         effect.set_blur_region(Some(&region));
         region.destroy();
+        info.wl_surface.commit();
         self.flush();
 
         debug!(
@@ -587,12 +837,15 @@ impl BackgroundEffectManager {
         // Install a resize watcher (once per window) so the blur region
         // is re-applied whenever the surface dimensions change — e.g. when
         // a Revealer expands and the layer-shell surface reconfigures.
-        let win_clone = window.clone();
-        Self::install_resize_watcher(window, "vibepanel-blur-resize-watched", move || {
-            if crate::services::config_manager::ConfigManager::global().blur_enabled()
+        // Use a weak ref to avoid a GObject ref cycle
+        // (GdkSurface → closure → Window → GdkSurface).
+        let win_weak = window.downgrade();
+        Self::install_resize_watcher(window, move || {
+            if let Some(win) = win_weak.upgrade()
+                && crate::services::config_manager::ConfigManager::global().blur_enabled()
                 && let Some(blur) = BackgroundEffectManager::global()
             {
-                blur.apply_blur_region(&win_clone, shadow_margin);
+                blur.apply_blur_region(&win, shadow_margin);
             }
         });
     }
@@ -626,10 +879,9 @@ impl BackgroundEffectManager {
 
         // Opaque/translucent bar: blur only the bar_box bounds, not the full surface.
         // Using apply_blur_surface so compute_bounds accounts for any margin/padding.
-        let radius =
-            crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32;
-
-        self.apply_blur_surface(window, bar_box, radius);
+        self.apply_blur_surface(window, bar_box, || {
+            crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32
+        });
     }
 
     /// Apply blur regions for individual widget islands on a transparent bar.
@@ -666,6 +918,9 @@ impl BackgroundEffectManager {
 
         effect.set_blur_region(Some(&region));
         region.destroy();
+        // This path can run from theme hot-reload, not only GTK allocation,
+        // so commit explicitly to apply the double-buffered region now.
+        info.wl_surface.commit();
         self.flush();
 
         debug!(
@@ -676,6 +931,20 @@ impl BackgroundEffectManager {
     }
 
     /// Remove the blur region for a window (e.g. on destroy).
+    ///
+    /// Best-effort cleanup.  Requires a currently mapped surface so
+    /// `SurfaceInfo::from_widget()` can resolve the `wl_surface`.  If
+    /// called from a late `Drop` after the surface is already unmapped or
+    /// destroyed, this silently no-ops and the stale `effects` HashMap
+    /// entry persists.  This is intentional and benign: primary cleanup
+    /// always happens from mapped-surface paths (`connect_destroy`,
+    /// `connect_closed`, fade-start removal, or `connect_map` stale
+    /// cleanup on next show), so the `Drop` safety nets in consumers are
+    /// defence-in-depth only.  Stale entries are small and bounded by the
+    /// number of surfaces torn down without prior cleanup (typically zero
+    /// during normal operation).  `ObjectId` equality is instance-based, not
+    /// wire-integer based, so stale entries never alias new surfaces even if
+    /// wire IDs are reused.
     pub fn remove_blur_region(&self, window: &impl gtk4::prelude::IsA<gtk4::Widget>) {
         let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
@@ -685,12 +954,16 @@ impl BackgroundEffectManager {
         if let Some(effect) = state.effects.remove(&info.surface_id) {
             effect.destroy();
             debug!("Removed blur region for surface");
-        }
-        drop(state);
+            drop(state);
 
-        // Flush so the destroy request reaches the compositor promptly.
-        // The change takes effect on the next wl_surface.commit (driven by GTK).
-        self.flush();
+            // Destroy is double-buffered; commit so the compositor removes
+            // the effect immediately.  Committing GDK's wl_surface outside
+            // the render cycle is safe here: we only touch protocol state
+            // that GDK does not manage (blur regions), and GTK's next frame
+            // commit will simply re-apply its own pending state on top.
+            info.wl_surface.commit();
+            self.flush();
+        }
     }
 
     /// Apply a blur region that tracks the ScaleBox grow-in animation.
@@ -751,7 +1024,29 @@ impl BackgroundEffectManager {
 
         effect.set_blur_region(Some(&region));
         region.destroy();
+        // Called only from GTK frame-clock ticks; GTK commits the surface for
+        // that frame, so this path intentionally avoids an extra commit per
+        // animation frame.
         self.flush();
+    }
+
+    /// Apply blur for the popover/Quick Settings opening animation.
+    ///
+    /// While opening, the region tracks the current grow-in scale. On the final
+    /// tick, switch to the normal full-size path so the resize watcher is
+    /// installed for later content/size changes.
+    pub fn apply_open_animation_blur(
+        &self,
+        window: &gtk4::ApplicationWindow,
+        shadow_margin: i32,
+        scale: f64,
+        complete: bool,
+    ) {
+        if complete {
+            self.apply_blur_region(window, shadow_margin);
+        } else {
+            self.apply_blur_region_animated(window, shadow_margin, scale);
+        }
     }
 
     /// Apply a blur region matching a content widget's allocation within its surface.
@@ -764,17 +1059,22 @@ impl BackgroundEffectManager {
     /// `surface_root` is any widget whose `GtkNative` owns the `wl_surface`
     /// (a `gtk4::Window`, `gtk4::ApplicationWindow`, or `gtk4::Popover`);
     /// `content` is the child widget whose allocation defines the blur region;
-    /// `radius` is the corner radius.
+    /// `radius_fn` is a closure returning the current corner radius.
+    ///
+    /// Using a closure instead of a plain `i32` ensures the deferred
+    /// readiness/resize watcher always reads the latest theme value.
+    /// Without this, a theme change after initial apply would leave the
+    /// watcher using the stale radius captured at first call.
     ///
     /// On first map the Wayland surface may still be a 1×1 placeholder before
     /// the compositor sends configure.  In that case, a one-shot watcher on
-    /// the GDK surface's `width` property defers the apply until configure
+    /// the GDK surface's `height` property defers the apply until configure
     /// arrives and layout completes.
     pub fn apply_blur_surface(
         &self,
         surface_root: &impl gtk4::prelude::IsA<gtk4::Widget>,
         content: &impl gtk4::prelude::IsA<gtk4::Widget>,
-        radius: i32,
+        radius_fn: impl Fn() -> i32 + Clone + 'static,
     ) {
         let Some(info) = SurfaceInfo::from_widget(surface_root) else {
             debug!("apply_blur_surface: no wl_surface, skipping");
@@ -800,33 +1100,10 @@ impl BackgroundEffectManager {
                 "apply_blur_surface: not ready (surface {}x{}, bounds {:?}), deferring",
                 width, height, bounds
             );
-            // Watch `width` (covers height-only changes too — see
-            // install_resize_watcher doc).  Defer to idle so the GTK layout
-            // pass completes before we read compute_bounds.
-            if let Some(gdk_surface) = surface_root_widget.native().and_then(|n| n.surface()) {
-                let key = "vibepanel-blur-surface-watched";
-                unsafe {
-                    if gdk_surface.data::<bool>(key).is_some() {
-                        return; // watcher already installed
-                    }
-                    gdk_surface.set_data(key, true);
-                }
-                // Clone as gtk4::Widget (the common base) so the closure can
-                // hold the value regardless of the concrete surface_root type.
-                let root_clone = surface_root_widget.clone();
-                let content_clone = content_widget.clone();
-                gdk_surface.connect_notify_local(Some("width"), move |_, _| {
-                    let rc = root_clone.clone();
-                    let cc = content_clone.clone();
-                    glib::idle_add_local_once(move || {
-                        if crate::services::config_manager::ConfigManager::global().blur_enabled()
-                            && let Some(blur) = Self::global()
-                        {
-                            blur.apply_blur_surface(&rc, &cc, radius);
-                        }
-                    });
-                });
-            }
+            // Install a resize watcher so we re-try once the surface gets a
+            // real size.  The watcher also handles subsequent resizes after
+            // the initial apply succeeds.
+            Self::install_surface_resize_watcher(surface_root_widget, content_widget, radius_fn);
             return;
         }
 
@@ -841,28 +1118,308 @@ impl BackgroundEffectManager {
         };
 
         let region = compositor.create_region(&self.qh, ());
+        let radius = radius_fn();
         add_rounded_rect_to_region(&region, bx, by, bw, bh, radius);
 
         effect.set_blur_region(Some(&region));
         region.destroy();
         // Commit the surface so the double-buffered blur region takes effect
         // immediately.  Without this, the region stays pending until GTK's
-        // next wl_surface.commit — which may never come for surfaces whose
+        // next wl_surface.commit -- which may never come for surfaces whose
         // layout is already complete (e.g. tray popovers reached via the
-        // deferred idle path).
+        // deferred idle path).  Safe for the same reason as the commit in
+        // remove_blur_region: we only touch blur state GDK doesn't manage.
         info.wl_surface.commit();
         self.flush();
 
-        // No dedicated resize watcher is installed here beyond the readiness
-        // watcher above.  That watcher remains connected and will re-apply the
-        // blur region on subsequent resizes, which is correct behaviour.
-        // Current consumers have stable content bounds after initial layout,
-        // so re-applies are infrequent.  A future consumer with dynamically-
-        // resizing content gets automatic re-apply for free via the same
-        // watcher.
+        // Install a resize watcher so the blur region is updated if the
+        // surface dimensions change after initial layout.  The idempotency
+        // guard inside ensures this is a no-op when the deferred path
+        // already installed one.
+        Self::install_surface_resize_watcher(surface_root_widget, content_widget, radius_fn);
+
         debug!(
             "Applied blur surface: {}x{} at ({},{}) r={} (surface {}x{})",
             bw, bh, bx, by, radius, width, height
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_rounded_rect_rects;
+
+    /// Helper: compute total pixel area covered by non-overlapping scanline rects.
+    fn total_area(rects: &[(i32, i32, i32, i32)]) -> i64 {
+        rects.iter().map(|&(_, _, w, h)| w as i64 * h as i64).sum()
+    }
+
+    /// Helper: rasterize to a pixel grid and count set pixels (detects overlaps).
+    fn rasterize_pixel_count(
+        rects: &[(i32, i32, i32, i32)],
+        bx: i32,
+        by: i32,
+        bw: i32,
+        bh: i32,
+    ) -> usize {
+        let mut grid = vec![false; (bw * bh) as usize];
+        for &(rx, ry, rw, rh) in rects {
+            for py in ry..ry + rh {
+                for px in rx..rx + rw {
+                    let idx = ((py - by) * bw + (px - bx)) as usize;
+                    grid[idx] = true;
+                }
+            }
+        }
+        grid.iter().filter(|&&v| v).count()
+    }
+
+    // ── Degenerate / invalid inputs ─────────────────────────────────────
+
+    #[test]
+    fn zero_width_returns_empty() {
+        assert!(compute_rounded_rect_rects(0, 0, 0, 10, 5).is_empty());
+    }
+
+    #[test]
+    fn zero_height_returns_empty() {
+        assert!(compute_rounded_rect_rects(0, 0, 10, 0, 5).is_empty());
+    }
+
+    #[test]
+    fn negative_width_returns_empty() {
+        assert!(compute_rounded_rect_rects(0, 0, -5, 10, 5).is_empty());
+    }
+
+    #[test]
+    fn negative_height_returns_empty() {
+        assert!(compute_rounded_rect_rects(0, 0, 10, -3, 5).is_empty());
+    }
+
+    #[test]
+    fn one_by_one_returns_single_rect() {
+        let rects = compute_rounded_rect_rects(5, 10, 1, 1, 0);
+        assert_eq!(rects, vec![(5, 10, 1, 1)]);
+    }
+
+    #[test]
+    fn one_by_one_with_radius_returns_single_rect() {
+        // radius clamps to min(1/2, 1/2) = 0 → plain rect
+        let rects = compute_rounded_rect_rects(0, 0, 1, 1, 10);
+        assert_eq!(rects, vec![(0, 0, 1, 1)]);
+    }
+
+    // ── Zero / negative radius ──────────────────────────────────────────
+
+    #[test]
+    fn zero_radius_returns_single_rect() {
+        let rects = compute_rounded_rect_rects(10, 20, 100, 50, 0);
+        assert_eq!(rects, vec![(10, 20, 100, 50)]);
+    }
+
+    #[test]
+    fn negative_radius_returns_single_rect() {
+        let rects = compute_rounded_rect_rects(0, 0, 40, 30, -5);
+        assert_eq!(rects, vec![(0, 0, 40, 30)]);
+    }
+
+    // ── Bounding-box containment ────────────────────────────────────────
+
+    #[test]
+    fn all_rects_within_bounding_box() {
+        for radius in [1, 5, 10, 20, 50] {
+            for (w, h) in [(20, 20), (100, 40), (40, 100), (3, 3), (50, 50)] {
+                let x = 10;
+                let y = 20;
+                let rects = compute_rounded_rect_rects(x, y, w, h, radius);
+                for &(rx, ry, rw, rh) in &rects {
+                    assert!(
+                        rx >= x && ry >= y && rx + rw <= x + w && ry + rh <= y + h,
+                        "rect ({rx},{ry},{rw},{rh}) outside bbox ({x},{y},{w},{h}) with r={radius}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn all_rects_have_positive_dimensions() {
+        for radius in [1, 5, 10, 20, 50] {
+            for (w, h) in [(20, 20), (100, 40), (2, 2), (3, 7)] {
+                let rects = compute_rounded_rect_rects(0, 0, w, h, radius);
+                for &(_, _, rw, rh) in &rects {
+                    assert!(
+                        rw > 0 && rh > 0,
+                        "non-positive dim ({rw},{rh}) for {w}x{h} r={radius}"
+                    );
+                }
+            }
+        }
+    }
+
+    // ── Area properties ─────────────────────────────────────────────────
+
+    #[test]
+    fn area_less_than_or_equal_to_bounding_box() {
+        for radius in [1, 5, 10, 20] {
+            for (w, h) in [(20, 20), (100, 40), (40, 100)] {
+                let rects = compute_rounded_rect_rects(0, 0, w, h, radius);
+                let area = total_area(&rects);
+                let bbox_area = w as i64 * h as i64;
+                assert!(
+                    area <= bbox_area,
+                    "area {area} > bbox {bbox_area} for {w}x{h} r={radius}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zero_radius_area_equals_bounding_box() {
+        let rects = compute_rounded_rect_rects(0, 0, 100, 50, 0);
+        assert_eq!(total_area(&rects), 100 * 50);
+    }
+
+    #[test]
+    fn rounded_area_strictly_less_than_bounding_box() {
+        // With a non-trivial radius, corners are cut so area must be less.
+        let rects = compute_rounded_rect_rects(0, 0, 100, 50, 10);
+        let area = total_area(&rects);
+        let bbox = 100i64 * 50;
+        assert!(area < bbox, "expected area < {bbox}, got {area}");
+        // But should still cover the vast majority.
+        assert!(area > bbox * 90 / 100, "area {area} too small for {bbox}");
+    }
+
+    #[test]
+    fn no_pixel_overlaps() {
+        // Rasterize and verify unique pixel count matches summed rect area.
+        for radius in [1, 5, 10, 15] {
+            for (w, h) in [(30, 30), (50, 20), (20, 50)] {
+                let rects = compute_rounded_rect_rects(0, 0, w, h, radius);
+                let sum_area = total_area(&rects) as usize;
+                let pixel_count = rasterize_pixel_count(&rects, 0, 0, w, h);
+                assert_eq!(
+                    sum_area, pixel_count,
+                    "overlap detected for {w}x{h} r={radius}: sum={sum_area} pixels={pixel_count}"
+                );
+            }
+        }
+    }
+
+    // ── Symmetry ────────────────────────────────────────────────────────
+
+    #[test]
+    fn vertical_symmetry() {
+        // The top and bottom halves should mirror each other.
+        let (w, h, r) = (40, 40, 10);
+        let rects = compute_rounded_rect_rects(0, 0, w, h, r);
+        let mut grid = vec![vec![false; w as usize]; h as usize];
+        for &(rx, ry, rw, rh) in &rects {
+            for py in ry..ry + rh {
+                for px in rx..rx + rw {
+                    grid[py as usize][px as usize] = true;
+                }
+            }
+        }
+        for y in 0..h as usize / 2 {
+            let mirror_y = h as usize - 1 - y;
+            assert_eq!(
+                grid[y], grid[mirror_y],
+                "row {y} != mirrored row {mirror_y}"
+            );
+        }
+    }
+
+    #[test]
+    fn horizontal_symmetry() {
+        // Left and right insets should be equal (symmetric corners).
+        let (w, h, r) = (40, 40, 10);
+        let rects = compute_rounded_rect_rects(0, 0, w, h, r);
+        let mut grid = vec![vec![false; w as usize]; h as usize];
+        for &(rx, ry, rw, rh) in &rects {
+            for py in ry..ry + rh {
+                for px in rx..rx + rw {
+                    grid[py as usize][px as usize] = true;
+                }
+            }
+        }
+        for (y, row) in grid.iter().enumerate() {
+            for x in 0..w as usize / 2 {
+                let mirror_x = w as usize - 1 - x;
+                assert_eq!(
+                    row[x], row[mirror_x],
+                    "({x},{y}) != mirror ({mirror_x},{y})"
+                );
+            }
+        }
+    }
+
+    // ── Pill shape (oversized radius) ───────────────────────────────────
+
+    #[test]
+    fn oversized_radius_clamps_to_pill() {
+        // radius=100 on a 20x10 rect → clamped to min(10, 5) = 5
+        let rects = compute_rounded_rect_rects(0, 0, 20, 10, 100);
+        assert!(!rects.is_empty());
+        for &(rx, ry, rw, rh) in &rects {
+            assert!(rx >= 0 && ry >= 0 && rx + rw <= 20 && ry + rh <= 10);
+        }
+    }
+
+    #[test]
+    fn pill_shape_has_no_central_rect_when_height_equals_two_radii() {
+        // 20x10 with r=5 → clamped radius = 5, height = 2*5 = 10 → no center
+        let rects = compute_rounded_rect_rects(0, 0, 20, 10, 5);
+        // All rects should be height=1 scanlines (no tall central rect).
+        for &(_, _, _, rh) in &rects {
+            assert_eq!(rh, 1, "expected all scanlines, got height {rh}");
+        }
+    }
+
+    // ── Offset (non-zero origin) ────────────────────────────────────────
+
+    #[test]
+    fn offset_origin_shifts_all_rects() {
+        let base = compute_rounded_rect_rects(0, 0, 30, 30, 8);
+        let shifted = compute_rounded_rect_rects(100, 200, 30, 30, 8);
+        assert_eq!(base.len(), shifted.len());
+        for (b, s) in base.iter().zip(shifted.iter()) {
+            assert_eq!(b.0 + 100, s.0, "x mismatch");
+            assert_eq!(b.1 + 200, s.1, "y mismatch");
+            assert_eq!(b.2, s.2, "width mismatch");
+            assert_eq!(b.3, s.3, "height mismatch");
+        }
+    }
+
+    // ── Odd dimensions ──────────────────────────────────────────────────
+
+    #[test]
+    fn odd_dimensions_produce_valid_rects() {
+        let rects = compute_rounded_rect_rects(0, 0, 31, 31, 7);
+        assert!(!rects.is_empty());
+        let pixel_count = rasterize_pixel_count(&rects, 0, 0, 31, 31);
+        let sum_area = total_area(&rects) as usize;
+        assert_eq!(sum_area, pixel_count, "overlap with odd dims");
+    }
+
+    // ── Full coverage: every row has at least one pixel ─────────────────
+
+    #[test]
+    fn every_row_covered() {
+        for radius in [1, 5, 10] {
+            let (w, h) = (30, 30);
+            let rects = compute_rounded_rect_rects(0, 0, w, h, radius);
+            let mut row_covered = vec![false; h as usize];
+            for &(_, ry, _, rh) in &rects {
+                for y in ry..ry + rh {
+                    row_covered[y as usize] = true;
+                }
+            }
+            assert!(
+                row_covered.iter().all(|&c| c),
+                "not all rows covered for r={radius}"
+            );
+        }
     }
 }

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -527,6 +527,212 @@ impl BackgroundEffectManager {
         }
     }
 
+    /// Apply a blur region for the bar surface.
+    ///
+    /// When the bar has a non-zero background opacity (translucent/opaque bar),
+    /// the entire bar surface is blurred as a single rounded rectangle.
+    ///
+    /// When the bar background is fully transparent (opacity == 0.0, islands mode),
+    /// individual widget island regions are blurred instead via
+    /// `apply_bar_island_blur_regions`.
+    ///
+    /// Called from bar.rs on `connect_map` and from the layout allocate callback.
+    pub fn apply_bar_blur_region(&self, window: &gtk4::ApplicationWindow) {
+        if !self.available {
+            return;
+        }
+
+        let bar_opacity =
+            crate::services::config_manager::ConfigManager::global().bar_background_opacity();
+
+        if bar_opacity == 0.0 {
+            // Islands mode: defer to per-island path (called separately by the
+            // layout allocate callback once island bounds are known).
+            return;
+        }
+
+        // Opaque/translucent bar: blur the entire surface as one rounded rect.
+        let radius =
+            crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32;
+
+        // Re-use apply_blur_region with shadow_margin=0 (bar has no shadow padding).
+        self.apply_blur_region_with_radius(window, 0, radius);
+    }
+
+    /// Apply blur regions for individual widget islands on a transparent bar.
+    ///
+    /// `islands` is a slice of `(x, y, width, height)` tuples in surface-local
+    /// logical coordinates, one per visible `.widget-wrapper` island. Each island
+    /// gets a rounded rectangle region matching the widget border radius.
+    ///
+    /// Called from bar.rs via the `CenterPriorityLayout` allocate callback.
+    pub fn apply_bar_island_blur_regions(
+        &self,
+        window: &gtk4::ApplicationWindow,
+        islands: &[(i32, i32, i32, i32)],
+    ) {
+        if !self.available || islands.is_empty() {
+            return;
+        }
+
+        let Some(native) = window.native() else {
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            return;
+        };
+
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+
+        let mut state = self.state.borrow_mut();
+        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+            return;
+        };
+        let manager = manager.clone();
+        let compositor = compositor.clone();
+
+        let effect = state
+            .effects
+            .entry(surface_id)
+            .or_insert_with(|| {
+                debug!("Creating background effect object for bar island surface");
+                manager.get_background_effect(&wl_surface, &self.qh, ())
+            })
+            .clone();
+
+        drop(state);
+
+        let radius =
+            crate::services::config_manager::ConfigManager::global().widget_border_radius() as i32;
+
+        let region = compositor.create_region(&self.qh, ());
+        for &(x, y, w, h) in islands {
+            add_rounded_rect_to_region(&region, x, y, w, h, radius);
+        }
+
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+
+        debug!(
+            "Applied bar island blur regions: {} islands, r={}",
+            islands.len(),
+            radius
+        );
+    }
+
+    /// Internal helper: apply a blur region for a window with an explicit radius,
+    /// bypassing the shadow_margin-derived radius logic in `apply_blur_region`.
+    fn apply_blur_region_with_radius(
+        &self,
+        window: &gtk4::ApplicationWindow,
+        shadow_margin: i32,
+        radius: i32,
+    ) {
+        if !self.available {
+            return;
+        }
+
+        let Some(native) = window.native() else {
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            return;
+        };
+
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+
+        let width = wayland_surface.width();
+        let height = wayland_surface.height();
+
+        if width <= 0 || height <= 0 {
+            let win_clone = window.clone();
+            glib::idle_add_local_once(move || {
+                if let Some(blur) = Self::global() {
+                    blur.apply_bar_blur_region(&win_clone);
+                }
+            });
+            return;
+        }
+
+        let mut state = self.state.borrow_mut();
+        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+            return;
+        };
+        let manager = manager.clone();
+        let compositor = compositor.clone();
+
+        let effect = state
+            .effects
+            .entry(surface_id)
+            .or_insert_with(|| {
+                debug!("Creating background effect object for bar surface");
+                manager.get_background_effect(&wl_surface, &self.qh, ())
+            })
+            .clone();
+
+        drop(state);
+
+        let m = shadow_margin;
+        let region = compositor.create_region(&self.qh, ());
+        add_rounded_rect_to_region(&region, m, m, width - 2 * m, height - 2 * m, radius);
+
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+
+        debug!(
+            "Applied bar blur region: {}x{} r={} (surface {}x{})",
+            width - 2 * m,
+            height - 2 * m,
+            radius,
+            width,
+            height
+        );
+
+        // Install a resize watcher so the blur region tracks surface size changes.
+        const BLUR_BAR_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-bar-resize-watched";
+        unsafe {
+            if window.data::<bool>(BLUR_BAR_RESIZE_WATCHED_KEY).is_none() {
+                window.set_data(BLUR_BAR_RESIZE_WATCHED_KEY, true);
+                let win_clone = window.clone();
+                if let Some(gdk_surf) = window.native().and_then(|n| n.surface()) {
+                    gdk_surf.connect_notify_local(Some("width"), move |_, _| {
+                        if let Some(blur) = BackgroundEffectManager::global() {
+                            blur.apply_bar_blur_region(&win_clone);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
     /// Remove the blur region for a window (e.g. on destroy).
     #[allow(dead_code)]
     pub fn remove_blur_region(&self, window: &gtk4::ApplicationWindow) {
@@ -556,6 +762,185 @@ impl BackgroundEffectManager {
         if let Some(effect) = state.effects.remove(&surface_id) {
             effect.destroy();
             debug!("Removed blur region for surface");
+        }
+        drop(state);
+
+        // Flush so the destroy request reaches the compositor promptly.
+        // The change takes effect on the next wl_surface.commit (driven by GTK).
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+    }
+
+    /// Apply a blur region that tracks the ScaleBox grow-in animation.
+    ///
+    /// During the open animation the ScaleBox clips its child to a centered rect
+    /// whose size is `content_size * scale`.  This method sets the blur region to
+    /// match that clip so the compositor blur grows in sync with the visual.
+    ///
+    /// `scale` should be the current ScaleBox scale (ANIM_SCALE_FROM → 1.0).
+    /// At `scale == 1.0` this produces the same region as `apply_blur_region`.
+    pub fn apply_blur_region_animated(
+        &self,
+        window: &gtk4::ApplicationWindow,
+        shadow_margin: i32,
+        scale: f64,
+    ) {
+        if !self.available {
+            return;
+        }
+
+        let Some(native) = window.native() else {
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            return;
+        };
+
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+
+        let mut state = self.state.borrow_mut();
+        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+            return;
+        };
+        let manager = manager.clone();
+        let compositor = compositor.clone();
+
+        let effect = state
+            .effects
+            .entry(surface_id)
+            .or_insert_with(|| manager.get_background_effect(&wl_surface, &self.qh, ()))
+            .clone();
+
+        drop(state);
+
+        let width = wayland_surface.width();
+        let height = wayland_surface.height();
+
+        if width <= 0 || height <= 0 {
+            return;
+        }
+
+        // Compute effective shadow margins (same logic as apply_blur_region).
+        let effective_margin = if shadow_margin > 0 {
+            crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
+        } else {
+            0
+        };
+
+        let m = effective_margin;
+        let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
+            let is_bottom =
+                crate::services::config_manager::ConfigManager::global().bar_is_bottom();
+            if is_bottom {
+                (m, 0, m, m)
+            } else {
+                (0, m, m, m)
+            }
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        // Content area within shadow margins (= ScaleBox allocation).
+        let content_w = (width - margin_start - margin_end) as f64;
+        let content_h = (height - margin_top - margin_bottom) as f64;
+
+        // ScaleBox clips to a centered rect of size content * scale.
+        let scaled_w = content_w * scale;
+        let scaled_h = content_h * scale;
+        let dx = (content_w - scaled_w) / 2.0;
+        let dy = (content_h - scaled_h) / 2.0;
+
+        // Final rect in surface coordinates.
+        let x = margin_start as f64 + dx;
+        let y = margin_top as f64 + dy;
+
+        let radius = if shadow_margin > 0 {
+            crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
+        } else {
+            0
+        };
+
+        let region = compositor.create_region(&self.qh, ());
+        add_rounded_rect_to_region(
+            &region,
+            x.round() as i32,
+            y.round() as i32,
+            scaled_w.round() as i32,
+            scaled_h.round() as i32,
+            radius,
+        );
+
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+    }
+
+    /// Clear the blur region for a surface without destroying the effect object.
+    ///
+    /// Sets a minimal 1x1 blur region which is effectively invisible.  We cannot
+    /// send `set_blur_region(NULL)` because the protocol defines NULL as "blur the
+    /// entire surface".  The effect object is kept alive so it can be reused on
+    /// the next open without re-creation.
+    ///
+    /// Called at the start of a close animation so the compositor stops drawing
+    /// blur behind the surface while it fades out.
+    pub fn clear_blur_region(&self, window: &gtk4::ApplicationWindow) {
+        if !self.available {
+            return;
+        }
+
+        let Some(native) = window.native() else {
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            return;
+        };
+
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+        let state = self.state.borrow();
+        let Some(compositor) = state.compositor.clone() else {
+            return;
+        };
+        if let Some(effect) = state.effects.get(&surface_id) {
+            // Set a 1x1 empty region instead of NULL — NULL means "blur the
+            // entire surface" per the protocol spec, which is not what we want.
+            // A minimal region is effectively invisible and keeps the effect
+            // object alive for reuse on the next open.
+            let region = compositor.create_region(&self.qh, ());
+            region.add(0, 0, 1, 1);
+            effect.set_blur_region(Some(&region));
+            region.destroy();
+            wl_surface.commit();
+            debug!("Cleared blur region for surface (set to 1x1)");
+        }
+        drop(state);
+
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
         }
     }
 }

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -5,6 +5,26 @@
 //! and transparent padding. This is a **zero-cost hint** — if the compositor
 //! has no blur configured, it is silently ignored.
 //!
+//! ## Surface scope
+//!
+//! Covers all vibepanel-managed surfaces with visible backgrounds:
+//! bar (opaque and island modes), layer-shell popovers, Quick Settings,
+//! notification toasts, OSD, tray menus, and the media pop-out window.
+//!
+//! Intentionally excluded:
+//! - **Quick Settings row sub-menus** (`gtk4::Popover` / `xdg_popup`) — wifi,
+//!   bluetooth, and power card context menus.  These are subordinate menus
+//!   inside an already-blurred layer-shell surface; the visual benefit is
+//!   negligible and they are not "top-level" surfaces in the user's view.
+//! - **Tooltips** (`services/tooltip.rs`) — layer-shell surfaces but tiny and
+//!   ephemeral; blur would not be visible behind a single-line label.
+//!
+//! Note: tray menus and the media pop-out are `xdg_popup` / XDG-toplevel
+//! surfaces respectively.  Whether the compositor actually renders blur for
+//! them depends on compositor support.  niri supports both as of PR #3483
+//! (`wip/branch`).  On compositors without support the hints are silently
+//! ignored — no harm done.
+//!
 //! ## Architecture
 //!
 //! The service bridges GDK's Wayland connection with `wayland-client` objects.
@@ -25,9 +45,9 @@ use gtk4::prelude::*;
 use tracing::{debug, trace, warn};
 use wayland_client::protocol::wl_compositor::WlCompositor;
 use wayland_client::protocol::wl_registry;
-use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle, WEnum};
+use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
 use wayland_protocols::ext::background_effect::v1::client::{
-    ext_background_effect_manager_v1::{self, Capability, ExtBackgroundEffectManagerV1},
+    ext_background_effect_manager_v1::{self, ExtBackgroundEffectManagerV1},
     ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
 };
 
@@ -43,8 +63,6 @@ struct BlurState {
     compositor: Option<WlCompositor>,
     /// Cached per-surface effect objects, keyed by `wl_surface` ObjectId.
     effects: HashMap<wayland_client::backend::ObjectId, ExtBackgroundEffectSurfaceV1>,
-    /// Whether the compositor advertised blur capability.
-    blur_capable: bool,
 }
 
 impl BlurState {
@@ -53,7 +71,6 @@ impl BlurState {
             manager: None,
             compositor: None,
             effects: HashMap::new(),
-            blur_capable: false,
         }
     }
 }
@@ -94,31 +111,14 @@ impl Dispatch<wl_registry::WlRegistry, ()> for BlurState {
 
 impl Dispatch<ExtBackgroundEffectManagerV1, ()> for BlurState {
     fn event(
-        state: &mut Self,
+        _state: &mut Self,
         _proxy: &ExtBackgroundEffectManagerV1,
-        event: ext_background_effect_manager_v1::Event,
+        _event: ext_background_effect_manager_v1::Event,
         _data: &(),
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
-            let was_capable = state.blur_capable;
-            // flags is WEnum<Capability> — extract the inner value and check for Blur.
-            state.blur_capable = match flags {
-                WEnum::Value(cap) => cap.contains(Capability::Blur),
-                WEnum::Unknown(_) => false,
-            };
-            if state.blur_capable != was_capable {
-                debug!(
-                    "Background effect blur capability: {}",
-                    if state.blur_capable {
-                        "available"
-                    } else {
-                        "lost"
-                    }
-                );
-            }
-        }
+        // No events we need to handle.
     }
 }
 
@@ -171,8 +171,10 @@ impl Dispatch<wayland_client::protocol::wl_region::WlRegion, ()> for BlurState {
 /// are geometrically unavoidable (pigeonhole principle) but are imperceptible
 /// there since the circle is nearly vertical.
 ///
-/// If `radius` is zero or the radius is too large for the dimensions, falls
-/// back to a single rectangle.
+/// If `radius` is zero or the dimensions are too small to accommodate it,
+/// clamps to a pill shape or falls back to a plain rectangle.
+/// Non-positive `width` or `height` are silently ignored (no `wl_region.add`
+/// call is made — per Wayland protocol, non-positive dimensions are invalid).
 fn add_rounded_rect_to_region(
     region: &wayland_client::protocol::wl_region::WlRegion,
     x: i32,
@@ -181,14 +183,26 @@ fn add_rounded_rect_to_region(
     height: i32,
     radius: i32,
 ) {
-    if radius <= 0 || radius * 2 > width || radius * 2 > height {
+    if width <= 0 || height <= 0 {
+        return;
+    }
+    if radius <= 0 {
+        region.add(x, y, width, height);
+        return;
+    }
+    // Clamp to half the smallest dimension so oversized radii produce a
+    // pill shape instead of a plain rectangle.
+    let radius = radius.min(width / 2).min(height / 2);
+    if radius <= 0 {
         region.add(x, y, width, height);
         return;
     }
 
     // Central rectangle spanning the full width, excluding the top and bottom
     // radius strips.
-    region.add(x, y + radius, width, height - 2 * radius);
+    if height > 2 * radius {
+        region.add(x, y + radius, width, height - 2 * radius);
+    }
 
     let r = radius as f64;
     for i in 0..radius as usize {
@@ -204,6 +218,85 @@ fn add_rounded_rect_to_region(
     }
 }
 
+/// Compute effective shadow margins and border radius for a blur region.
+///
+/// Resolves the base `shadow_margin` through `SurfaceStyleManager` (respecting
+/// the `shadows_enabled` flag) and applies the asymmetric layout where the
+/// bar-adjacent side gets 0 margin.
+///
+/// Returns `(margin_top, margin_bottom, margin_start, margin_end, radius)`.
+fn compute_shadow_layout(shadow_margin: i32) -> (i32, i32, i32, i32, i32) {
+    let effective_margin = if shadow_margin > 0 {
+        crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
+    } else {
+        0
+    };
+
+    let m = effective_margin;
+    let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
+        let is_bottom = crate::services::config_manager::ConfigManager::global().bar_is_bottom();
+        if is_bottom {
+            (m, 0, m, m) // bar at bottom → top/start/end get margin, bottom = 0
+        } else {
+            (0, m, m, m) // bar at top → bottom/start/end get margin, top = 0
+        }
+    } else {
+        (0, 0, 0, 0)
+    };
+
+    let radius = if shadow_margin > 0 {
+        crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
+    } else {
+        0
+    };
+
+    (margin_top, margin_bottom, margin_start, margin_end, radius)
+}
+
+// ── Surface info helper ─────────────────────────────────────────────────────
+
+/// Resolved Wayland surface info for a GTK widget.
+///
+/// Extracts the `wl_surface`, GDK `WaylandSurface`, and a stable `ObjectId`
+/// for use as a cache key.  Avoids duplicating the same 15-line lookup
+/// boilerplate across every method that needs to interact with a surface.
+struct SurfaceInfo {
+    wl_surface: wayland_client::protocol::wl_surface::WlSurface,
+    wayland_surface: gdk4_wayland::WaylandSurface,
+    surface_id: wayland_client::backend::ObjectId,
+}
+
+impl SurfaceInfo {
+    /// Resolve surface info from any widget that has a native surface.
+    fn from_widget(widget: &impl gtk4::prelude::IsA<gtk4::Widget>) -> Option<Self> {
+        let native = widget.as_ref().native()?;
+        let gdk_surface = native.surface()?;
+        let wayland_surface = gdk_surface
+            .downcast::<gdk4_wayland::WaylandSurface>()
+            .ok()?;
+        let wl_surface = wayland_surface.wl_surface()?;
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+        Some(Self {
+            wl_surface,
+            wayland_surface,
+            surface_id,
+        })
+    }
+
+    /// Surface width in logical pixels.
+    fn width(&self) -> i32 {
+        self.wayland_surface.width()
+    }
+
+    /// Surface height in logical pixels.
+    fn height(&self) -> i32 {
+        self.wayland_surface.height()
+    }
+}
+
 // ── Thread-local singleton ──────────────────────────────────────────────────
 
 thread_local! {
@@ -215,8 +308,6 @@ pub struct BackgroundEffectManager {
     state: RefCell<BlurState>,
     event_queue: RefCell<EventQueue<BlurState>>,
     qh: QueueHandle<BlurState>,
-    /// Whether the protocol is available on this compositor.
-    available: bool,
 }
 
 impl BackgroundEffectManager {
@@ -224,7 +315,7 @@ impl BackgroundEffectManager {
     ///
     /// Must be called on the main thread after `gtk4::gdk::Display::default()` is available.
     /// If the compositor does not advertise `ext_background_effect_manager_v1`, the
-    /// service becomes inert — all `apply_blur_region` calls are no-ops.
+    /// singleton remains `None` and all callers' `global()` checks become no-ops.
     pub fn init_global() {
         INSTANCE.with(|cell| {
             if cell.borrow().is_some() {
@@ -306,15 +397,8 @@ impl BackgroundEffectManager {
             return None;
         }
 
-        // Second roundtrip to receive the capabilities event.
-        if let Err(e) = event_queue.roundtrip(&mut state) {
-            warn!("Failed blur service capabilities roundtrip: {e}");
-            return None;
-        }
-
         debug!(
-            "Blur service initialized (blur_capable={}, compositor={:?})",
-            state.blur_capable,
+            "Blur service initialized (compositor={:?})",
             state.compositor.is_some()
         );
 
@@ -322,10 +406,9 @@ impl BackgroundEffectManager {
             state: RefCell::new(state),
             event_queue: RefCell::new(event_queue),
             qh,
-            available: true,
         };
 
-        // Install fd watcher to dispatch events (e.g. capability changes).
+        // Install fd watcher to dispatch incoming protocol events.
         mgr.install_event_dispatch();
 
         Some(mgr)
@@ -372,6 +455,65 @@ impl BackgroundEffectManager {
         });
     }
 
+    /// Get or create the per-surface effect object and return it alongside
+    /// a cloned compositor reference.
+    ///
+    /// The effect is cached by `wl_surface` `ObjectId` to avoid the protocol
+    /// error raised when creating duplicates.
+    fn get_or_create_effect(
+        &self,
+        info: &SurfaceInfo,
+    ) -> Option<(ExtBackgroundEffectSurfaceV1, WlCompositor)> {
+        let mut state = self.state.borrow_mut();
+        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+            return None;
+        };
+        let manager = manager.clone();
+        let compositor = compositor.clone();
+
+        let effect = state
+            .effects
+            .entry(info.surface_id.clone())
+            .or_insert_with(|| {
+                debug!("Creating background effect object for surface");
+                manager.get_background_effect(&info.wl_surface, &self.qh, ())
+            })
+            .clone();
+
+        Some((effect, compositor))
+    }
+
+    /// Flush the event queue so requests reach the compositor promptly.
+    fn flush(&self) {
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+    }
+
+    /// Install a one-shot resize watcher on a window's GDK surface.
+    ///
+    /// We watch only `width`, which is sufficient: GDK's internal
+    /// `_gdk_surface_update_size()` emits both `notify::width` and
+    /// `notify::height` whenever *any* dimension changes, so height-only
+    /// configures still fire `notify::width`.
+    ///
+    /// The watcher is installed at most once per `key` per window.
+    fn install_resize_watcher(
+        window: &gtk4::ApplicationWindow,
+        key: &'static str,
+        on_resize: impl Fn() + 'static,
+    ) {
+        unsafe {
+            if window.data::<bool>(key).is_some() {
+                return;
+            }
+            window.set_data(key, true);
+        }
+        if let Some(gdk_surface) = window.native().and_then(|n| n.surface()) {
+            gdk_surface.connect_notify_local(Some("width"), move |_, _| on_resize());
+        }
+    }
+
     /// Apply a blur region hint to the given window's surface.
     ///
     /// `shadow_margin` is the padding (in surface-local px) between the layer-shell
@@ -386,96 +528,44 @@ impl BackgroundEffectManager {
     /// This is fire-and-forget: the region is double-buffered and applied on
     /// GTK's next `wl_surface.commit`.
     pub fn apply_blur_region(&self, window: &gtk4::ApplicationWindow, shadow_margin: i32) {
-        if !self.available {
-            return;
-        }
-
-        // Get the wl_surface from the GDK surface.
-        let Some(native) = window.native() else {
-            trace!("No native for window, skipping blur");
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            trace!("No GDK surface for window, skipping blur");
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
+        let Some(info) = SurfaceInfo::from_widget(window) else {
             trace!("No wl_surface for window, skipping blur");
             return;
         };
 
-        // Use fully-qualified syntax to avoid clash with gtk4::prelude's id() methods.
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
-
-        // Get or create the effect object for this surface.
-        // Extract manager clone before entry API to avoid borrow conflict.
-        let mut state = self.state.borrow_mut();
-
-        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
-            return;
-        };
-        let manager = manager.clone();
-        let compositor = compositor.clone();
-
-        let effect = state
-            .effects
-            .entry(surface_id)
-            .or_insert_with(|| {
-                debug!("Creating background effect object for surface");
-                manager.get_background_effect(&wl_surface, &self.qh, ())
-            })
-            .clone();
-
-        drop(state);
-
-        // Get the surface dimensions from the WaylandSurface (which derefs to gdk::Surface).
-        let width = wayland_surface.width();
-        let height = wayland_surface.height();
+        let width = info.width();
+        let height = info.height();
 
         if width <= 0 || height <= 0 {
-            // Surface not sized yet (common on first map). Schedule an idle retry
-            // so we apply the region once GTK has committed actual dimensions.
+            // Surface not sized yet (common on first map). Schedule a one-shot
+            // idle retry so we apply the region once GTK has committed actual
+            // dimensions. A set_data guard prevents stacking multiple retries if
+            // this is called several times before the surface gets sized.
+            const RETRY_KEY: &str = "vibepanel-blur-region-retry-pending";
+            if unsafe { window.data::<bool>(RETRY_KEY) }.is_some() {
+                trace!("Idle retry already pending, skipping duplicate");
+                return;
+            }
+            unsafe { window.set_data(RETRY_KEY, true) };
             trace!("Surface has no size yet, deferring blur region to idle");
             let win_clone = window.clone();
             glib::idle_add_local_once(move || {
-                if let Some(blur) = Self::global() {
+                unsafe { win_clone.steal_data::<bool>(RETRY_KEY) };
+                if crate::services::config_manager::ConfigManager::global().blur_enabled()
+                    && let Some(blur) = Self::global()
+                {
                     blur.apply_blur_region(&win_clone, shadow_margin);
                 }
             });
             return;
         }
 
-        // Run the base margin through SurfaceStyleManager to respect the
-        // shadows_enabled flag — when shadows are off, the actual margin is 0
-        // even though the caller passes the base constant.
-        let effective_margin = if shadow_margin > 0 {
-            crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
-        } else {
-            0
+        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
+            return;
         };
 
-        // Compute per-side margins matching `SurfaceStyleManager::apply_shadow_margins`:
-        // the bar-adjacent side gets 0 margin (content is flush against the bar),
-        // the other three sides get the full effective margin.
-        let m = effective_margin;
-        let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
-            let is_bottom =
-                crate::services::config_manager::ConfigManager::global().bar_is_bottom();
-            if is_bottom {
-                (m, 0, m, m) // bar at bottom → top/start/end get margin, bottom = 0
-            } else {
-                (0, m, m, m) // bar at top → bottom/start/end get margin, top = 0
-            }
-        } else {
-            (0, 0, 0, 0)
-        };
+        let (margin_top, margin_bottom, margin_start, margin_end, radius) =
+            compute_shadow_layout(shadow_margin);
 
         let region = compositor.create_region(&self.qh, ());
         let x = margin_start;
@@ -483,25 +573,11 @@ impl BackgroundEffectManager {
         let w = width - margin_start - margin_end;
         let h = height - margin_top - margin_bottom;
 
-        // Use rounded corners for surfaces with shadow margins (popovers, QS).
-        // The bar (shadow_margin == 0) has no visible border-radius for blur.
-        let radius = if shadow_margin > 0 {
-            crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
-        } else {
-            0
-        };
-
         add_rounded_rect_to_region(&region, x, y, w, h, radius);
 
         effect.set_blur_region(Some(&region));
-
-        // The region object can be destroyed immediately (copy semantics).
         region.destroy();
-
-        // Flush to ensure the request reaches the compositor.
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
+        self.flush();
 
         debug!(
             "Applied blur region: {}x{} at ({},{}) r={} margins t={} b={} s={} e={} (surface {}x{})",
@@ -511,37 +587,34 @@ impl BackgroundEffectManager {
         // Install a resize watcher (once per window) so the blur region
         // is re-applied whenever the surface dimensions change — e.g. when
         // a Revealer expands and the layer-shell surface reconfigures.
-        const BLUR_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-resize-watched";
-        unsafe {
-            if window.data::<bool>(BLUR_RESIZE_WATCHED_KEY).is_none() {
-                window.set_data(BLUR_RESIZE_WATCHED_KEY, true);
-                let win_clone = window.clone();
-                if let Some(gdk_surface) = window.native().and_then(|n| n.surface()) {
-                    gdk_surface.connect_notify_local(Some("width"), move |_, _| {
-                        if let Some(blur) = BackgroundEffectManager::global() {
-                            blur.apply_blur_region(&win_clone, shadow_margin);
-                        }
-                    });
-                }
+        let win_clone = window.clone();
+        Self::install_resize_watcher(window, "vibepanel-blur-resize-watched", move || {
+            if crate::services::config_manager::ConfigManager::global().blur_enabled()
+                && let Some(blur) = BackgroundEffectManager::global()
+            {
+                blur.apply_blur_region(&win_clone, shadow_margin);
             }
-        }
+        });
     }
 
     /// Apply a blur region for the bar surface.
     ///
     /// When the bar has a non-zero background opacity (translucent/opaque bar),
-    /// the entire bar surface is blurred as a single rounded rectangle.
+    /// the blur region is derived from `bar_box`'s allocation within the surface
+    /// via `compute_bounds`.  This correctly excludes the transparent
+    /// `.bar-margin-spacer` and `.bar-shell-inner` padding areas that surround
+    /// the visible bar background when `screen_margin > 0`.
     ///
     /// When the bar background is fully transparent (opacity == 0.0, islands mode),
     /// individual widget island regions are blurred instead via
     /// `apply_bar_island_blur_regions`.
     ///
-    /// Called from bar.rs on `connect_map` and from the layout allocate callback.
-    pub fn apply_bar_blur_region(&self, window: &gtk4::ApplicationWindow) {
-        if !self.available {
-            return;
-        }
-
+    /// Called from bar.rs on `connect_map` and from the `on_theme_change` handler.
+    pub fn apply_bar_blur_region(
+        &self,
+        window: &gtk4::ApplicationWindow,
+        bar_box: &impl gtk4::prelude::IsA<gtk4::Widget>,
+    ) {
         let bar_opacity =
             crate::services::config_manager::ConfigManager::global().bar_background_opacity();
 
@@ -551,12 +624,12 @@ impl BackgroundEffectManager {
             return;
         }
 
-        // Opaque/translucent bar: blur the entire surface as one rounded rect.
+        // Opaque/translucent bar: blur only the bar_box bounds, not the full surface.
+        // Using apply_blur_surface so compute_bounds accounts for any margin/padding.
         let radius =
             crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32;
 
-        // Re-use apply_blur_region with shadow_margin=0 (bar has no shadow padding).
-        self.apply_blur_region_with_radius(window, 0, radius);
+        self.apply_blur_surface(window, bar_box, radius);
     }
 
     /// Apply blur regions for individual widget islands on a transparent bar.
@@ -571,46 +644,17 @@ impl BackgroundEffectManager {
         window: &gtk4::ApplicationWindow,
         islands: &[(i32, i32, i32, i32)],
     ) {
-        if !self.available || islands.is_empty() {
+        if islands.is_empty() {
             return;
         }
 
-        let Some(native) = window.native() else {
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
+        let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
         };
 
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
-
-        let mut state = self.state.borrow_mut();
-        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
             return;
         };
-        let manager = manager.clone();
-        let compositor = compositor.clone();
-
-        let effect = state
-            .effects
-            .entry(surface_id)
-            .or_insert_with(|| {
-                debug!("Creating background effect object for bar island surface");
-                manager.get_background_effect(&wl_surface, &self.qh, ())
-            })
-            .clone();
-
-        drop(state);
 
         let radius =
             crate::services::config_manager::ConfigManager::global().widget_border_radius() as i32;
@@ -622,10 +666,7 @@ impl BackgroundEffectManager {
 
         effect.set_blur_region(Some(&region));
         region.destroy();
-
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
+        self.flush();
 
         debug!(
             "Applied bar island blur regions: {} islands, r={}",
@@ -634,132 +675,14 @@ impl BackgroundEffectManager {
         );
     }
 
-    /// Internal helper: apply a blur region for a window with an explicit radius,
-    /// bypassing the shadow_margin-derived radius logic in `apply_blur_region`.
-    fn apply_blur_region_with_radius(
-        &self,
-        window: &gtk4::ApplicationWindow,
-        shadow_margin: i32,
-        radius: i32,
-    ) {
-        if !self.available {
-            return;
-        }
-
-        let Some(native) = window.native() else {
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
-            return;
-        };
-
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
-
-        let width = wayland_surface.width();
-        let height = wayland_surface.height();
-
-        if width <= 0 || height <= 0 {
-            let win_clone = window.clone();
-            glib::idle_add_local_once(move || {
-                if let Some(blur) = Self::global() {
-                    blur.apply_bar_blur_region(&win_clone);
-                }
-            });
-            return;
-        }
-
-        let mut state = self.state.borrow_mut();
-        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
-            return;
-        };
-        let manager = manager.clone();
-        let compositor = compositor.clone();
-
-        let effect = state
-            .effects
-            .entry(surface_id)
-            .or_insert_with(|| {
-                debug!("Creating background effect object for bar surface");
-                manager.get_background_effect(&wl_surface, &self.qh, ())
-            })
-            .clone();
-
-        drop(state);
-
-        let m = shadow_margin;
-        let region = compositor.create_region(&self.qh, ());
-        add_rounded_rect_to_region(&region, m, m, width - 2 * m, height - 2 * m, radius);
-
-        effect.set_blur_region(Some(&region));
-        region.destroy();
-
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
-
-        debug!(
-            "Applied bar blur region: {}x{} r={} (surface {}x{})",
-            width - 2 * m,
-            height - 2 * m,
-            radius,
-            width,
-            height
-        );
-
-        // Install a resize watcher so the blur region tracks surface size changes.
-        const BLUR_BAR_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-bar-resize-watched";
-        unsafe {
-            if window.data::<bool>(BLUR_BAR_RESIZE_WATCHED_KEY).is_none() {
-                window.set_data(BLUR_BAR_RESIZE_WATCHED_KEY, true);
-                let win_clone = window.clone();
-                if let Some(gdk_surf) = window.native().and_then(|n| n.surface()) {
-                    gdk_surf.connect_notify_local(Some("width"), move |_, _| {
-                        if let Some(blur) = BackgroundEffectManager::global() {
-                            blur.apply_bar_blur_region(&win_clone);
-                        }
-                    });
-                }
-            }
-        }
-    }
-
     /// Remove the blur region for a window (e.g. on destroy).
-    #[allow(dead_code)]
-    pub fn remove_blur_region(&self, window: &gtk4::ApplicationWindow) {
-        if !self.available {
-            return;
-        }
-
-        let Some(native) = window.native() else {
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
+    pub fn remove_blur_region(&self, window: &impl gtk4::prelude::IsA<gtk4::Widget>) {
+        let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
         };
 
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
         let mut state = self.state.borrow_mut();
-        if let Some(effect) = state.effects.remove(&surface_id) {
+        if let Some(effect) = state.effects.remove(&info.surface_id) {
             effect.destroy();
             debug!("Removed blur region for surface");
         }
@@ -767,9 +690,7 @@ impl BackgroundEffectManager {
 
         // Flush so the destroy request reaches the compositor promptly.
         // The change takes effect on the next wl_surface.commit (driven by GTK).
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
+        self.flush();
     }
 
     /// Apply a blur region that tracks the ScaleBox grow-in animation.
@@ -786,70 +707,23 @@ impl BackgroundEffectManager {
         shadow_margin: i32,
         scale: f64,
     ) {
-        if !self.available {
-            return;
-        }
-
-        let Some(native) = window.native() else {
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
+        let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
         };
 
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
-
-        let mut state = self.state.borrow_mut();
-        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
             return;
         };
-        let manager = manager.clone();
-        let compositor = compositor.clone();
 
-        let effect = state
-            .effects
-            .entry(surface_id)
-            .or_insert_with(|| manager.get_background_effect(&wl_surface, &self.qh, ()))
-            .clone();
-
-        drop(state);
-
-        let width = wayland_surface.width();
-        let height = wayland_surface.height();
+        let width = info.width();
+        let height = info.height();
 
         if width <= 0 || height <= 0 {
             return;
         }
 
-        // Compute effective shadow margins (same logic as apply_blur_region).
-        let effective_margin = if shadow_margin > 0 {
-            crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
-        } else {
-            0
-        };
-
-        let m = effective_margin;
-        let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
-            let is_bottom =
-                crate::services::config_manager::ConfigManager::global().bar_is_bottom();
-            if is_bottom {
-                (m, 0, m, m)
-            } else {
-                (0, m, m, m)
-            }
-        } else {
-            (0, 0, 0, 0)
-        };
+        let (margin_top, margin_bottom, margin_start, margin_end, radius) =
+            compute_shadow_layout(shadow_margin);
 
         // Content area within shadow margins (= ScaleBox allocation).
         let content_w = (width - margin_start - margin_end) as f64;
@@ -865,12 +739,6 @@ impl BackgroundEffectManager {
         let x = margin_start as f64 + dx;
         let y = margin_top as f64 + dy;
 
-        let radius = if shadow_margin > 0 {
-            crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
-        } else {
-            0
-        };
-
         let region = compositor.create_region(&self.qh, ());
         add_rounded_rect_to_region(
             &region,
@@ -883,64 +751,118 @@ impl BackgroundEffectManager {
 
         effect.set_blur_region(Some(&region));
         region.destroy();
-
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
+        self.flush();
     }
 
-    /// Clear the blur region for a surface without destroying the effect object.
+    /// Apply a blur region matching a content widget's allocation within its surface.
     ///
-    /// Sets a minimal 1x1 blur region which is effectively invisible.  We cannot
-    /// send `set_blur_region(NULL)` because the protocol defines NULL as "blur the
-    /// entire surface".  The effect object is kept alive so it can be reused on
-    /// the next open without re-creation.
+    /// Designed for surfaces without explicit shadow margins (OSD, notification
+    /// toast, tray menu popover, media pop-out) where the surface may be
+    /// slightly larger than the visible content due to CSS box-shadow expansion.
+    /// The `content` widget's allocation provides the exact bounds to blur.
     ///
-    /// Called at the start of a close animation so the compositor stops drawing
-    /// blur behind the surface while it fades out.
-    pub fn clear_blur_region(&self, window: &gtk4::ApplicationWindow) {
-        if !self.available {
+    /// `surface_root` is any widget whose `GtkNative` owns the `wl_surface`
+    /// (a `gtk4::Window`, `gtk4::ApplicationWindow`, or `gtk4::Popover`);
+    /// `content` is the child widget whose allocation defines the blur region;
+    /// `radius` is the corner radius.
+    ///
+    /// On first map the Wayland surface may still be a 1×1 placeholder before
+    /// the compositor sends configure.  In that case, a one-shot watcher on
+    /// the GDK surface's `width` property defers the apply until configure
+    /// arrives and layout completes.
+    pub fn apply_blur_surface(
+        &self,
+        surface_root: &impl gtk4::prelude::IsA<gtk4::Widget>,
+        content: &impl gtk4::prelude::IsA<gtk4::Widget>,
+        radius: i32,
+    ) {
+        let Some(info) = SurfaceInfo::from_widget(surface_root) else {
+            debug!("apply_blur_surface: no wl_surface, skipping");
             return;
-        }
+        };
 
-        let Some(native) = window.native() else {
-            return;
-        };
-        let Some(gdk_surface) = native.surface() else {
-            return;
-        };
-        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        let Some(wl_surface) = wayland_surface.wl_surface() else {
-            return;
-        };
+        let width = info.width();
+        let height = info.height();
 
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
+        let surface_root_widget = surface_root.as_ref();
+        let content_widget = content.as_ref();
+
+        // Validate that the surface has a real size (not the initial 1×1
+        // placeholder) and that compute_bounds returns sensible values.
+        let surface_ready = width > 1 && height > 1;
+        let bounds = content_widget.compute_bounds(surface_root_widget);
+        let bounds_valid = bounds
+            .as_ref()
+            .is_some_and(|b| b.x() >= 0.0 && b.y() >= 0.0 && b.width() > 0.0 && b.height() > 0.0);
+
+        if !surface_ready || !bounds_valid {
+            debug!(
+                "apply_blur_surface: not ready (surface {}x{}, bounds {:?}), deferring",
+                width, height, bounds
             );
-        let state = self.state.borrow();
-        let Some(compositor) = state.compositor.clone() else {
+            // Watch `width` (covers height-only changes too — see
+            // install_resize_watcher doc).  Defer to idle so the GTK layout
+            // pass completes before we read compute_bounds.
+            if let Some(gdk_surface) = surface_root_widget.native().and_then(|n| n.surface()) {
+                let key = "vibepanel-blur-surface-watched";
+                unsafe {
+                    if gdk_surface.data::<bool>(key).is_some() {
+                        return; // watcher already installed
+                    }
+                    gdk_surface.set_data(key, true);
+                }
+                // Clone as gtk4::Widget (the common base) so the closure can
+                // hold the value regardless of the concrete surface_root type.
+                let root_clone = surface_root_widget.clone();
+                let content_clone = content_widget.clone();
+                gdk_surface.connect_notify_local(Some("width"), move |_, _| {
+                    let rc = root_clone.clone();
+                    let cc = content_clone.clone();
+                    glib::idle_add_local_once(move || {
+                        if crate::services::config_manager::ConfigManager::global().blur_enabled()
+                            && let Some(blur) = Self::global()
+                        {
+                            blur.apply_blur_surface(&rc, &cc, radius);
+                        }
+                    });
+                });
+            }
+            return;
+        }
+
+        let bounds = bounds.unwrap();
+        let bx = bounds.x().round() as i32;
+        let by = bounds.y().round() as i32;
+        let bw = bounds.width().round() as i32;
+        let bh = bounds.height().round() as i32;
+
+        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
             return;
         };
-        if let Some(effect) = state.effects.get(&surface_id) {
-            // Set a 1x1 empty region instead of NULL — NULL means "blur the
-            // entire surface" per the protocol spec, which is not what we want.
-            // A minimal region is effectively invisible and keeps the effect
-            // object alive for reuse on the next open.
-            let region = compositor.create_region(&self.qh, ());
-            region.add(0, 0, 1, 1);
-            effect.set_blur_region(Some(&region));
-            region.destroy();
-            wl_surface.commit();
-            debug!("Cleared blur region for surface (set to 1x1)");
-        }
-        drop(state);
 
-        if let Ok(eq) = self.event_queue.try_borrow() {
-            let _ = eq.flush();
-        }
+        let region = compositor.create_region(&self.qh, ());
+        add_rounded_rect_to_region(&region, bx, by, bw, bh, radius);
+
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+        // Commit the surface so the double-buffered blur region takes effect
+        // immediately.  Without this, the region stays pending until GTK's
+        // next wl_surface.commit — which may never come for surfaces whose
+        // layout is already complete (e.g. tray popovers reached via the
+        // deferred idle path).
+        info.wl_surface.commit();
+        self.flush();
+
+        // No dedicated resize watcher is installed here beyond the readiness
+        // watcher above.  That watcher remains connected and will re-apply the
+        // blur region on subsequent resizes, which is correct behaviour.
+        // Current consumers have stable content bounds after initial layout,
+        // so re-applies are infrequent.  A future consumer with dynamically-
+        // resizing content gets automatic re-apply for free via the same
+        // watcher.
+        debug!(
+            "Applied blur surface: {}x{} at ({},{}) r={} (surface {}x{})",
+            bw, bh, bx, by, radius, width, height
+        );
     }
 }

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -1,0 +1,561 @@
+//! Wayland background effect (blur) region hints.
+//!
+//! Uses the `ext-background-effect-v1` staging protocol to tell the compositor
+//! exactly which region of each surface should be blurred, excluding shadows
+//! and transparent padding. This is a **zero-cost hint** — if the compositor
+//! has no blur configured, it is silently ignored.
+//!
+//! ## Architecture
+//!
+//! The service bridges GDK's Wayland connection with `wayland-client` objects.
+//! It creates its own `EventQueue` on GDK's `wl_display` and integrates it
+//! into the glib main loop via `unix_fd_add_local`.
+//!
+//! Per-surface `ExtBackgroundEffectSurfaceV1` objects are cached by
+//! `ObjectId` to avoid the protocol error raised when creating duplicates.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::os::fd::{AsFd, AsRawFd};
+use std::rc::Rc;
+
+use gdk4_wayland::prelude::*;
+use gtk4::glib;
+use gtk4::prelude::*;
+use tracing::{debug, trace, warn};
+use wayland_client::protocol::wl_compositor::WlCompositor;
+use wayland_client::protocol::wl_registry;
+use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle, WEnum};
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1::{self, Capability, ExtBackgroundEffectManagerV1},
+    ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
+};
+
+// ── Dispatch state ──────────────────────────────────────────────────────────
+
+/// Internal wayland-client dispatch state.
+///
+/// Holds the bound manager, compositor, and per-surface effect objects.
+struct BlurState {
+    /// The bound manager global (set after registry advertises it).
+    manager: Option<ExtBackgroundEffectManagerV1>,
+    /// The compositor global (needed to create `wl_region` objects).
+    compositor: Option<WlCompositor>,
+    /// Cached per-surface effect objects, keyed by `wl_surface` ObjectId.
+    effects: HashMap<wayland_client::backend::ObjectId, ExtBackgroundEffectSurfaceV1>,
+    /// Whether the compositor advertised blur capability.
+    blur_capable: bool,
+}
+
+impl BlurState {
+    fn new() -> Self {
+        Self {
+            manager: None,
+            compositor: None,
+            effects: HashMap::new(),
+            blur_capable: false,
+        }
+    }
+}
+
+// ── Dispatch impls ──────────────────────────────────────────────────────────
+
+impl Dispatch<wl_registry::WlRegistry, ()> for BlurState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "ext_background_effect_manager_v1" => {
+                    debug!("Found ext_background_effect_manager_v1 v{version}");
+                    let mgr: ExtBackgroundEffectManagerV1 =
+                        registry.bind(name, version.min(1), qh, ());
+                    state.manager = Some(mgr);
+                }
+                "wl_compositor" => {
+                    let comp: WlCompositor = registry.bind(name, version.min(4), qh, ());
+                    state.compositor = Some(comp);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<ExtBackgroundEffectManagerV1, ()> for BlurState {
+    fn event(
+        state: &mut Self,
+        _proxy: &ExtBackgroundEffectManagerV1,
+        event: ext_background_effect_manager_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            let was_capable = state.blur_capable;
+            // flags is WEnum<Capability> — extract the inner value and check for Blur.
+            state.blur_capable = match flags {
+                WEnum::Value(cap) => cap.contains(Capability::Blur),
+                WEnum::Unknown(_) => false,
+            };
+            if state.blur_capable != was_capable {
+                debug!(
+                    "Background effect blur capability: {}",
+                    if state.blur_capable {
+                        "available"
+                    } else {
+                        "lost"
+                    }
+                );
+            }
+        }
+    }
+}
+
+impl Dispatch<ExtBackgroundEffectSurfaceV1, ()> for BlurState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ExtBackgroundEffectSurfaceV1,
+        _event: ext_background_effect_surface_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        // This interface has no events.
+    }
+}
+
+impl Dispatch<WlCompositor, ()> for BlurState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlCompositor,
+        _event: wayland_client::protocol::wl_compositor::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        // wl_compositor has no events.
+    }
+}
+
+impl Dispatch<wayland_client::protocol::wl_region::WlRegion, ()> for BlurState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wayland_client::protocol::wl_region::WlRegion,
+        _event: wayland_client::protocol::wl_region::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        // wl_region has no events.
+    }
+}
+
+// ── Rounded-rect scanline rasterization ─────────────────────────────────────
+
+/// Add a rounded rectangle to a `wl_region` using scanline rasterization.
+///
+/// Uses `round(exact_inset)` per row — nearest-integer assignment minimises
+/// total error and max adjacent delta compared to ceil, floor, or Bresenham
+/// for the filled-region use case. Some flat runs at the bottom of the arc
+/// are geometrically unavoidable (pigeonhole principle) but are imperceptible
+/// there since the circle is nearly vertical.
+///
+/// If `radius` is zero or the radius is too large for the dimensions, falls
+/// back to a single rectangle.
+fn add_rounded_rect_to_region(
+    region: &wayland_client::protocol::wl_region::WlRegion,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    radius: i32,
+) {
+    if radius <= 0 || radius * 2 > width || radius * 2 > height {
+        region.add(x, y, width, height);
+        return;
+    }
+
+    // Central rectangle spanning the full width, excluding the top and bottom
+    // radius strips.
+    region.add(x, y + radius, width, height - 2 * radius);
+
+    let r = radius as f64;
+    for i in 0..radius as usize {
+        let dy = r - 0.5 - i as f64;
+        let inset = if dy < 0.0 {
+            0
+        } else {
+            (r - (r * r - dy * dy).sqrt()).round() as i32
+        };
+        let row_w = (width - 2 * inset).max(1);
+        region.add(x + inset, y + i as i32, row_w, 1);
+        region.add(x + inset, y + height - 1 - i as i32, row_w, 1);
+    }
+}
+
+// ── Thread-local singleton ──────────────────────────────────────────────────
+
+thread_local! {
+    static INSTANCE: RefCell<Option<Rc<BackgroundEffectManager>>> = const { RefCell::new(None) };
+}
+
+/// Manages `ext-background-effect-v1` blur region hints for all vibepanel surfaces.
+pub struct BackgroundEffectManager {
+    state: RefCell<BlurState>,
+    event_queue: RefCell<EventQueue<BlurState>>,
+    qh: QueueHandle<BlurState>,
+    /// Whether the protocol is available on this compositor.
+    available: bool,
+}
+
+impl BackgroundEffectManager {
+    /// Initialize the global singleton.
+    ///
+    /// Must be called on the main thread after `gtk4::gdk::Display::default()` is available.
+    /// If the compositor does not advertise `ext_background_effect_manager_v1`, the
+    /// service becomes inert — all `apply_blur_region` calls are no-ops.
+    pub fn init_global() {
+        INSTANCE.with(|cell| {
+            if cell.borrow().is_some() {
+                return;
+            }
+
+            let mgr = Self::try_init();
+            *cell.borrow_mut() = mgr.map(Rc::new);
+        });
+    }
+
+    /// Get a reference to the global manager, if available.
+    pub fn global() -> Option<Rc<Self>> {
+        INSTANCE.with(|cell| cell.borrow().clone())
+    }
+
+    /// Get the `wayland_client::Connection` that GDK uses internally.
+    ///
+    /// `gdk4_wayland::WaylandDisplay::connection()` is `pub(crate)` so we can't call
+    /// it directly. Instead we call `wl_display()` which internally creates and
+    /// caches the Connection in GObject qdata, then extract the Backend from the
+    /// returned proxy to reconstruct the *same* Connection.
+    ///
+    /// This is critical: creating a second `Backend::from_foreign_display()` would
+    /// allocate a separate libwayland event queue, and roundtrips on it can consume
+    /// events from the shared fd that GDK expects to read, causing missed
+    /// layer-shell configure events (bar appears in middle of screen).
+    fn connection_from_gdk_display(
+        wayland_display: &gdk4_wayland::WaylandDisplay,
+    ) -> Option<Connection> {
+        use wayland_client::Proxy;
+
+        // wl_display() internally calls the private connection() which creates
+        // and caches the Connection. The returned WlDisplay proxy holds a
+        // WeakBackend reference to that same Connection's backend.
+        let wl_display = wayland_display.wl_display()?;
+        let backend = wl_display.backend().upgrade()?;
+        Some(Connection::from_backend(backend))
+    }
+
+    /// Attempt to initialize.
+    fn try_init() -> Option<Self> {
+        // Check we're on a Wayland display.
+        let gdk_display = gtk4::gdk::Display::default()?;
+        let wayland_display = gdk_display
+            .downcast::<gdk4_wayland::WaylandDisplay>()
+            .ok()?;
+
+        // Quick check: does the compositor advertise this protocol at all?
+        if !wayland_display.query_registry("ext_background_effect_manager_v1") {
+            debug!(
+                "Compositor does not advertise ext_background_effect_manager_v1, blur hints disabled"
+            );
+            return None;
+        }
+
+        debug!("ext_background_effect_manager_v1 found in registry, initializing blur service");
+
+        // Build a wayland-client Connection from GDK's foreign wl_display.
+        let connection = Self::connection_from_gdk_display(&wayland_display)?;
+
+        // Create our own event queue on GDK's connection.
+        let mut event_queue: EventQueue<BlurState> = connection.new_event_queue();
+        let qh = event_queue.handle();
+
+        // Get registry from the display on our queue.
+        let display = connection.display();
+        let _registry = display.get_registry(&qh, ());
+
+        // Initial roundtrip to discover globals.
+        let mut state = BlurState::new();
+        if let Err(e) = event_queue.roundtrip(&mut state) {
+            warn!("Failed blur service roundtrip: {e}");
+            return None;
+        }
+
+        if state.manager.is_none() {
+            debug!("ext_background_effect_manager_v1 not bound after roundtrip");
+            return None;
+        }
+
+        // Second roundtrip to receive the capabilities event.
+        if let Err(e) = event_queue.roundtrip(&mut state) {
+            warn!("Failed blur service capabilities roundtrip: {e}");
+            return None;
+        }
+
+        debug!(
+            "Blur service initialized (blur_capable={}, compositor={:?})",
+            state.blur_capable,
+            state.compositor.is_some()
+        );
+
+        let mgr = Self {
+            state: RefCell::new(state),
+            event_queue: RefCell::new(event_queue),
+            qh,
+            available: true,
+        };
+
+        // Install fd watcher to dispatch events (e.g. capability changes).
+        mgr.install_event_dispatch();
+
+        Some(mgr)
+    }
+
+    /// Install a glib fd watcher to dispatch wayland events for our queue.
+    fn install_event_dispatch(&self) {
+        // We need a raw fd for glib::unix_fd_add_local.
+        // The fd is borrowed from the event queue which lives as long as Self (thread-local singleton).
+        let eq_ref = self.event_queue.borrow().as_fd().as_raw_fd();
+
+        // Use the global accessor from inside the callback to avoid lifetime issues.
+        glib::unix_fd_add_local(eq_ref, glib::IOCondition::IN, move |_fd, _cond| {
+            INSTANCE.with(|cell| {
+                let borrow = cell.borrow();
+                let Some(mgr) = borrow.as_ref() else {
+                    return glib::ControlFlow::Break;
+                };
+
+                let mut eq = mgr.event_queue.borrow_mut();
+                let mut st = mgr.state.borrow_mut();
+
+                if let Err(e) = eq.dispatch_pending(&mut *st) {
+                    warn!("Blur event dispatch error: {e}");
+                    return glib::ControlFlow::Continue;
+                }
+
+                if let Some(guard) = eq.prepare_read() {
+                    match guard.read() {
+                        Ok(_) => {
+                            let _ = eq.dispatch_pending(&mut *st);
+                        }
+                        Err(wayland_client::backend::WaylandError::Io(io_err))
+                            if io_err.kind() == std::io::ErrorKind::WouldBlock => {}
+                        Err(e) => {
+                            warn!("Blur wayland read error: {e}");
+                        }
+                    }
+                }
+
+                let _ = eq.flush();
+                glib::ControlFlow::Continue
+            })
+        });
+    }
+
+    /// Apply a blur region hint to the given window's surface.
+    ///
+    /// `shadow_margin` is the padding (in surface-local px) between the layer-shell
+    /// surface edge and the visible content. The margins are applied asymmetrically
+    /// to match `SurfaceStyleManager::apply_shadow_margins`: the bar-adjacent side
+    /// gets 0 margin (content is flush against the bar), while the other three
+    /// sides are inset by `shadow_margin`.
+    ///
+    /// If the surface has no size yet (first map), this schedules a one-shot idle
+    /// retry so the blur region is applied once GTK has committed dimensions.
+    ///
+    /// This is fire-and-forget: the region is double-buffered and applied on
+    /// GTK's next `wl_surface.commit`.
+    pub fn apply_blur_region(&self, window: &gtk4::ApplicationWindow, shadow_margin: i32) {
+        if !self.available {
+            return;
+        }
+
+        // Get the wl_surface from the GDK surface.
+        let Some(native) = window.native() else {
+            trace!("No native for window, skipping blur");
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            trace!("No GDK surface for window, skipping blur");
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            trace!("No wl_surface for window, skipping blur");
+            return;
+        };
+
+        // Use fully-qualified syntax to avoid clash with gtk4::prelude's id() methods.
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+
+        // Get or create the effect object for this surface.
+        // Extract manager clone before entry API to avoid borrow conflict.
+        let mut state = self.state.borrow_mut();
+
+        let (Some(manager), Some(compositor)) = (&state.manager, &state.compositor) else {
+            return;
+        };
+        let manager = manager.clone();
+        let compositor = compositor.clone();
+
+        let effect = state
+            .effects
+            .entry(surface_id)
+            .or_insert_with(|| {
+                debug!("Creating background effect object for surface");
+                manager.get_background_effect(&wl_surface, &self.qh, ())
+            })
+            .clone();
+
+        drop(state);
+
+        // Get the surface dimensions from the WaylandSurface (which derefs to gdk::Surface).
+        let width = wayland_surface.width();
+        let height = wayland_surface.height();
+
+        if width <= 0 || height <= 0 {
+            // Surface not sized yet (common on first map). Schedule an idle retry
+            // so we apply the region once GTK has committed actual dimensions.
+            trace!("Surface has no size yet, deferring blur region to idle");
+            let win_clone = window.clone();
+            glib::idle_add_local_once(move || {
+                if let Some(blur) = Self::global() {
+                    blur.apply_blur_region(&win_clone, shadow_margin);
+                }
+            });
+            return;
+        }
+
+        // Run the base margin through SurfaceStyleManager to respect the
+        // shadows_enabled flag — when shadows are off, the actual margin is 0
+        // even though the caller passes the base constant.
+        let effective_margin = if shadow_margin > 0 {
+            crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
+        } else {
+            0
+        };
+
+        // Compute per-side margins matching `SurfaceStyleManager::apply_shadow_margins`:
+        // the bar-adjacent side gets 0 margin (content is flush against the bar),
+        // the other three sides get the full effective margin.
+        let m = effective_margin;
+        let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
+            let is_bottom =
+                crate::services::config_manager::ConfigManager::global().bar_is_bottom();
+            if is_bottom {
+                (m, 0, m, m) // bar at bottom → top/start/end get margin, bottom = 0
+            } else {
+                (0, m, m, m) // bar at top → bottom/start/end get margin, top = 0
+            }
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        let region = compositor.create_region(&self.qh, ());
+        let x = margin_start;
+        let y = margin_top;
+        let w = width - margin_start - margin_end;
+        let h = height - margin_top - margin_bottom;
+
+        // Use rounded corners for surfaces with shadow margins (popovers, QS).
+        // The bar (shadow_margin == 0) has no visible border-radius for blur.
+        let radius = if shadow_margin > 0 {
+            crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
+        } else {
+            0
+        };
+
+        add_rounded_rect_to_region(&region, x, y, w, h, radius);
+
+        effect.set_blur_region(Some(&region));
+
+        // The region object can be destroyed immediately (copy semantics).
+        region.destroy();
+
+        // Flush to ensure the request reaches the compositor.
+        if let Ok(eq) = self.event_queue.try_borrow() {
+            let _ = eq.flush();
+        }
+
+        debug!(
+            "Applied blur region: {}x{} at ({},{}) r={} margins t={} b={} s={} e={} (surface {}x{})",
+            w, h, x, y, radius, margin_top, margin_bottom, margin_start, margin_end, width, height
+        );
+
+        // Install a resize watcher (once per window) so the blur region
+        // is re-applied whenever the surface dimensions change — e.g. when
+        // a Revealer expands and the layer-shell surface reconfigures.
+        const BLUR_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-resize-watched";
+        unsafe {
+            if window.data::<bool>(BLUR_RESIZE_WATCHED_KEY).is_none() {
+                window.set_data(BLUR_RESIZE_WATCHED_KEY, true);
+                let win_clone = window.clone();
+                if let Some(gdk_surface) = window.native().and_then(|n| n.surface()) {
+                    gdk_surface.connect_notify_local(Some("width"), move |_, _| {
+                        if let Some(blur) = BackgroundEffectManager::global() {
+                            blur.apply_blur_region(&win_clone, shadow_margin);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    /// Remove the blur region for a window (e.g. on destroy).
+    #[allow(dead_code)]
+    pub fn remove_blur_region(&self, window: &gtk4::ApplicationWindow) {
+        if !self.available {
+            return;
+        }
+
+        let Some(native) = window.native() else {
+            return;
+        };
+        let Some(gdk_surface) = native.surface() else {
+            return;
+        };
+        let wayland_surface = match gdk_surface.downcast::<gdk4_wayland::WaylandSurface>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let Some(wl_surface) = wayland_surface.wl_surface() else {
+            return;
+        };
+
+        let surface_id =
+            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
+                &wl_surface,
+            );
+        let mut state = self.state.borrow_mut();
+        if let Some(effect) = state.effects.remove(&surface_id) {
+            effect.destroy();
+            debug!("Removed blur region for surface");
+        }
+    }
+}

--- a/crates/vibepanel/src/services/bar_manager.rs
+++ b/crates/vibepanel/src/services/bar_manager.rs
@@ -47,6 +47,11 @@ struct BarInstance {
 
 impl Drop for BarInstance {
     fn drop(&mut self) {
+        // Clean up the blur effect entry so it doesn't leak in the
+        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
+            blur.remove_blur_region(&self.window);
+        }
         // Automatically close the window when this instance is dropped.
         // This handles explicit removal, HashMap replacements, and potential panics.
         self.window.close();

--- a/crates/vibepanel/src/services/bar_manager.rs
+++ b/crates/vibepanel/src/services/bar_manager.rs
@@ -47,8 +47,8 @@ struct BarInstance {
 
 impl Drop for BarInstance {
     fn drop(&mut self) {
-        // Clean up the blur effect entry so it doesn't leak in the
-        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        // Best-effort blur cleanup; may no-op if the surface is already
+        // unmapped.  See BackgroundEffectManager::remove_blur_region docs.
         if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
             blur.remove_blur_region(&self.window);
         }
@@ -304,6 +304,14 @@ impl BarManager {
     /// the delayed sync runs.
     pub fn hide_all(&self) {
         for instance in self.bars.borrow().values() {
+            // Remove blur before hiding — blur is compositor-side and persists
+            // even when the surface is at opacity 0.  The BarInstance::Drop impl
+            // also calls remove_blur_region, so this is idempotent.
+            if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.remove_blur_region(&instance.window);
+            }
             instance.window.set_opacity(0.0);
         }
         debug!("All bars hidden for monitor change");
@@ -313,6 +321,9 @@ impl BarManager {
     ///
     /// Called after sync_monitors to reveal bars that weren't removed.
     /// No-op if bars are IPC-hidden (the hidden state takes precedence).
+    ///
+    /// Blur regions are not restored here — `reconfigure_all()` rebuilds
+    /// bars before this call, and `connect_map` re-applies blur on map.
     pub fn show_all(&self) {
         if self.hidden.get() {
             debug!("show_all skipped: bars are IPC-hidden");
@@ -330,6 +341,14 @@ impl BarManager {
     /// exclusive zone. Uses `set_visible(false)` which unmaps the layer-shell
     /// surface at the compositor level — `set_opacity(0.0)` alone is not
     /// sufficient because the compositor still composites the surface.
+    ///
+    /// Blur regions are **not** removed here — unmapping suspends
+    /// compositor-side blur while the protocol object persists across
+    /// unmap/remap.  The compositor restores blur automatically on
+    /// `ipc_show()`.  This differs from `hide_all()` which uses
+    /// `set_opacity(0.0)` (surface stays mapped, blur must be explicitly
+    /// removed to avoid blurring an invisible surface).  See
+    /// `background_effect.rs` "Blur lifecycle" docs.
     pub fn ipc_hide(&self) {
         if self.hidden.get() {
             return;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -332,7 +332,7 @@ impl ConfigManager {
     /// Check if compositor background blur is enabled.
     ///
     /// When true, vibepanel sends ext-background-effect-v1 blur region hints
-    /// for popovers, quick settings, and the bar.
+    /// for popovers, quick settings, notification toasts, OSD, and the bar.
     pub fn blur_enabled(&self) -> bool {
         self.config.borrow().theme.blur
     }
@@ -767,8 +767,12 @@ impl ConfigManager {
             if let Some(display) = gtk4::gdk::Display::default() {
                 BarManager::global().reconfigure_all(&display, &new_config);
             }
-        } else if theme_changed {
-            // Theme-only changes: notify callbacks for programmatic styling updates
+        }
+
+        if theme_changed {
+            // Notify theme callbacks even during structural rebuild, because
+            // non-bar surfaces (e.g. media pop-out) persist across bar rebuilds
+            // and need to react to theme changes independently.
             self.theme_callbacks.notify(&());
         }
 
@@ -893,6 +897,19 @@ impl ConfigManager {
         self.shutdown_flag.store(true, Ordering::Relaxed);
         self.stop_wallpaper_polling();
         debug!("Config watcher stopped");
+    }
+}
+
+/// Drop guard that disconnects a theme callback when dropped.
+///
+/// Wrap a `CallbackId` from [`ConfigManager::on_theme_change`] in this guard
+/// to ensure the callback is automatically unregistered when the owning
+/// widget is destroyed.
+pub struct ThemeCallbackGuard(pub CallbackId);
+
+impl Drop for ThemeCallbackGuard {
+    fn drop(&mut self) {
+        ConfigManager::global().disconnect_theme_callback(self.0);
     }
 }
 

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -332,7 +332,8 @@ impl ConfigManager {
     /// Check if compositor background blur is enabled.
     ///
     /// When true, vibepanel sends ext-background-effect-v1 blur region hints
-    /// for popovers, quick settings, notification toasts, OSD, and the bar.
+    /// for the bar, popovers, quick settings, notification toasts, OSD,
+    /// tray menus, and media pop-out windows.
     pub fn blur_enabled(&self) -> bool {
         self.config.borrow().theme.blur
     }
@@ -963,6 +964,14 @@ fn config_structure_changed(old: &Config, new: &Config) -> bool {
 
     if old.bar.inset != new.bar.inset {
         debug!("bar.inset changed ({} -> {})", old.bar.inset, new.bar.inset);
+        return true;
+    }
+
+    if old.bar.background_opacity != new.bar.background_opacity {
+        debug!(
+            "bar.background_opacity changed ({} -> {})",
+            old.bar.background_opacity, new.bar.background_opacity
+        );
         return true;
     }
 

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -237,6 +237,20 @@ impl ConfigManager {
         self.palette.borrow().surface_border_radius
     }
 
+    /// Get the computed bar border radius in pixels.
+    pub fn bar_border_radius(&self) -> u32 {
+        self.palette.borrow().bar_border_radius
+    }
+
+    /// Get the computed widget border radius in pixels.
+    ///
+    /// This is the radius applied to individual widget islands (`.widget` elements).
+    /// Use this for blur regions on widget islands — not `bar_border_radius`, which
+    /// includes bar padding and applies to the whole bar surface.
+    pub fn widget_border_radius(&self) -> u32 {
+        self.palette.borrow().widget_border_radius
+    }
+
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).
     ///
     /// This is derived from the widget border radius configuration.

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -315,6 +315,14 @@ impl ConfigManager {
             .and_then(|p| p.parent().map(|d| d.to_path_buf()))
     }
 
+    /// Check if compositor background blur is enabled.
+    ///
+    /// When true, vibepanel sends ext-background-effect-v1 blur region hints
+    /// for popovers, quick settings, and the bar.
+    pub fn blur_enabled(&self) -> bool {
+        self.config.borrow().theme.blur
+    }
+
     /// Get a widget option value from the current configuration.
     ///
     /// Returns `None` if the widget has no config section or the option doesn't exist.

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -653,8 +653,8 @@ impl LayerShellPopover {
                 shell.set_scale(ANIM_SCALE_FROM);
                 shell.remove_child();
             }
-            // Blur removal is unnecessary here — set_visible(false) unmaps
-            // the wl_surface, so the compositor discards blur automatically.
+            // No explicit blur removal needed — unmapping suspends
+            // compositor-side blur while the protocol object persists.
             // Blur is re-applied on next map via connect_map.
             window.set_visible(false);
             // Fire on_close now since there's no animation to wait for.
@@ -672,10 +672,7 @@ impl LayerShellPopover {
         // surface fades out.  Blur is a compositor effect independent of surface
         // opacity — if left in place it would remain visible as the content
         // becomes transparent.
-        if ConfigManager::global().blur_enabled()
-            && let Some(blur) =
-                crate::services::background_effect::BackgroundEffectManager::global()
-        {
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
             blur.remove_blur_region(&window);
         }
 
@@ -895,15 +892,6 @@ impl LayerShellPopover {
                         shell.set_opacity(1.0);
                         shell.set_scale(1.0);
                     }
-                    // Apply blur region immediately (the tick callback won't
-                    // run to animate it in).
-                    if ConfigManager::global().blur_enabled()
-                        && let Some(blur) =
-                            crate::services::background_effect::BackgroundEffectManager::global()
-                        && let Some(ref window) = *popover.window.borrow()
-                    {
-                        blur.apply_blur_region(window, POPOVER_SHADOW_MARGIN);
-                    }
                 }
             }
         });
@@ -958,12 +946,27 @@ impl LayerShellPopover {
         // size yet, so apply_blur_region defers via idle.  On re-show it sets
         // the full-size region, which the animation tick overwrites with a
         // scaled region within 1-2 frames.
+        //
+        // The else-branch removes any stale protocol object left from a
+        // previous map cycle.  This handles the case where blur was enabled
+        // when the popover was last shown, then disabled while the popover
+        // was hidden (unmapped).  `remove_blur_region` requires a mapped
+        // surface, so connect_map is the earliest reliable cleanup point.
+        //
+        // Known limitation: config changes to `theme.blur` or border radius
+        // while the popover is open take effect on next open, not immediately.
+        // Popovers grab focus so config edits are unlikely while open.
         window.connect_map(move |win| {
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
+            if ConfigManager::global().blur_enabled() {
+                if let Some(blur) =
                     crate::services::background_effect::BackgroundEffectManager::global()
+                {
+                    blur.apply_blur_region(win, POPOVER_SHADOW_MARGIN);
+                }
+            } else if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
             {
-                blur.apply_blur_region(win, POPOVER_SHADOW_MARGIN);
+                blur.remove_blur_region(win);
             }
         });
 
@@ -1076,16 +1079,13 @@ impl LayerShellPopover {
             let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
             shell_for_scale.set_scale(scale);
 
-            // The compositor might draw blur at the final full size while the
-            // ScaleBox visual is still growing in, causing a brief flash of
-            // oversized blur. Shrink the blur region to match the current scale.
             if direction == AnimDirection::Opening
                 && ConfigManager::global().blur_enabled()
                 && let Some(blur) =
                     crate::services::background_effect::BackgroundEffectManager::global()
                 && let Some(ref w) = window
             {
-                blur.apply_blur_region_animated(w, POPOVER_SHADOW_MARGIN, scale);
+                blur.apply_open_animation_blur(w, POPOVER_SHADOW_MARGIN, scale, complete);
             }
 
             if complete {
@@ -1107,15 +1107,6 @@ impl LayerShellPopover {
                     // Open complete — ensure we're at exactly 1.0.
                     shell.set_opacity(1.0);
                     shell_for_scale.set_scale(1.0);
-                    // Set final full-size blur region (scale == 1.0, same as
-                    // apply_blur_region) to install the resize watcher.
-                    if ConfigManager::global().blur_enabled()
-                        && let Some(blur) =
-                            crate::services::background_effect::BackgroundEffectManager::global()
-                        && let Some(ref w) = window
-                    {
-                        blur.apply_blur_region(w, POPOVER_SHADOW_MARGIN);
-                    }
                 }
                 return ControlFlow::Break;
             }
@@ -1196,8 +1187,9 @@ impl Drop for LayerShellPopover {
         if let Some(catcher) = self.click_catcher.borrow_mut().take() {
             catcher.close();
         }
-        // Clean up the blur effect entry so it doesn't leak in the
-        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        // Best-effort blur cleanup; primary removal happens at fade-start
+        // in hide().  May no-op if already unmapped.
+        // See BackgroundEffectManager::remove_blur_region docs.
         if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global()
             && let Some(ref window) = *self.window.borrow()
         {

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -653,12 +653,9 @@ impl LayerShellPopover {
                 shell.set_scale(ANIM_SCALE_FROM);
                 shell.remove_child();
             }
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
-                    crate::services::background_effect::BackgroundEffectManager::global()
-            {
-                blur.clear_blur_region(&window);
-            }
+            // Blur removal is unnecessary here — set_visible(false) unmaps
+            // the wl_surface, so the compositor discards blur automatically.
+            // Blur is re-applied on next map via connect_map.
             window.set_visible(false);
             // Fire on_close now since there's no animation to wait for.
             if let Some(ref cb) = *self.on_close.borrow() {
@@ -671,13 +668,15 @@ impl LayerShellPopover {
         // may not have fired yet, leaving window.opacity at 0.0).
         window.set_opacity(1.0);
 
-        // Clear blur at the start of the close animation so the compositor
-        // stops drawing blur behind the surface while it fades out.
+        // Remove blur immediately so the compositor stops drawing it while the
+        // surface fades out.  Blur is a compositor effect independent of surface
+        // opacity — if left in place it would remain visible as the content
+        // becomes transparent.
         if ConfigManager::global().blur_enabled()
             && let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
         {
-            blur.clear_blur_region(&window);
+            blur.remove_blur_region(&window);
         }
 
         // Start (or reverse into) the close animation.
@@ -953,8 +952,12 @@ impl LayerShellPopover {
             });
         }
 
-        // Apply blur region hint when the popover surface is mapped.
-        // Inset by POPOVER_SHADOW_MARGIN to exclude shadow padding from blur.
+        // Apply blur on every map (first show and re-show).  Close calls
+        // set_visible(false) which unmaps the surface, so connect_map fires
+        // again when the window is re-shown.  On first map the surface has no
+        // size yet, so apply_blur_region defers via idle.  On re-show it sets
+        // the full-size region, which the animation tick overwrites with a
+        // scaled region within 1-2 frames.
         window.connect_map(move |win| {
             if ConfigManager::global().blur_enabled()
                 && let Some(blur) =
@@ -1073,8 +1076,9 @@ impl LayerShellPopover {
             let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
             shell_for_scale.set_scale(scale);
 
-            // During opening, update the blur region to match the ScaleBox clip
-            // so the compositor blur grows in sync with the visual.
+            // The compositor might draw blur at the final full size while the
+            // ScaleBox visual is still growing in, causing a brief flash of
+            // oversized blur. Shrink the blur region to match the current scale.
             if direction == AnimDirection::Opening
                 && ConfigManager::global().blur_enabled()
                 && let Some(blur) =
@@ -1191,6 +1195,13 @@ impl Drop for LayerShellPopover {
 
         if let Some(catcher) = self.click_catcher.borrow_mut().take() {
             catcher.close();
+        }
+        // Clean up the blur effect entry so it doesn't leak in the
+        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global()
+            && let Some(ref window) = *self.window.borrow()
+        {
+            blur.remove_blur_region(window);
         }
         if let Some(window) = self.window.borrow_mut().take() {
             window.close();

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -871,6 +871,14 @@ impl LayerShellPopover {
                 popover.update_position();
                 if let Some(ref window) = *popover.window.borrow() {
                     window.set_opacity(1.0);
+
+                    // Apply blur region now that the surface is mapped and sized.
+                    if ConfigManager::global().blur_enabled()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                    {
+                        blur.apply_blur_region(window, POPOVER_SHADOW_MARGIN);
+                    }
                 }
 
                 if ConfigManager::global().animations_enabled() {
@@ -928,6 +936,17 @@ impl LayerShellPopover {
                 }
             });
         }
+
+        // Apply blur region hint when the popover surface is mapped.
+        // Inset by POPOVER_SHADOW_MARGIN to exclude shadow padding from blur.
+        window.connect_map(move |win| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.apply_blur_region(win, POPOVER_SHADOW_MARGIN);
+            }
+        });
 
         *self.window.borrow_mut() = Some(window.clone());
         window

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -653,6 +653,12 @@ impl LayerShellPopover {
                 shell.set_scale(ANIM_SCALE_FROM);
                 shell.remove_child();
             }
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.clear_blur_region(&window);
+            }
             window.set_visible(false);
             // Fire on_close now since there's no animation to wait for.
             if let Some(ref cb) = *self.on_close.borrow() {
@@ -664,6 +670,15 @@ impl LayerShellPopover {
         // Ensure the window is fully visible (the idle callback from show_internal
         // may not have fired yet, leaving window.opacity at 0.0).
         window.set_opacity(1.0);
+
+        // Clear blur at the start of the close animation so the compositor
+        // stops drawing blur behind the surface while it fades out.
+        if ConfigManager::global().blur_enabled()
+            && let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+        {
+            blur.clear_blur_region(&window);
+        }
 
         // Start (or reverse into) the close animation.
         // on_close fires when the animation completes (in the tick callback).
@@ -871,14 +886,6 @@ impl LayerShellPopover {
                 popover.update_position();
                 if let Some(ref window) = *popover.window.borrow() {
                     window.set_opacity(1.0);
-
-                    // Apply blur region now that the surface is mapped and sized.
-                    if ConfigManager::global().blur_enabled()
-                        && let Some(blur) =
-                            crate::services::background_effect::BackgroundEffectManager::global()
-                    {
-                        blur.apply_blur_region(window, POPOVER_SHADOW_MARGIN);
-                    }
                 }
 
                 if ConfigManager::global().animations_enabled() {
@@ -888,6 +895,15 @@ impl LayerShellPopover {
                     if let Some(ref shell) = *popover.anim_shell.borrow() {
                         shell.set_opacity(1.0);
                         shell.set_scale(1.0);
+                    }
+                    // Apply blur region immediately (the tick callback won't
+                    // run to animate it in).
+                    if ConfigManager::global().blur_enabled()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                        && let Some(ref window) = *popover.window.borrow()
+                    {
+                        blur.apply_blur_region(window, POPOVER_SHADOW_MARGIN);
                     }
                 }
             }
@@ -1057,6 +1073,17 @@ impl LayerShellPopover {
             let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
             shell_for_scale.set_scale(scale);
 
+            // During opening, update the blur region to match the ScaleBox clip
+            // so the compositor blur grows in sync with the visual.
+            if direction == AnimDirection::Opening
+                && ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+                && let Some(ref w) = window
+            {
+                blur.apply_blur_region_animated(w, POPOVER_SHADOW_MARGIN, scale);
+            }
+
             if complete {
                 anim_state.borrow_mut().active = false;
 
@@ -1076,6 +1103,15 @@ impl LayerShellPopover {
                     // Open complete — ensure we're at exactly 1.0.
                     shell.set_opacity(1.0);
                     shell_for_scale.set_scale(1.0);
+                    // Set final full-size blur region (scale == 1.0, same as
+                    // apply_blur_region) to install the resize watcher.
+                    if ConfigManager::global().blur_enabled()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                        && let Some(ref w) = window
+                    {
+                        blur.apply_blur_region(w, POPOVER_SHADOW_MARGIN);
+                    }
                 }
                 return ControlFlow::Break;
             }

--- a/crates/vibepanel/src/widgets/media_window.rs
+++ b/crates/vibepanel/src/widgets/media_window.rs
@@ -8,9 +8,9 @@ use gtk4::glib::clone;
 use gtk4::prelude::*;
 use gtk4::{Align, ApplicationWindow, Box as GtkBox, GestureDrag, Orientation, Window};
 
-use crate::services::background_effect::BackgroundEffectManager;
+use crate::services::background_effect::attach_blur_surface_lifecycle;
 use crate::services::callbacks::CallbackId;
-use crate::services::config_manager::ConfigManager;
+use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::media::MediaService;
 use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{media, surface};
@@ -26,12 +26,12 @@ const WINDOW_BLOB_MARGIN: i32 = 12;
 /// Smaller blob displacement for the compact window layout.
 const WINDOW_BLOB_MAX_DISPLACEMENT: f64 = 8.0;
 
-/// Handle to the media pop-out window. Drop this to close the window.
+/// Handle to the media pop-out window. Dropping disconnects the theme callback.
 pub struct MediaWindowHandle {
     window: Window,
     _callback_id: Rc<RefCell<Option<CallbackId>>>,
-    /// Theme-change callback ID; disconnected in `Drop`.
-    _theme_callback_id: Option<CallbackId>,
+    /// Theme-change callback guard; disconnected automatically on `Drop`.
+    _theme_callback_guard: ThemeCallbackGuard,
     opacity_provider: gtk4::CssProvider,
 }
 
@@ -49,14 +49,6 @@ impl MediaWindowHandle {
         let opacity = opacity.clamp(0.0, 1.0);
         let css = format!("box {{ opacity: {}; }}", opacity);
         self.opacity_provider.load_from_string(&css);
-    }
-}
-
-impl Drop for MediaWindowHandle {
-    fn drop(&mut self) {
-        if let Some(id) = self._theme_callback_id.take() {
-            ConfigManager::global().disconnect_theme_callback(id);
-        }
     }
 }
 
@@ -258,56 +250,23 @@ where
         *callback_id_cell.borrow_mut() = Some(callback_id);
     }
 
-    // Apply blur hint to the window surface.  connect_map fires every time
-    // the window is shown (present()); apply_blur_surface defers via idle if
-    // the surface has not yet been configured.
-    window.connect_map(clone!(
-        #[weak]
-        main_box,
-        move |win| {
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) = BackgroundEffectManager::global()
-            {
-                let radius = ConfigManager::global().surface_border_radius() as i32;
-                blur.apply_blur_surface(win, &main_box, radius);
-            }
-        }
-    ));
+    let theme_callback_guard = attach_blur_surface_lifecycle(
+        &window,
+        move |_| Some(main_box.clone().upcast::<gtk4::Widget>()),
+        || ConfigManager::global().surface_border_radius() as i32,
+    );
 
+    // Disconnect media updates when the GTK window is destroyed.
+    // Blur cleanup is handled by attach_blur_surface_lifecycle.
     window.connect_destroy(clone!(
         #[strong]
         callback_id_cell,
-        move |win| {
-            if let Some(blur) = BackgroundEffectManager::global() {
-                blur.remove_blur_region(win);
-            }
+        move |_| {
             if let Some(id) = callback_id_cell.borrow_mut().take() {
                 MediaService::global().disconnect(id);
             }
         }
     ));
-
-    // Hot-reload: re-apply or remove blur when the user toggles `theme.blur`
-    // while the media window is open.  Follows the same pattern as bar.rs.
-    let theme_callback_id = {
-        let win_weak = window.downgrade();
-        let main_box_weak = main_box.downgrade();
-        ConfigManager::global().on_theme_change(move || {
-            let Some(win) = win_weak.upgrade() else {
-                return;
-            };
-            if ConfigManager::global().blur_enabled() {
-                if let Some(blur) = BackgroundEffectManager::global()
-                    && let Some(main_box) = main_box_weak.upgrade()
-                {
-                    let radius = ConfigManager::global().surface_border_radius() as i32;
-                    blur.apply_blur_surface(&win, &main_box, radius);
-                }
-            } else if let Some(blur) = BackgroundEffectManager::global() {
-                blur.remove_blur_region(&win);
-            }
-        })
-    };
 
     window.connect_close_request(move |_| {
         on_close();
@@ -317,7 +276,7 @@ where
     MediaWindowHandle {
         window,
         _callback_id: callback_id_cell,
-        _theme_callback_id: Some(theme_callback_id),
+        _theme_callback_guard: theme_callback_guard,
         opacity_provider,
     }
 }

--- a/crates/vibepanel/src/widgets/media_window.rs
+++ b/crates/vibepanel/src/widgets/media_window.rs
@@ -8,6 +8,7 @@ use gtk4::glib::clone;
 use gtk4::prelude::*;
 use gtk4::{Align, ApplicationWindow, Box as GtkBox, GestureDrag, Orientation, Window};
 
+use crate::services::background_effect::BackgroundEffectManager;
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::media::MediaService;
@@ -29,6 +30,8 @@ const WINDOW_BLOB_MAX_DISPLACEMENT: f64 = 8.0;
 pub struct MediaWindowHandle {
     window: Window,
     _callback_id: Rc<RefCell<Option<CallbackId>>>,
+    /// Theme-change callback ID; disconnected in `Drop`.
+    _theme_callback_id: Option<CallbackId>,
     opacity_provider: gtk4::CssProvider,
 }
 
@@ -46,6 +49,14 @@ impl MediaWindowHandle {
         let opacity = opacity.clamp(0.0, 1.0);
         let css = format!("box {{ opacity: {}; }}", opacity);
         self.opacity_provider.load_from_string(&css);
+    }
+}
+
+impl Drop for MediaWindowHandle {
+    fn drop(&mut self) {
+        if let Some(id) = self._theme_callback_id.take() {
+            ConfigManager::global().disconnect_theme_callback(id);
+        }
     }
 }
 
@@ -247,15 +258,56 @@ where
         *callback_id_cell.borrow_mut() = Some(callback_id);
     }
 
+    // Apply blur hint to the window surface.  connect_map fires every time
+    // the window is shown (present()); apply_blur_surface defers via idle if
+    // the surface has not yet been configured.
+    window.connect_map(clone!(
+        #[weak]
+        main_box,
+        move |win| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) = BackgroundEffectManager::global()
+            {
+                let radius = ConfigManager::global().surface_border_radius() as i32;
+                blur.apply_blur_surface(win, &main_box, radius);
+            }
+        }
+    ));
+
     window.connect_destroy(clone!(
         #[strong]
         callback_id_cell,
-        move |_| {
+        move |win| {
+            if let Some(blur) = BackgroundEffectManager::global() {
+                blur.remove_blur_region(win);
+            }
             if let Some(id) = callback_id_cell.borrow_mut().take() {
                 MediaService::global().disconnect(id);
             }
         }
     ));
+
+    // Hot-reload: re-apply or remove blur when the user toggles `theme.blur`
+    // while the media window is open.  Follows the same pattern as bar.rs.
+    let theme_callback_id = {
+        let win_weak = window.downgrade();
+        let main_box_weak = main_box.downgrade();
+        ConfigManager::global().on_theme_change(move || {
+            let Some(win) = win_weak.upgrade() else {
+                return;
+            };
+            if ConfigManager::global().blur_enabled() {
+                if let Some(blur) = BackgroundEffectManager::global()
+                    && let Some(main_box) = main_box_weak.upgrade()
+                {
+                    let radius = ConfigManager::global().surface_border_radius() as i32;
+                    blur.apply_blur_surface(&win, &main_box, radius);
+                }
+            } else if let Some(blur) = BackgroundEffectManager::global() {
+                blur.remove_blur_region(&win);
+            }
+        })
+    };
 
     window.connect_close_request(move |_| {
         on_close();
@@ -265,6 +317,7 @@ where
     MediaWindowHandle {
         window,
         _callback_id: callback_id_cell,
+        _theme_callback_id: Some(theme_callback_id),
         opacity_provider,
     }
 }

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -23,6 +23,11 @@ pub const TOAST_MARGIN_RIGHT: i32 = 10;
 /// Popover dimensions
 pub const POPOVER_WIDTH: i32 = 400;
 
+/// Shadow margin for freely-floating surfaces (toast, OSD).
+/// Applied uniformly on all four sides so the CSS `box-shadow` is not clipped
+/// at the layer-shell surface boundary.
+pub const SURFACE_SHADOW_MARGIN: i32 = 8;
+
 /// Threshold for body text length before we show the expand button.
 /// Bodies shorter than this are shown in full without expand/collapse UI.
 pub const BODY_TRUNCATE_THRESHOLD: usize = 80;

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -25,9 +25,9 @@ use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{button, color, notification as notif};
 
 use super::notifications_common::{
-    POPOVER_WIDTH, TOAST_BAR_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP, TOAST_MARGIN_RIGHT,
-    TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS, create_notification_image_widget,
-    sanitize_body_markup,
+    POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_BAR_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
+    TOAST_MARGIN_RIGHT, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
+    create_notification_image_widget, sanitize_body_markup,
 };
 
 /// Floating toast window for displaying a single notification.
@@ -84,7 +84,10 @@ impl NotificationToast {
         window.set_anchor(opposite_edge, false);
 
         window.set_margin(bar_edge, initial_margin);
-        window.set_margin(Edge::Right, TOAST_MARGIN_RIGHT);
+        let right_margin = (TOAST_MARGIN_RIGHT
+            - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
+        .max(0);
+        window.set_margin(Edge::Right, right_margin);
 
         let notification_id = notification.id;
         let toast = Rc::new(Self {
@@ -163,6 +166,32 @@ impl NotificationToast {
             });
         });
 
+        // Apply blur region hint when the toast surface is mapped.
+        // The window's child (outer container) defines the blur bounds,
+        // excluding the CSS box-shadow expansion that GTK adds to the surface.
+        toast.window.connect_map(move |win| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+                && let Some(content) = win.child()
+            {
+                let radius = ConfigManager::global().surface_border_radius() as i32;
+                blur.apply_blur_surface(win, &content, radius);
+            }
+        });
+
+        // Remove the blur region as soon as the native surface is torn down.
+        // connect_destroy fires while the Wayland surface still exists, so
+        // remove_blur_region can reach SurfaceInfo::from_widget.  The Drop impl
+        // below is retained as a safety net for any path that skips destroy.
+        toast.window.connect_destroy(|win| {
+            if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.remove_blur_region(win);
+            }
+        });
+
         toast
     }
 
@@ -178,6 +207,16 @@ impl NotificationToast {
 
         // Apply surface styling
         SurfaceStyleManager::global().apply_surface_styles(&outer, false);
+
+        // Apply uniform shadow margins so the CSS box-shadow is not clipped at
+        // the layer-shell surface boundary.  Unlike popovers (which are flush
+        // against the bar on one side), the toast floats freely and needs equal
+        // margins on all four sides.
+        let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
+        outer.set_margin_top(sm);
+        outer.set_margin_bottom(sm);
+        outer.set_margin_start(sm);
+        outer.set_margin_end(sm);
 
         // Add urgency styling
         if notification.urgency == URGENCY_CRITICAL {
@@ -406,6 +445,11 @@ impl Drop for NotificationToast {
         if let Some(source_id) = self.timeout_source.borrow_mut().take() {
             source_id.remove();
         }
+        // Clean up the blur effect object so it doesn't leak in the
+        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
+            blur.remove_blur_region(&self.window);
+        }
     }
 }
 
@@ -436,14 +480,19 @@ impl NotificationToastManager {
             self.remove_toast(notification.id);
         }
 
-        // Calculate initial margin from existing toasts
+        // Calculate initial margin from existing toasts.
+        // Each toast window includes shadow margins (sm on each side), making
+        // the window taller than the visible content.  Subtract the shadow
+        // margins from the height contribution so the visual gap between
+        // content boxes matches TOAST_GAP.
+        let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
         let initial_margin = {
             let order = self.toast_order.borrow();
             let toasts = self.toasts.borrow();
-            let mut y_offset = TOAST_BAR_MARGIN;
+            let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
             for &id in order.iter() {
                 if let Some(toast) = toasts.get(&id) {
-                    y_offset += toast.height() + TOAST_GAP;
+                    y_offset += (toast.height() - 2 * sm).max(0) + TOAST_GAP;
                 }
             }
             y_offset
@@ -504,11 +553,12 @@ impl NotificationToastManager {
     fn reposition_toasts(&self) {
         let order = self.toast_order.borrow();
         let toasts = self.toasts.borrow();
-        let mut y_offset = TOAST_BAR_MARGIN;
+        let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
+        let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
         for &id in order.iter() {
             if let Some(toast) = toasts.get(&id) {
                 toast.update_bar_margin(y_offset, ConfigManager::global().animations_enabled());
-                y_offset += toast.height() + TOAST_GAP;
+                y_offset += (toast.height() - 2 * sm).max(0) + TOAST_GAP;
             }
         }
     }

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -20,7 +20,8 @@ use crate::services::notification::{Notification, URGENCY_CRITICAL, URGENCY_LOW}
 type ToastCallback = Rc<dyn Fn(u32)>;
 /// Type alias for toast action callbacks.
 type ToastActionCallback = Rc<dyn Fn(u32, &str)>;
-use crate::services::config_manager::ConfigManager;
+use crate::services::background_effect::attach_blur_surface_lifecycle;
+use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{button, color, notification as notif};
 
@@ -40,6 +41,8 @@ pub(super) struct NotificationToast {
     bar_edge: Edge,
     /// Actual rendered height, measured after window is mapped
     height: Cell<i32>,
+    /// Theme-change callback guard; disconnected automatically on `Drop`.
+    theme_callback_guard: RefCell<Option<ThemeCallbackGuard>>,
 }
 
 impl NotificationToast {
@@ -98,6 +101,7 @@ impl NotificationToast {
             animation_source: RefCell::new(None),
             bar_edge,
             height: Cell::new(TOAST_ESTIMATED_HEIGHT),
+            theme_callback_guard: RefCell::new(None),
         });
 
         toast.build_content(notification, on_dismiss.clone(), on_action);
@@ -166,31 +170,15 @@ impl NotificationToast {
             });
         });
 
-        // Apply blur region hint when the toast surface is mapped.
-        // The window's child (outer container) defines the blur bounds,
-        // excluding the CSS box-shadow expansion that GTK adds to the surface.
-        toast.window.connect_map(move |win| {
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
-                    crate::services::background_effect::BackgroundEffectManager::global()
-                && let Some(content) = win.child()
-            {
-                let radius = ConfigManager::global().surface_border_radius() as i32;
-                blur.apply_blur_surface(win, &content, radius);
-            }
-        });
-
-        // Remove the blur region as soon as the native surface is torn down.
-        // connect_destroy fires while the Wayland surface still exists, so
-        // remove_blur_region can reach SurfaceInfo::from_widget.  The Drop impl
-        // below is retained as a safety net for any path that skips destroy.
-        toast.window.connect_destroy(|win| {
-            if let Some(blur) =
-                crate::services::background_effect::BackgroundEffectManager::global()
-            {
-                blur.remove_blur_region(win);
-            }
-        });
+        let theme_callback_guard = attach_blur_surface_lifecycle(
+            &toast.window,
+            |win: &Window| win.child(),
+            || ConfigManager::global().surface_border_radius() as i32,
+        );
+        toast
+            .theme_callback_guard
+            .borrow_mut()
+            .replace(theme_callback_guard);
 
         toast
     }
@@ -445,11 +433,8 @@ impl Drop for NotificationToast {
         if let Some(source_id) = self.timeout_source.borrow_mut().take() {
             source_id.remove();
         }
-        // Clean up the blur effect object so it doesn't leak in the
-        // BackgroundEffectManager's effects HashMap after the surface is gone.
-        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
-            blur.remove_blur_region(&self.window);
-        }
+        // ThemeCallbackGuard handles disconnect_theme_callback on drop.
+        drop(self.theme_callback_guard.borrow_mut().take());
     }
 }
 

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -25,8 +25,9 @@ use tracing::{debug, warn};
 use vibepanel_core::config::OsdConfig;
 
 use crate::services::audio::AudioSnapshot;
+use crate::services::background_effect::attach_blur_surface_lifecycle;
 use crate::services::brightness::BrightnessSnapshot;
-use crate::services::config_manager::ConfigManager;
+use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::icons::IconsService;
 use crate::services::ipc::IpcMessage;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -188,6 +189,7 @@ pub struct OsdOverlay {
     // Callback IDs for deterministic cleanup.
     brightness_callback_id: Cell<Option<CallbackId>>,
     audio_callback_id: Cell<Option<CallbackId>>,
+    theme_callback_guard: RefCell<Option<ThemeCallbackGuard>>,
 }
 
 impl OsdOverlay {
@@ -248,32 +250,14 @@ impl OsdOverlay {
         // Anchor window according to position.
         Self::apply_position(&window, &position);
 
-        // Apply blur region hint when the OSD surface is mapped.
-        // The container's allocation defines the blur bounds, excluding the
-        // CSS box-shadow expansion that GTK adds to the surface.
-        let blur_container = container.clone();
-        window.connect_map(move |win| {
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
-                    crate::services::background_effect::BackgroundEffectManager::global()
-            {
+        let theme_callback_guard = attach_blur_surface_lifecycle(
+            &window,
+            |win: &gtk4::Window| win.child(),
+            || {
                 // Same as `--radius-widget-lg: calc(widget-radius * 2)` in theme CSS.
-                let radius = ConfigManager::global().widget_border_radius() as i32 * 2;
-                blur.apply_blur_surface(win, &blur_container, radius);
-            }
-        });
-
-        // Remove the blur region as soon as the native surface is torn down.
-        // connect_destroy fires while the Wayland surface still exists, so
-        // remove_blur_region can reach SurfaceInfo::from_widget.  The Drop impl
-        // below is retained as a safety net for any path that skips destroy.
-        window.connect_destroy(|win| {
-            if let Some(blur) =
-                crate::services::background_effect::BackgroundEffectManager::global()
-            {
-                blur.remove_blur_region(win);
-            }
-        });
+                ConfigManager::global().widget_border_radius() as i32 * 2
+            },
+        );
 
         let overlay = Rc::new(Self {
             window,
@@ -287,6 +271,7 @@ impl OsdOverlay {
             last_muted: Cell::new(false),
             brightness_callback_id: Cell::new(None),
             audio_callback_id: Cell::new(None),
+            theme_callback_guard: RefCell::new(Some(theme_callback_guard)),
         });
 
         overlay.connect_brightness();
@@ -400,6 +385,9 @@ impl OsdOverlay {
 
         let source_id = glib::timeout_add_local(Duration::from_millis(timeout as u64), move || {
             if let Some(this) = this_weak.upgrade() {
+                // No explicit blur removal needed — unmapping suspends
+                // compositor-side blur while the protocol object persists.
+                // connect_map re-applies blur on next show.
                 this.window.set_visible(false);
                 *this.hide_source.borrow_mut() = None;
             }
@@ -574,10 +562,7 @@ impl Drop for OsdOverlay {
         if let Some(id) = self.audio_callback_id.take() {
             AudioService::global().disconnect(id);
         }
-        // Clean up the blur effect entry so it doesn't leak in the
-        // BackgroundEffectManager's effects HashMap after the surface is gone.
-        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
-            blur.remove_blur_region(&self.window);
-        }
+        // ThemeCallbackGuard handles disconnect_theme_callback on drop.
+        drop(self.theme_callback_guard.borrow_mut().take());
     }
 }

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -26,6 +26,7 @@ use vibepanel_core::config::OsdConfig;
 
 use crate::services::audio::AudioSnapshot;
 use crate::services::brightness::BrightnessSnapshot;
+use crate::services::config_manager::ConfigManager;
 use crate::services::icons::IconsService;
 use crate::services::ipc::IpcMessage;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -246,6 +247,33 @@ impl OsdOverlay {
 
         // Anchor window according to position.
         Self::apply_position(&window, &position);
+
+        // Apply blur region hint when the OSD surface is mapped.
+        // The container's allocation defines the blur bounds, excluding the
+        // CSS box-shadow expansion that GTK adds to the surface.
+        let blur_container = container.clone();
+        window.connect_map(move |win| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                // Same as `--radius-widget-lg: calc(widget-radius * 2)` in theme CSS.
+                let radius = ConfigManager::global().widget_border_radius() as i32 * 2;
+                blur.apply_blur_surface(win, &blur_container, radius);
+            }
+        });
+
+        // Remove the blur region as soon as the native surface is torn down.
+        // connect_destroy fires while the Wayland surface still exists, so
+        // remove_blur_region can reach SurfaceInfo::from_widget.  The Drop impl
+        // below is retained as a safety net for any path that skips destroy.
+        window.connect_destroy(|win| {
+            if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.remove_blur_region(win);
+            }
+        });
 
         let overlay = Rc::new(Self {
             window,
@@ -545,6 +573,11 @@ impl Drop for OsdOverlay {
         }
         if let Some(id) = self.audio_callback_id.take() {
             AudioService::global().disconnect(id);
+        }
+        // Clean up the blur effect entry so it doesn't leak in the
+        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
+            blur.remove_blur_region(&self.window);
         }
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -306,12 +306,27 @@ impl QuickSettingsWindow {
         // so apply_blur_region defers via idle.  On re-show, anim_shell is at
         // opacity 0 (transparent) until the animation tick overwrites the region
         // with a scaled version within 1-2 frames.
+        //
+        // The else-branch removes any stale protocol object left from a
+        // previous map cycle.  This handles the case where blur was enabled
+        // when QS was last shown, then disabled while QS was hidden (unmapped).
+        // `remove_blur_region` requires a mapped surface, so connect_map is
+        // the earliest reliable cleanup point.
+        //
+        // Known limitation: config changes to `theme.blur` or border radius
+        // while Quick Settings is open take effect on next open, not
+        // immediately.  QS grabs focus so config edits are unlikely while open.
         window.connect_map(move |win| {
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
+            if ConfigManager::global().blur_enabled() {
+                if let Some(blur) =
                     crate::services::background_effect::BackgroundEffectManager::global()
+                {
+                    blur.apply_blur_region(win, QUICK_SETTINGS_OUTER_MARGIN);
+                }
+            } else if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
             {
-                blur.apply_blur_region(win, QUICK_SETTINGS_OUTER_MARGIN);
+                blur.remove_blur_region(win);
             }
         });
 
@@ -1449,16 +1464,6 @@ impl QuickSettingsWindow {
                     }
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
-
-                    // When animations are disabled, apply blur region immediately
-                    // (the tick callback won't run to animate it in).
-                    if !ConfigManager::global().animations_enabled()
-                        && ConfigManager::global().blur_enabled()
-                        && let Some(blur) =
-                            crate::services::background_effect::BackgroundEffectManager::global()
-                    {
-                        blur.apply_blur_region(&qs.window, QUICK_SETTINGS_OUTER_MARGIN);
-                    }
                 }
             });
         } else {
@@ -1493,16 +1498,6 @@ impl QuickSettingsWindow {
 
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
-
-                    // When animations are disabled, apply blur region immediately
-                    // (the tick callback won't run to animate it in).
-                    if !ConfigManager::global().animations_enabled()
-                        && ConfigManager::global().blur_enabled()
-                        && let Some(blur) =
-                            crate::services::background_effect::BackgroundEffectManager::global()
-                    {
-                        blur.apply_blur_region(&qs.window, QUICK_SETTINGS_OUTER_MARGIN);
-                    }
                 }
             });
         }
@@ -1625,8 +1620,8 @@ impl QuickSettingsWindow {
             self.anim_shell.set_scale(ANIM_SCALE_FROM);
             self.is_animating_out.set(false);
             self.reset_ui_state();
-            // Blur removal is unnecessary here — set_visible(false) unmaps
-            // the wl_surface, so the compositor discards blur automatically.
+            // No explicit blur removal needed — unmapping suspends
+            // compositor-side blur while the protocol object persists.
             // Blur is re-applied on next map via connect_map.
             self.window.set_visible(false);
             return;
@@ -1640,10 +1635,7 @@ impl QuickSettingsWindow {
         // surface fades out.  Blur is a compositor effect independent of surface
         // opacity — if left in place it would remain visible as the content
         // becomes transparent.
-        if ConfigManager::global().blur_enabled()
-            && let Some(blur) =
-                crate::services::background_effect::BackgroundEffectManager::global()
-        {
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
             blur.remove_blur_region(&self.window);
         }
 
@@ -1735,16 +1727,18 @@ impl QuickSettingsWindow {
                 let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
                 shell_clone.set_scale(scale);
 
-                // The compositor might draw blur at the final full size while the
-                // ScaleBox visual is still growing in, causing a brief flash of
-                // oversized blur. Shrink the blur region to match the current scale.
                 if direction == AnimDirection::Opening
                     && ConfigManager::global().blur_enabled()
                     && let Some(blur) =
                         crate::services::background_effect::BackgroundEffectManager::global()
                     && let Some(window) = window_weak.upgrade()
                 {
-                    blur.apply_blur_region_animated(&window, QUICK_SETTINGS_OUTER_MARGIN, scale);
+                    blur.apply_open_animation_blur(
+                        &window,
+                        QUICK_SETTINGS_OUTER_MARGIN,
+                        scale,
+                        complete,
+                    );
                 }
 
                 if complete {
@@ -1763,16 +1757,6 @@ impl QuickSettingsWindow {
                     } else {
                         shell.set_opacity(1.0);
                         shell_clone.set_scale(1.0);
-                        // Set final full-size blur region (scale == 1.0) to
-                        // install the resize watcher.
-                        if ConfigManager::global().blur_enabled()
-                            && let Some(blur) =
-                                crate::services::background_effect::BackgroundEffectManager::global(
-                                )
-                            && let Some(window) = window_weak.upgrade()
-                        {
-                            blur.apply_blur_region(&window, QUICK_SETTINGS_OUTER_MARGIN);
-                        }
                     }
                     return ControlFlow::Break;
                 }
@@ -1845,8 +1829,9 @@ impl Drop for QuickSettingsWindow {
             catcher.close();
         }
 
-        // Clean up the blur effect entry so it doesn't leak in the
-        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        // Best-effort blur cleanup; primary removal happens at fade-start
+        // in hide_panel().  May no-op if already unmapped.
+        // See BackgroundEffectManager::remove_blur_region docs.
         if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
             blur.remove_blur_region(&self.window);
         }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -302,8 +302,10 @@ impl QuickSettingsWindow {
             });
         }
 
-        // Apply blur region hint when the QS surface is mapped.
-        // Inset by QUICK_SETTINGS_OUTER_MARGIN to exclude shadow padding from blur.
+        // Apply blur when mapped.  On first map the surface has no size yet
+        // so apply_blur_region defers via idle.  On re-show, anim_shell is at
+        // opacity 0 (transparent) until the animation tick overwrites the region
+        // with a scaled version within 1-2 frames.
         window.connect_map(move |win| {
             if ConfigManager::global().blur_enabled()
                 && let Some(blur) =
@@ -1623,12 +1625,9 @@ impl QuickSettingsWindow {
             self.anim_shell.set_scale(ANIM_SCALE_FROM);
             self.is_animating_out.set(false);
             self.reset_ui_state();
-            if ConfigManager::global().blur_enabled()
-                && let Some(blur) =
-                    crate::services::background_effect::BackgroundEffectManager::global()
-            {
-                blur.clear_blur_region(&self.window);
-            }
+            // Blur removal is unnecessary here — set_visible(false) unmaps
+            // the wl_surface, so the compositor discards blur automatically.
+            // Blur is re-applied on next map via connect_map.
             self.window.set_visible(false);
             return;
         }
@@ -1637,13 +1636,15 @@ impl QuickSettingsWindow {
         // may not have fired yet, leaving window.opacity at 0.0).
         self.window.set_opacity(1.0);
 
-        // Clear blur at the start of the close animation so the compositor
-        // stops drawing blur behind the surface while it fades out.
+        // Remove blur immediately so the compositor stops drawing it while the
+        // surface fades out.  Blur is a compositor effect independent of surface
+        // opacity — if left in place it would remain visible as the content
+        // becomes transparent.
         if ConfigManager::global().blur_enabled()
             && let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
         {
-            blur.clear_blur_region(&self.window);
+            blur.remove_blur_region(&self.window);
         }
 
         // Start (or reverse into) the close animation.
@@ -1734,8 +1735,9 @@ impl QuickSettingsWindow {
                 let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
                 shell_clone.set_scale(scale);
 
-                // During opening, update the blur region to match the ScaleBox clip
-                // so the compositor blur grows in sync with the visual.
+                // The compositor might draw blur at the final full size while the
+                // ScaleBox visual is still growing in, causing a brief flash of
+                // oversized blur. Shrink the blur region to match the current scale.
                 if direction == AnimDirection::Opening
                     && ConfigManager::global().blur_enabled()
                     && let Some(blur) =
@@ -1841,6 +1843,12 @@ impl Drop for QuickSettingsWindow {
         // Destroy click-catcher if still alive
         if let Some(catcher) = self.click_catcher.borrow_mut().take() {
             catcher.close();
+        }
+
+        // Clean up the blur effect entry so it doesn't leak in the
+        // BackgroundEffectManager's effects HashMap after the surface is gone.
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
+            blur.remove_blur_region(&self.window);
         }
 
         // Destroy the GTK window

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -302,6 +302,17 @@ impl QuickSettingsWindow {
             });
         }
 
+        // Apply blur region hint when the QS surface is mapped.
+        // Inset by QUICK_SETTINGS_OUTER_MARGIN to exclude shadow padding from blur.
+        window.connect_map(move |win| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.apply_blur_region(win, QUICK_SETTINGS_OUTER_MARGIN);
+            }
+        });
+
         // Subscribe to services
         Self::subscribe_to_services(&qs);
 
@@ -1436,6 +1447,14 @@ impl QuickSettingsWindow {
                     }
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
+
+                    // Apply blur region (re-show: surface is already sized).
+                    if ConfigManager::global().blur_enabled()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                    {
+                        blur.apply_blur_region(&qs.window, QUICK_SETTINGS_OUTER_MARGIN);
+                    }
                 }
             });
         } else {
@@ -1470,6 +1489,14 @@ impl QuickSettingsWindow {
 
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
+
+                    // Apply blur region (first show: surface is now sized after update_position).
+                    if ConfigManager::global().blur_enabled()
+                        && let Some(blur) =
+                            crate::services::background_effect::BackgroundEffectManager::global()
+                    {
+                        blur.apply_blur_region(&qs.window, QUICK_SETTINGS_OUTER_MARGIN);
+                    }
                 }
             });
         }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -1448,8 +1448,10 @@ impl QuickSettingsWindow {
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
 
-                    // Apply blur region (re-show: surface is already sized).
-                    if ConfigManager::global().blur_enabled()
+                    // When animations are disabled, apply blur region immediately
+                    // (the tick callback won't run to animate it in).
+                    if !ConfigManager::global().animations_enabled()
+                        && ConfigManager::global().blur_enabled()
                         && let Some(blur) =
                             crate::services::background_effect::BackgroundEffectManager::global()
                     {
@@ -1490,8 +1492,10 @@ impl QuickSettingsWindow {
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
 
-                    // Apply blur region (first show: surface is now sized after update_position).
-                    if ConfigManager::global().blur_enabled()
+                    // When animations are disabled, apply blur region immediately
+                    // (the tick callback won't run to animate it in).
+                    if !ConfigManager::global().animations_enabled()
+                        && ConfigManager::global().blur_enabled()
                         && let Some(blur) =
                             crate::services::background_effect::BackgroundEffectManager::global()
                     {
@@ -1619,6 +1623,12 @@ impl QuickSettingsWindow {
             self.anim_shell.set_scale(ANIM_SCALE_FROM);
             self.is_animating_out.set(false);
             self.reset_ui_state();
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) =
+                    crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.clear_blur_region(&self.window);
+            }
             self.window.set_visible(false);
             return;
         }
@@ -1626,6 +1636,15 @@ impl QuickSettingsWindow {
         // Ensure the window is fully visible (the idle callback from show_panel
         // may not have fired yet, leaving window.opacity at 0.0).
         self.window.set_opacity(1.0);
+
+        // Clear blur at the start of the close animation so the compositor
+        // stops drawing blur behind the surface while it fades out.
+        if ConfigManager::global().blur_enabled()
+            && let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+        {
+            blur.clear_blur_region(&self.window);
+        }
 
         // Start (or reverse into) the close animation.
         self.start_animation(AnimDirection::Closing, generation);
@@ -1715,6 +1734,17 @@ impl QuickSettingsWindow {
                 let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
                 shell_clone.set_scale(scale);
 
+                // During opening, update the blur region to match the ScaleBox clip
+                // so the compositor blur grows in sync with the visual.
+                if direction == AnimDirection::Opening
+                    && ConfigManager::global().blur_enabled()
+                    && let Some(blur) =
+                        crate::services::background_effect::BackgroundEffectManager::global()
+                    && let Some(window) = window_weak.upgrade()
+                {
+                    blur.apply_blur_region_animated(&window, QUICK_SETTINGS_OUTER_MARGIN, scale);
+                }
+
                 if complete {
                     anim_state.borrow_mut().active = false;
 
@@ -1731,6 +1761,16 @@ impl QuickSettingsWindow {
                     } else {
                         shell.set_opacity(1.0);
                         shell_clone.set_scale(1.0);
+                        // Set final full-size blur region (scale == 1.0) to
+                        // install the resize watcher.
+                        if ConfigManager::global().blur_enabled()
+                            && let Some(blur) =
+                                crate::services::background_effect::BackgroundEffectManager::global(
+                                )
+                            && let Some(window) = window_weak.upgrade()
+                        {
+                            blur.apply_blur_region(&window, QUICK_SETTINGS_OUTER_MARGIN);
+                        }
                     }
                     return ControlFlow::Break;
                 }

--- a/crates/vibepanel/src/widgets/tray.rs
+++ b/crates/vibepanel/src/widgets/tray.rs
@@ -17,6 +17,7 @@ use tracing::debug;
 use vibepanel_core::config::WidgetEntry;
 use vibepanel_core::{parse_hex_color, theme::relative_luminance};
 
+use crate::services::background_effect::BackgroundEffectManager;
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -961,10 +962,28 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
         let state_for_close = state_clone.clone();
         let parent_for_close = parent_clone.clone();
         popover.connect_closed(move |p| {
+            // Remove blur effect object for this popup surface.
+            if let Some(blur) = BackgroundEffectManager::global() {
+                blur.remove_blur_region(p);
+            }
             state_for_close.borrow_mut().menu = None;
             parent_for_close.remove_css_class(widget::TRAY_ITEM_MENU_OPEN);
             if p.parent().is_some() {
                 p.unparent();
+            }
+        });
+
+        // Apply blur hint to the popup surface.  Must be connected before
+        // popup() — GTK4 fires the map signal synchronously during popup(),
+        // so a handler registered after popup() is never invoked.
+        let popover_for_blur = popover.clone();
+        let container_for_blur = container.clone();
+        popover.connect_map(move |_| {
+            if ConfigManager::global().blur_enabled()
+                && let Some(blur) = BackgroundEffectManager::global()
+            {
+                let radius = ConfigManager::global().surface_border_radius() as i32;
+                blur.apply_blur_surface(&popover_for_blur, &container_for_blur, radius);
             }
         });
 

--- a/crates/vibepanel/src/widgets/tray.rs
+++ b/crates/vibepanel/src/widgets/tray.rs
@@ -92,6 +92,17 @@ struct MenuState {
     stack: Vec<Vec<TrayMenuEntry>>,
 }
 
+impl Drop for MenuState {
+    fn drop(&mut self) {
+        // Safety net: remove the blur protocol object if this MenuState is
+        // dropped without going through the connect_closed handler (e.g.
+        // bar teardown on config reload, monitor disconnect, or shutdown).
+        if let Some(blur) = BackgroundEffectManager::global() {
+            blur.remove_blur_region(&self.popover);
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ContrastParams {
     bg_luminance: f64,
@@ -870,7 +881,11 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
     // Close existing menu if any - extract popover first to avoid borrow conflict
     let old_popover = {
         let mut st = state.borrow_mut();
-        st.menu.take().map(|m| m.popover)
+        st.menu.take().map(|m| {
+            let popover = m.popover.clone();
+            drop(m); // runs Drop → remove_blur_region
+            popover
+        })
     };
     if let Some(popover) = old_popover
         && popover.parent().is_some()
@@ -976,14 +991,14 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
         // Apply blur hint to the popup surface.  Must be connected before
         // popup() — GTK4 fires the map signal synchronously during popup(),
         // so a handler registered after popup() is never invoked.
-        let popover_for_blur = popover.clone();
         let container_for_blur = container.clone();
-        popover.connect_map(move |_| {
+        popover.connect_map(move |p| {
             if ConfigManager::global().blur_enabled()
                 && let Some(blur) = BackgroundEffectManager::global()
             {
-                let radius = ConfigManager::global().surface_border_radius() as i32;
-                blur.apply_blur_surface(&popover_for_blur, &container_for_blur, radius);
+                blur.apply_blur_surface(p, &container_for_blur, || {
+                    ConfigManager::global().surface_border_radius() as i32
+                });
             }
         });
 


### PR DESCRIPTION
Adds window blur via the `ext-background-effect-v1` Wayland protocol across all surfaces: bar, popovers, quick settings, OSD, notification toasts, tray menus  and media popout window.

`ext-background-effect-v1` gives full control of what, where, and when to apply blur resulting in a better result than when only relying on generic layer rules in the compositor.

<img width="289" height="368" alt="image" src="https://github.com/user-attachments/assets/cfd90ad5-6934-47b1-8154-6249ca7b48f5" />
<img width="312" height="268" alt="image" src="https://github.com/user-attachments/assets/3fb6e863-ac52-41c6-9295-738fc91e4187" />
