### PR TITLE
feat(theme): add semantic hover variables

### DIFF
--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -563,7 +563,6 @@ impl ThemePalette {
         } else {
             0
         };
-
         format!(
             r#"
 :root {{
@@ -577,7 +576,7 @@ impl ThemePalette {
     --widget-hover-tint: {widget_hover_tint};
     /* Semantic hover backgrounds for user CSS overrides. */
     --color-widget-hover-bg: {widget_hover_bg_value};
-    --color-workspace-indicator-hover-bg: var(--color-card-overlay-hover);
+    --color-workspace-indicator-hover-default-bg: var(--color-card-overlay-hover);
     --color-workspace-indicator-active-hover-bg: var(--color-accent-hover-bg);
     --color-taskbar-button-hover-bg: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
     --color-taskbar-button-active-hover-bg: var(--color-accent-hover-bg);
@@ -1552,6 +1551,19 @@ mod tests {
         assert!(css.contains("--radius-bar:"));
         assert!(css.contains("--widget-height:"));
         assert!(css.contains("--font-family:"));
+    }
+
+    #[test]
+    fn test_workspace_indicator_hover_default_uses_internal_token() {
+        let config = Config::default();
+        let palette = ThemePalette::from_config(&config, None, None);
+        let css = palette.css_vars_block();
+
+        assert!(css.contains(
+            "--color-workspace-indicator-hover-default-bg: var(--color-card-overlay-hover);"
+        ));
+        assert!(!css.contains("--color-workspace-indicator-hover-bg:"));
+        assert!(!css.contains("--color-workspace-indicator-minimal-hover-bg"));
     }
 
     #[test]

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -575,9 +575,9 @@ impl ThemePalette {
     --widget-hover-tint: {widget_hover_tint};
     /* Semantic hover backgrounds for user CSS overrides. */
     --color-widget-hover-bg: color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint));
-    --color-widget-group-hover-bg: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
     --color-workspace-indicator-hover-bg: var(--color-card-overlay-hover);
     --color-workspace-indicator-active-hover-bg: var(--color-accent-hover-bg);
+    --color-taskbar-button-hover-bg: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
     --color-taskbar-button-active-hover-bg: var(--color-accent-hover-bg);
 
     /* ===== Background Colors ===== */

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -573,6 +573,12 @@ impl ThemePalette {
     --widget-background-opacity: {widget_bg_opacity}%;
     --popover-background-opacity: {popover_bg_opacity}%;
     --widget-hover-tint: {widget_hover_tint};
+    /* Semantic hover backgrounds for user CSS overrides. */
+    --color-widget-hover-bg: color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint));
+    --color-widget-group-hover-bg: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+    --color-workspace-indicator-hover-bg: var(--color-card-overlay-hover);
+    --color-workspace-indicator-active-hover-bg: var(--color-accent-hover-bg);
+    --color-taskbar-button-active-hover-bg: var(--color-accent-hover-bg);
 
     /* ===== Background Colors ===== */
     /* Bar background with opacity applied via color-mix */

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -70,6 +70,8 @@ const DEFAULT_STATE_WARNING: &str = "#e5c07b";
 const DEFAULT_STATE_URGENT: &str = "#ff6b6b";
 const DEFAULT_FONT_FAMILY: &str = "monospace";
 
+const WIDGET_HOVER_BG_VALUE: &str = "color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint))";
+
 // Size scaling factors (empirically tuned for visual balance at bar sizes 28-60px)
 const FONT_SCALE: f64 = 0.6;
 const TEXT_ICON_SCALE: f64 = 0.50;
@@ -574,7 +576,7 @@ impl ThemePalette {
     --popover-background-opacity: {popover_bg_opacity}%;
     --widget-hover-tint: {widget_hover_tint};
     /* Semantic hover backgrounds for user CSS overrides. */
-    --color-widget-hover-bg: color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint));
+    --color-widget-hover-bg: {widget_hover_bg_value};
     --color-workspace-indicator-hover-bg: var(--color-card-overlay-hover);
     --color-workspace-indicator-active-hover-bg: var(--color-accent-hover-bg);
     --color-taskbar-button-hover-bg: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
@@ -689,6 +691,7 @@ impl ThemePalette {
 "#,
             bar_bg_with_opacity = self.bar_background_with_opacity(),
             widget_bg_color = self.widget_background,
+            widget_hover_bg_value = WIDGET_HOVER_BG_VALUE,
             widget_bg_opacity = (self.widget_opacity * 100.0).round() as u32,
             popover_bg_opacity = match self.popover_opacity {
                 Some(explicit) => (explicit * 100.0).round() as u32,
@@ -813,6 +816,7 @@ impl ThemePalette {
                 if let Some((r, g, b)) = parse_hex_color(color) {
                     let normalized = format!("#{:02x}{:02x}{:02x}", r, g, b);
                     rules.push(format!("--widget-background-color: {};", normalized));
+                    rules.push(format!("--color-widget-hover-bg: {WIDGET_HOVER_BG_VALUE};"));
                 } else {
                     tracing::warn!(
                         "Invalid background_color '{}' for widget '{}' - expected hex color",
@@ -828,7 +832,8 @@ impl ThemePalette {
                 css.push_str(&format!(
                     r#"
 .widget.{css_name},
-.widget-group.{css_name},
+.widget-item.{css_name},
+.widget-merge-group.{css_name},
 .{css_name}-popover {{
     {rules}
 }}
@@ -1564,11 +1569,21 @@ mod tests {
 
         let css = ThemePalette::generate_per_widget_css(&config);
 
-        // Should generate CSS targeting widget, widget-group, and popover
+        // Should generate CSS targeting widget surfaces, grouped paint elements, and popover.
+        // The transparent .widget-group surface must not receive per-widget variables;
+        // they would inherit into unrelated children in mixed groups.
         assert!(css.contains(".widget.clock"), "should target .widget.clock");
         assert!(
-            css.contains(".widget-group.clock"),
-            "should target .widget-group.clock"
+            css.contains(".widget-item.clock"),
+            "should target .widget-item.clock"
+        );
+        assert!(
+            !css.contains(".widget-group.clock"),
+            "should not target transparent .widget-group.clock"
+        );
+        assert!(
+            css.contains(".widget-merge-group.clock"),
+            "should target .widget-merge-group.clock"
         );
         assert!(
             css.contains(".clock-popover"),
@@ -1578,6 +1593,12 @@ mod tests {
         assert!(
             css.contains("--widget-background-color: #f5c2e7"),
             "should set --widget-background-color"
+        );
+        assert!(
+            css.contains(&format!(
+                "--color-widget-hover-bg: {WIDGET_HOVER_BG_VALUE};"
+            )),
+            "should rederive --color-widget-hover-bg from per-widget background"
         );
     }
 

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -277,36 +277,24 @@ fn build_widget_or_group(
             let mut count = 0;
 
             // Build entries individually (used for singletons and merge fallback).
-            let build_individually = |entries: &[WidgetEntry],
-                                      content: &gtk4::Box,
-                                      state: &mut BarState|
-             -> usize {
-                let mut n = 0;
-                for entry in entries {
-                    if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id) {
-                        // Group surface owns the background, so strip the
-                        // standalone wrapper class and force the inner .widget
-                        // surface transparent.  .widget is kept for border-radius
-                        // (ripple clipping); a scoped provider at transient
-                        // priority beats user CSS that also targets .widget.
-                        built.widget.remove_css_class(class::WIDGET_WRAPPER);
-                        if let Some(surface) = built.widget.first_child() {
-                            let provider = gtk4::CssProvider::new();
-                            provider.load_from_string(
-                                    ".widget { background-color: transparent; background-image: none; }",
-                                );
-                            #[allow(deprecated)]
-                            surface
-                                .style_context()
-                                .add_provider(&provider, TRANSIENT_CSS_PRIORITY);
+            // Each child paints its own background; the group surface is transparent.
+            let build_individually =
+                |entries: &[WidgetEntry], content: &gtk4::Box, state: &mut BarState| -> usize {
+                    let mut n = 0;
+                    for entry in entries {
+                        if let Some(built) = WidgetFactory::build(entry, Some(qs_handle), output_id)
+                        {
+                            // Strip the standalone wrapper class so the wrapper-hover
+                            // rule doesn't fire — per-item hover is handled by a
+                            // group-scoped rule that paints on the .widget-item.
+                            built.widget.remove_css_class(class::WIDGET_WRAPPER);
+                            content.append(&built.widget);
+                            state.add_handle(built.handle);
+                            n += 1;
                         }
-                        content.append(&built.widget);
-                        state.add_handle(built.handle);
-                        n += 1;
                     }
-                }
-                n
-            };
+                    n
+                };
 
             for (kind, start, end) in &runs {
                 let run_entries = &group[*start..*end];

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -288,6 +288,7 @@ fn build_widget_or_group(
                             // rule doesn't fire — per-item hover is handled by a
                             // group-scoped rule that paints on the .widget-item.
                             built.widget.remove_css_class(class::WIDGET_WRAPPER);
+                            built.widget.set_overflow(gtk4::Overflow::Hidden);
                             content.append(&built.widget);
                             state.add_handle(built.handle);
                             n += 1;
@@ -372,8 +373,16 @@ fn build_merge_group(
     wrapper.set_child(Some(&inner_content));
 
     let ripple_handle = RippleHandle::new();
-    wrapper.add_overlay(ripple_handle.widget());
-    wrapper.set_measure_overlay(ripple_handle.widget(), true);
+    // Wrap the ripple DrawingArea in a Box that establishes a fully-rounded
+    // clip, so the ripple matches the inner pill shape on hover. The merge
+    // group itself uses position-aware radius (square at seams in mixed
+    // groups), which would otherwise leak the ripple into the corners.
+    let ripple_clip = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    ripple_clip.add_css_class("widget-merge-group-ripple-clip");
+    ripple_clip.set_overflow(gtk4::Overflow::Hidden);
+    ripple_clip.append(ripple_handle.widget());
+    wrapper.add_overlay(&ripple_clip);
+    wrapper.set_measure_overlay(&ripple_clip, true);
 
     let widget_name = entries[0].name.clone();
     let menu_handle = MenuHandle::new_placeholder(widget_name, wrapper.clone());

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -237,23 +237,14 @@ fn build_widget_or_group(
             content.set_vexpand(true);
             content.set_valign(gtk4::Align::Fill);
 
-            // Visual surface — also carries .widget-group so user CSS
-            // targeting either class hits the background element, not the wrapper.
+            // Group surface — transparent in CSS. Direct children paint their
+            // own backgrounds so hover colors composite once over the bar.
             let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
             surface.add_css_class(class::WIDGET);
             surface.add_css_class(class::WIDGET_GROUP);
             surface.set_overflow(gtk4::Overflow::Hidden);
             surface.set_hexpand(true);
             surface.set_vexpand(true);
-
-            // Add the first widget's name as a CSS class on the surface for
-            // per-widget CSS variable targeting.  Theme-generated selectors
-            // like `.widget.cpu` and user CSS like `.cpu { ... }` both hit
-            // the painted surface — not the transparent wrapper.
-            if let Some(first_entry) = group.first() {
-                let css_name = first_entry.name.replace('_', "-");
-                surface.add_css_class(&css_name);
-            }
 
             surface.append(&content);
             island.append(&surface);
@@ -288,6 +279,9 @@ fn build_widget_or_group(
                             // rule doesn't fire — per-item hover is handled by a
                             // group-scoped rule that paints on the .widget-item.
                             built.widget.remove_css_class(class::WIDGET_WRAPPER);
+                            built.widget.add_css_class(&entry.name.replace('_', "-"));
+                            // Grouped hover uses a large box-shadow spread to refill
+                            // the cell around the pill; this clips it to item bounds.
                             built.widget.set_overflow(gtk4::Overflow::Hidden);
                             content.append(&built.widget);
                             state.add_handle(built.handle);
@@ -363,6 +357,11 @@ fn build_merge_group(
     let wrapper = Overlay::new();
     wrapper.add_css_class(class::WIDGET_MERGE_GROUP);
     wrapper.add_css_class(state::CLICKABLE);
+    // Merged groups paint as a single button; only the leading widget's
+    // per-widget background class applies.
+    wrapper.add_css_class(&entries[0].name.replace('_', "-"));
+    // Required for the merge-group hover pill: its 9999px box-shadow
+    // refill is clipped here so it cannot bleed outside the group.
     wrapper.set_overflow(gtk4::Overflow::Hidden);
 
     let inner_content = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
@@ -378,7 +377,7 @@ fn build_merge_group(
     // group itself uses position-aware radius (square at seams in mixed
     // groups), which would otherwise leak the ripple into the corners.
     let ripple_clip = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
-    ripple_clip.add_css_class("widget-merge-group-ripple-clip");
+    ripple_clip.add_css_class(class::WIDGET_MERGE_GROUP_RIPPLE_CLIP);
     ripple_clip.set_overflow(gtk4::Overflow::Hidden);
     ripple_clip.append(ripple_handle.widget());
     wrapper.add_overlay(&ripple_clip);

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -50,6 +50,10 @@ pub mod class {
     /// Merges adjacent same-popover widgets into a single visual button.
     pub const WIDGET_MERGE_GROUP: &str = "widget-merge-group";
 
+    /// Merge group ripple clip (`.widget-merge-group-ripple-clip`).
+    /// Clips the ripple to the rounded inner hover pill.
+    pub const WIDGET_MERGE_GROUP_RIPPLE_CLIP: &str = "widget-merge-group-ripple-clip";
+
     /// Inner content box of a merge group (`.merge-group-content`).
     pub const MERGE_GROUP_CONTENT: &str = "merge-group-content";
 

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -111,6 +111,7 @@ sectioned-bar.bar {{
 }}
 .widget-group > .content > .widget-item > .widget {{
     background-color: transparent;
+    box-shadow: none;
 }}
 
 /* Halve the visible inter-item gap at every seam inside a group. Each
@@ -168,12 +169,18 @@ sectioned-bar.bar {{
     border-bottom-right-radius: var(--radius-widget);
 }}
 
-/* Grouped child hover — replaces the child's base so translucent values
-   composite over the bar background (matches standalone widget hover).
-   Applies to plain items (paint moved to .widget-item) and merge wrappers. */
-.widget-group .content > .widget-item.clickable:hover,
-.widget-group .content > .widget-merge-group.clickable:hover {{
+/* Grouped child hover — clears the cell base and paints a rounded hover
+   pill on the inner surface. The spread shadow restores the cell's base
+   color behind the rounded corners, clipped by the child allocation, so
+   translucent hover values composite over the bar background exactly once
+   without exposing wallpaper at mixed-group seams. */
+.widget-group > .content > .widget-item.clickable:hover {{
+    background-color: transparent;
+}}
+.widget-group > .content > .widget-item.clickable:hover > .widget {{
     background-color: var(--color-widget-hover-bg);
+    border-radius: var(--radius-widget);
+    box-shadow: 0 0 0 9999px {widget_bg};
 }}
 
 /* ===== MERGE GROUP ===== */
@@ -185,6 +192,27 @@ sectioned-bar.bar {{
 .widget-merge-group {{
     background-color: {widget_bg};
     border-radius: var(--radius-widget);
+}}
+.widget-merge-group > .merge-group-content {{
+    box-shadow: none;
+}}
+
+/* Ripple clip box (added in build_merge_group). Establishes a rounded clip
+   for the merge-group ripple so it matches the inner pill shape — the
+   merge-group itself uses position-aware radius and would otherwise leak
+   the ripple past rounded hover edges at mixed-group seams. */
+.widget-merge-group-ripple-clip {{
+    border-radius: var(--radius-widget);
+    background: transparent;
+}}
+
+.widget-group > .content > .widget-merge-group.clickable:hover {{
+    background-color: transparent;
+}}
+.widget-group > .content > .widget-merge-group.clickable:hover > .merge-group-content {{
+    background-color: var(--color-widget-hover-bg);
+    border-radius: var(--radius-widget);
+    box-shadow: 0 0 0 9999px {widget_bg};
 }}
 
 /* Passive items in merge groups don't show their own hover */

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -269,11 +269,7 @@ overlay.workspace-indicator {{
 
 /* Workspace hover backgrounds use scoped tokens so active hover can differ from global accent hover. */
 .workspace-indicator.clickable:hover {{
-    background-color: var(--color-workspace-indicator-hover-bg);
-}}
-
-.workspace-indicator-minimal.clickable:hover {{
-    background-color: var(--color-workspace-indicator-hover-bg);
+    background-color: var(--color-workspace-indicator-hover-bg, var(--color-workspace-indicator-hover-default-bg));
 }}
 
 .workspace-indicator.active.clickable:hover {{
@@ -281,6 +277,7 @@ overlay.workspace-indicator {{
 }}
 
 .workspace-indicator-minimal {{
+    --color-workspace-indicator-hover-default-bg: color-mix(in srgb, var(--color-foreground-faint) 80%, var(--widget-hover-tint));
     background-color: var(--color-foreground-faint);
 }}
 

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -330,7 +330,7 @@ overlay.workspace-indicator {{
 }}
 
 .taskbar-button.clickable:hover {{
-    background-color: var(--color-widget-group-hover-bg);
+    background-color: var(--color-taskbar-button-hover-bg);
 }}
 
 .taskbar-button.active {{

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -139,15 +139,15 @@ sectioned-bar.bar {{
 /* Position-aware pill shape: outer corners rounded only on the leading
    and trailing children; interior edges square so adjacent children meet
    flush. Applies to both plain items and merge wrappers. */
-.widget-group .content > .widget-item,
-.widget-group .content > .widget-merge-group {{
+.widget-group > .content > .widget-item,
+.widget-group > .content > .widget-merge-group {{
     border-radius: 0;
 }}
-.widget-group .content > :first-child {{
+.widget-group > .content > :first-child {{
     border-top-left-radius: var(--radius-widget);
     border-bottom-left-radius: var(--radius-widget);
 }}
-.widget-group .content > :last-child {{
+.widget-group > .content > :last-child {{
     border-top-right-radius: var(--radius-widget);
     border-bottom-right-radius: var(--radius-widget);
 }}

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -3,7 +3,7 @@
 //! Note: This module requires config values for screen_margin and spacing,
 //! so it returns a formatted String rather than a static str.
 
-use super::{CONTENT_PADDING_X, WIDGET_BG_HOVER, WIDGET_BG_WITH_OPACITY};
+use super::{CONTENT_PADDING_X, WIDGET_BG_WITH_OPACITY};
 use crate::widgets::workspaces::{
     INDICATOR_ACTIVE_MULT, INDICATOR_HEIGHT_MULT, INDICATOR_INACTIVE_MULT, LONG_INDICATOR_HPAD,
 };
@@ -17,7 +17,6 @@ use crate::widgets::workspaces::{
 /// alive even when `theme.animations = false`.
 pub fn css(screen_margin: u32, spacing: u32, workspace_animations: bool) -> String {
     let widget_bg = WIDGET_BG_WITH_OPACITY;
-    let widget_bg_hover = WIDGET_BG_HOVER;
     let inactive_mult = INDICATOR_INACTIVE_MULT;
     let active_mult = INDICATOR_ACTIVE_MULT;
     let height_mult = INDICATOR_HEIGHT_MULT;
@@ -91,7 +90,7 @@ sectioned-bar.bar {{
 
 /* Hover targets the wrapper but paints on the surface child */
 .widget-wrapper.clickable:hover > .widget:not(.widget-group) {{
-    background-color: {widget_bg_hover};
+    background-color: var(--color-widget-hover-bg);
 }}
 
 /* Pull non-first items left to overlap adjacent .content padding (2 × {content_pad_x}px).
@@ -118,7 +117,7 @@ sectioned-bar.bar {{
 
 /* Grouped item hover — tint only (group surface provides base background) */
 .widget-group .content > .widget-item.clickable:hover {{
-    background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+    background-color: var(--color-widget-group-hover-bg);
 }}
 
 /* ===== MERGE GROUP ===== */
@@ -132,7 +131,7 @@ sectioned-bar.bar {{
 
 /* Merge group hover — shared background for the entire merged button */
 .widget-merge-group.clickable:hover {{
-    background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+    background-color: var(--color-widget-group-hover-bg);
 }}
 
 /* Passive items in merge groups don't show their own hover */
@@ -179,19 +178,17 @@ overlay.workspace-indicator {{
     border-radius: calc(var(--radius-pill) * 1.2);
 }}
 
-/* Workspace indicator hover — background-color fades via the 100ms ease
-   transition above.  Accent state uses --color-accent-hover-bg (pre-computed in
-   the theme with luminance-aware tint direction and ratio). */
+/* Workspace hover backgrounds use scoped tokens so active hover can differ from global accent hover. */
 .workspace-indicator.clickable:hover {{
-    background-color: var(--color-card-overlay-hover);
+    background-color: var(--color-workspace-indicator-hover-bg);
 }}
 
 .workspace-indicator-minimal.clickable:hover {{
-    background-color: color-mix(in srgb, var(--color-foreground-faint) 80%, var(--widget-hover-tint));
+    background-color: var(--color-workspace-indicator-hover-bg);
 }}
 
 .workspace-indicator.active.clickable:hover {{
-    background-color: var(--color-accent-hover-bg);
+    background-color: var(--color-workspace-indicator-active-hover-bg);
 }}
 
 .workspace-indicator-minimal {{
@@ -244,7 +241,7 @@ overlay.workspace-indicator {{
 }}
 
 .taskbar-button.clickable:hover {{
-    background-color: color-mix(in srgb, transparent 92%, var(--widget-hover-tint));
+    background-color: var(--color-widget-group-hover-bg);
 }}
 
 .taskbar-button.active {{
@@ -253,7 +250,7 @@ overlay.workspace-indicator {{
 }}
 
 .taskbar-button.active.clickable:hover {{
-    background-color: var(--color-accent-hover-bg);
+    background-color: var(--color-taskbar-button-active-hover-bg);
 }}
 
 "#

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -22,6 +22,7 @@ pub fn css(screen_margin: u32, spacing: u32, workspace_animations: bool) -> Stri
     let height_mult = INDICATOR_HEIGHT_MULT;
     let long_hpad = LONG_INDICATOR_HPAD;
     let content_pad_x = CONTENT_PADDING_X;
+    let content_pad_x_half = CONTENT_PADDING_X / 2;
     let content_pad_x_double = 2 * CONTENT_PADDING_X;
     let workspace_transition = if workspace_animations {
         "transition: min-width 200ms linear, background-color 100ms ease;"
@@ -83,9 +84,14 @@ sectioned-bar.bar {{
     padding: var(--widget-padding-y) {content_pad_x}px;
 }}
 
-/* Widget groups - remove padding so hover can extend to edges */
+/* Widget groups — surface is transparent; each child paints its own base
+   so translucent hover composites over the bar background, not on a
+   stacked group base. Outer pill shape comes from position-aware radius
+   on the first/last children below. */
 .widget.widget-group {{
     padding: 0;
+    background-color: transparent;
+    background-image: none;
 }}
 
 /* Hover targets the wrapper but paints on the surface child */
@@ -93,45 +99,92 @@ sectioned-bar.bar {{
     background-color: var(--color-widget-hover-bg);
 }}
 
-/* Pull non-first items left to overlap adjacent .content padding (2 × {content_pad_x}px).
-   Merge groups (.widget-merge-group) are also direct children of .content,
-   so they need the same treatment when they follow another item. */
-.widget-group .content > .widget-item:not(:first-child),
-.widget-group .content > .widget-merge-group:not(:first-child) {{
-    margin-left: -{content_pad_x_double}px;
+/* Each grouped child paints its own background. Both adjacent painted
+   siblings (.widget-merge-group and .widget-item) sit at the same DOM
+   depth (direct children of .widget-group > .content) so their painted
+   regions meet flush in the parent Box. The inner .widget stays
+   transparent — painting the outer .widget-item ensures the painted
+   surface fills the item's allocation, eliminating subpixel seams that
+   appear when paint depth differs between siblings. */
+.widget-group > .content > .widget-item {{
+    background-color: {widget_bg};
 }}
-
-/* Base border-radius for grouped items — must be present in the non-hover
-   state so the radius doesn't snap on/off during the background transition */
-.widget-group .content > .widget-item {{
-    border-radius: var(--radius-widget);
-}}
-
-/* Nested surfaces transparent — theme-priority fallback for grouped active
-   widgets.  The primary suppression is a scoped CSS provider in bar.rs
-   (transient priority), but this catches edge cases at theme priority. */
-.widget.widget-group .widget {{
+.widget-group > .content > .widget-item > .widget {{
     background-color: transparent;
-    border-radius: inherit;
 }}
 
-/* Grouped item hover — tint only (group surface provides base background) */
-.widget-group .content > .widget-item.clickable:hover {{
-    background-color: var(--color-widget-group-hover-bg);
+/* Halve the visible inter-item gap at every seam inside a group. Each
+   item carries `pad_x` on both inner-content sides; without override,
+   adjacent items show `2 * pad_x` between their icons (looks doubled vs
+   the intra-merge gap, which is collapsed by the negative-margin overlap
+   inside .merge-group-content + .merge-group-content's set_spacing).
+   Halving both seam-facing sides to `pad_x / 2` yields a total seam gap
+   of `pad_x`, matching MERGE_GROUP_SPACING for visual consistency.
+   - .widget-item: padding lives on .widget > overlay > .content.
+   - .widget-merge-group: the leftmost/rightmost passive item's .content
+     carries the seam-facing padding (interior passive items are already
+     overlapped by margin-left).
+   :not(:first-child) → has a previous sibling → halve left side.
+   :not(:last-child)  → has a following sibling → halve right side. */
+.widget-group > .content > .widget-item:not(:first-child) > .widget > overlay > .content,
+.widget-group > .content > .widget-merge-group:not(:first-child) > .merge-group-content > .widget-item:first-child > .content {{
+    padding-left: {content_pad_x_half}px;
+}}
+.widget-group > .content > .widget-item:not(:last-child) > .widget > overlay > .content,
+.widget-group > .content > .widget-merge-group:not(:last-child) > .merge-group-content > .widget-item:last-child > .content {{
+    padding-right: {content_pad_x_half}px;
+}}
+
+/* Position-aware pill shape: outer corners rounded only on the leading
+   and trailing children; interior edges square so adjacent children meet
+   flush. Applies to both plain items and merge wrappers. */
+.widget-group .content > .widget-item,
+.widget-group .content > .widget-merge-group {{
+    border-radius: 0;
+}}
+.widget-group .content > :first-child {{
+    border-top-left-radius: var(--radius-widget);
+    border-bottom-left-radius: var(--radius-widget);
+}}
+.widget-group .content > :last-child {{
+    border-top-right-radius: var(--radius-widget);
+    border-bottom-right-radius: var(--radius-widget);
+}}
+
+/* Inner .widget surface inside grouped items must match its parent
+   .widget-item's position-aware radius — the inner .widget has
+   Overflow::Hidden which clips the ripple, so without this override
+   the ripple would clip to the standalone --radius-widget shape and
+   not reach the painted square corners at interior seams. */
+.widget-group > .content > .widget-item > .widget {{
+    border-radius: 0;
+}}
+.widget-group > .content > .widget-item:first-child > .widget {{
+    border-top-left-radius: var(--radius-widget);
+    border-bottom-left-radius: var(--radius-widget);
+}}
+.widget-group > .content > .widget-item:last-child > .widget {{
+    border-top-right-radius: var(--radius-widget);
+    border-bottom-right-radius: var(--radius-widget);
+}}
+
+/* Grouped child hover — replaces the child's base so translucent values
+   composite over the bar background (matches standalone widget hover).
+   Applies to plain items (paint moved to .widget-item) and merge wrappers. */
+.widget-group .content > .widget-item.clickable:hover,
+.widget-group .content > .widget-merge-group.clickable:hover {{
+    background-color: var(--color-widget-hover-bg);
 }}
 
 /* ===== MERGE GROUP ===== */
 
 /* Merge group wrapper — acts as a single visual button for adjacent
-   same-popover widgets. Rounded corners clip the shared ripple effect.
-   overflow:hidden is set in Rust (not a valid GTK4 CSS property). */
+   same-popover widgets. Paints its own base; the parent group surface
+   is transparent. overflow:hidden is set in Rust (not a valid GTK4 CSS
+   property). */
 .widget-merge-group {{
+    background-color: {widget_bg};
     border-radius: var(--radius-widget);
-}}
-
-/* Merge group hover — shared background for the entire merged button */
-.widget-merge-group.clickable:hover {{
-    background-color: var(--color-widget-group-hover-bg);
 }}
 
 /* Passive items in merge groups don't show their own hover */
@@ -144,8 +197,16 @@ sectioned-bar.bar {{
     margin-left: -{content_pad_x_double}px;
 }}
 
-/* Spacing between items inside widgets */
-.widget .content > *:not(:last-child),
+/* Spacing between items inside widgets (icon→label, etc.).
+   Restricted to inner .content elements: standalone widgets' .content sits
+   inside .widget (which is NOT .widget-group), and grouped items' inner
+   .content sits inside .widget-item.passive (merge groups) or one extra
+   level deep under .widget-group's outer .content. The outer .content
+   directly under .widget.widget-group must NOT match — its direct children
+   are the painted siblings (.widget-merge-group, .widget-item) that need
+   to meet flush with zero margin between them. */
+.widget:not(.widget-group) > overlay > .content > *:not(:last-child),
+.widget:not(.widget-group) > .content > *:not(:last-child),
 .widget-group .content .content > *:not(:last-child) {{
     margin-right: var(--spacing-widget-gap);
 }}

--- a/crates/vibepanel/src/widgets/css/mod.rs
+++ b/crates/vibepanel/src/widgets/css/mod.rs
@@ -23,10 +23,6 @@ pub const WIDGET_BG_WITH_OPACITY: &str = "color-mix(in srgb, var(--widget-backgr
 /// Popover background with opacity — uses max(bar, widget) opacity so popovers stay visible in "single bar" mode.
 pub const POPOVER_BG_WITH_OPACITY: &str = "color-mix(in srgb, var(--widget-background-color) var(--popover-background-opacity), transparent)";
 
-/// Widget hover background — blends 8% of the hover tint (white/black) into the base background.
-/// Uses nested `color-mix()` so per-widget `--widget-background-color` overrides cascade automatically.
-pub const WIDGET_BG_HOVER: &str = "color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint))";
-
 /// Popover open/close animation duration in milliseconds.
 ///
 /// Single source of truth for tick-callback animation durations.


### PR DESCRIPTION
Adds stable CSS variables for customizing widget, workspace, and taskbar hover backgrounds without targeting internal GTK structure.

Variables:
```css
- --color-widget-hover-bg                                    # regular widget hover
- --color-workspace-indicator-hover-bg                       # inactive workspace indicators
- --color-workspace-indicator-active-hover-bg                # active workspace indicator
- --color-taskbar-button-active-hover-bg                     # active taskbar window
```

Closes #108.