### PR TITLE
feat(workspaces): hyprland named workspaces and new config options

### DIFF
--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -590,11 +590,14 @@ impl HyprlandBackend {
     }
 
     fn workspace_id_from_event_name(&self, workspace_name: &str) -> Option<i32> {
-        workspace_name
-            .parse::<i64>()
+        let name = workspace_name
+            .strip_prefix("name:")
+            .unwrap_or(workspace_name);
+
+        name.parse::<i64>()
             .ok()
             .and_then(|id| i32::try_from(id).ok())
-            .or_else(|| self.workspace_id_for_name(workspace_name))
+            .or_else(|| self.workspace_id_for_name(name))
     }
 
     /// Refresh active window info from Hyprland.
@@ -1230,7 +1233,7 @@ mod tests {
             output: None,
         }];
 
-        backend.handle_event("focusedmon>>DP-1,web");
+        backend.handle_event("focusedmon>>DP-1,name:web");
 
         let snapshot = backend.workspace_snapshot.read();
         assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
@@ -1256,10 +1259,42 @@ mod tests {
             .write()
             .insert("DP-1".to_string(), 1);
 
-        backend.handle_event("focusedmon>>DP-1,web");
+        backend.handle_event("focusedmon>>DP-1,name:web");
 
         let snapshot = backend.workspace_snapshot.read();
         assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
         assert_eq!(backend.monitor_workspaces.read().get("DP-1"), Some(&-1337));
+    }
+
+    #[test]
+    fn workspace_event_resolves_prefixed_named_workspace() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        backend.handle_event("workspace>>name:web");
+
+        let snapshot = backend.workspace_snapshot.read();
+        assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
+    }
+
+    #[test]
+    fn workspacev2_event_resolves_prefixed_named_workspace() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        backend.handle_event("workspacev2>>-1337,name:web");
+
+        let snapshot = backend.workspace_snapshot.read();
+        assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
     }
 }

--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -173,6 +173,8 @@ impl HyprlandBackend {
             return None;
         }
 
+        // Hyprland reserves 0 as invalid/no workspace; valid numeric workspaces
+        // are positive and named workspaces use negative compositor-assigned IDs.
         if let Some(id) = id.and_then(|id| i32::try_from(id).ok())
             && id != 0
         {
@@ -214,7 +216,10 @@ impl HyprlandBackend {
                 id,
                 WorkspaceMeta {
                     id,
-                    idx: id,
+                    // Positive IDs are user-facing numeric workspaces. Negative
+                    // IDs belong to truly named workspaces and are Hyprland
+                    // internals, so they have no meaningful numeric index.
+                    idx: if id > 0 { id } else { -1 },
                     name,
                     output: None,
                 },
@@ -223,12 +228,12 @@ impl HyprlandBackend {
 
         let mut workspaces: Vec<_> = merged.into_values().collect();
         workspaces.sort_by(|a, b| match (a.id > 0, b.id > 0) {
-            (true, true) => a.idx.cmp(&b.idx),
+            (true, true) => a.id.cmp(&b.id),
             (true, false) => std::cmp::Ordering::Less,
             (false, true) => std::cmp::Ordering::Greater,
             // Hyprland assigns named workspace IDs downward from -1337; values
             // closer to zero were created earlier and should appear first.
-            (false, false) => b.idx.cmp(&a.idx),
+            (false, false) => b.id.cmp(&a.id),
         });
         workspaces
     }
@@ -268,6 +273,13 @@ impl HyprlandBackend {
         if workspace_id < 0 {
             let workspaces = self.workspaces.read();
             if let Some(ws) = workspaces.iter().find(|ws| ws.id == workspace_id) {
+                if ws.name.chars().any(char::is_whitespace) {
+                    warn!(
+                        "Hyprland named workspace {:?} contains whitespace; switching may fail \
+                         if Hyprland does not accept the raw name in workspace dispatch",
+                        ws.name
+                    );
+                }
                 return format!("name:{}", ws.name);
             }
             warn!("No Hyprland workspace found for named workspace id {workspace_id}");
@@ -577,6 +589,14 @@ impl HyprlandBackend {
         changed
     }
 
+    fn workspace_id_from_event_name(&self, workspace_name: &str) -> Option<i32> {
+        workspace_name
+            .parse::<i64>()
+            .ok()
+            .and_then(|id| i32::try_from(id).ok())
+            .or_else(|| self.workspace_id_for_name(workspace_name))
+    }
+
     /// Refresh active window info from Hyprland.
     ///
     /// Queries `activewindow` JSON and updates `focused_window`.
@@ -637,12 +657,7 @@ impl HyprlandBackend {
         match event {
             "workspace" => {
                 // workspace>>ID or workspace>>NAME
-                if let Some(ws_id) = data
-                    .parse::<i64>()
-                    .ok()
-                    .and_then(|id| i32::try_from(id).ok())
-                    .or_else(|| self.workspace_id_for_name(data))
-                {
+                if let Some(ws_id) = self.workspace_id_from_event_name(data) {
                     if !self.has_workspace_metadata(ws_id) {
                         workspace_changed |= self.refresh_occupied();
                     }
@@ -660,11 +675,9 @@ impl HyprlandBackend {
             "workspacev2" => {
                 // workspacev2>>ID,NAME
                 if let Some((id_str, name)) = data.split_once(',')
-                    && let Some(ws_id) = id_str
-                        .parse::<i64>()
-                        .ok()
-                        .and_then(|id| i32::try_from(id).ok())
-                        .or_else(|| self.workspace_id_for_name(name))
+                    && let Some(ws_id) = self
+                        .workspace_id_from_event_name(id_str)
+                        .or_else(|| self.workspace_id_from_event_name(name))
                 {
                     if !self.has_workspace_metadata(ws_id) {
                         workspace_changed |= self.refresh_occupied();
@@ -713,25 +726,33 @@ impl HyprlandBackend {
             "focusedmon" => {
                 // focusedmon>>MONNAME,WORKSPACENAME
                 // Update focused monitor and global active workspace
-                if let Some((mon_name, _ws_name)) = data.split_once(',') {
+                if let Some((mon_name, ws_name)) = data.split_once(',') {
                     *self.focused_monitor.write() = Some(mon_name.to_string());
 
                     // Update global active_workspace to this monitor's active workspace
-                    let monitor_ws = self.monitor_workspaces.read();
-                    if let Some(&ws_id) = monitor_ws.get(mon_name) {
+                    let cached_ws_id = self.monitor_workspaces.read().get(mon_name).copied();
+                    let event_ws_id = self.workspace_id_from_event_name(ws_name);
+
+                    if let Some(ws_id) = event_ws_id.or(cached_ws_id) {
+                        self.monitor_workspaces
+                            .write()
+                            .insert(mon_name.to_string(), ws_id);
+
                         let mut snapshot = self.workspace_snapshot.write();
                         if !snapshot.active_workspace.contains(&ws_id)
                             || snapshot.active_workspace.len() != 1
                         {
                             snapshot.active_workspace.clear();
                             snapshot.active_workspace.insert(ws_id);
-                            // Also update per_output active workspace
-                            if let Some(per_output) = snapshot.per_output.get_mut(mon_name) {
-                                per_output.active_workspace.clear();
-                                per_output.active_workspace.insert(ws_id);
-                            }
+                            // Also update per_output active workspace.
+                            let per_output =
+                                snapshot.per_output.entry(mon_name.to_string()).or_default();
+                            per_output.active_workspace.clear();
+                            per_output.active_workspace.insert(ws_id);
                             workspace_changed = true;
                         }
+                    } else {
+                        workspace_changed = self.refresh_occupied();
                     }
                 }
             }
@@ -1063,6 +1084,7 @@ impl PartialEq for WindowInfo {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::HashSet;
 
     #[test]
     fn workspace_meta_from_ipc_merges_names_with_defaults() {
@@ -1096,7 +1118,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_meta_from_ipc_preserves_named_workspace_ids() {
+    fn workspace_meta_from_ipc_preserves_named_workspace_ids_without_display_index() {
         let ipc = vec![json!({
             "id": -1337,
             "name": "name:web",
@@ -1108,11 +1130,27 @@ mod tests {
         let web = workspaces.iter().find(|ws| ws.name == "web").unwrap();
 
         assert_eq!(web.id, -1337);
-        assert_eq!(web.idx, -1337);
+        assert_eq!(web.idx, -1);
         assert_eq!(
             HyprlandBackend::workspace_id_from_snapshot(&ipc[0]),
             Some(web.id)
         );
+    }
+
+    #[test]
+    fn workspace_meta_from_ipc_preserves_numbered_workspace_index() {
+        let ipc = vec![json!({
+            "id": 4,
+            "name": "Discord",
+            "windows": 1,
+            "monitor": "DP-1"
+        })];
+
+        let workspaces = HyprlandBackend::workspace_meta_from_ipc(&ipc);
+        let discord = workspaces.iter().find(|ws| ws.id == 4).unwrap();
+
+        assert_eq!(discord.name, "Discord");
+        assert_eq!(discord.idx, 4);
     }
 
     #[test]
@@ -1130,6 +1168,13 @@ mod tests {
 
         assert!(workspace_10_pos < first_named_pos);
         assert!(first_named_pos < second_named_pos);
+
+        let named_ids: Vec<_> = workspaces
+            .iter()
+            .filter(|ws| ws.id < 0)
+            .map(|ws| ws.id)
+            .collect();
+        assert_eq!(named_ids, vec![-1337, -1338]);
     }
 
     #[test]
@@ -1137,7 +1182,7 @@ mod tests {
         let backend = HyprlandBackend::new(None);
         *backend.workspaces.write() = vec![WorkspaceMeta {
             id: -1337,
-            idx: -1337,
+            idx: -1,
             name: "web".to_string(),
             output: None,
         }];
@@ -1151,7 +1196,7 @@ mod tests {
         let backend = HyprlandBackend::new(None);
         *backend.workspaces.write() = vec![WorkspaceMeta {
             id: -1337,
-            idx: -1337,
+            idx: -1,
             name: "web".to_string(),
             output: None,
         }];
@@ -1166,12 +1211,55 @@ mod tests {
         let backend = HyprlandBackend::new(None);
         *backend.workspaces.write() = vec![WorkspaceMeta {
             id: -1337,
-            idx: -1337,
+            idx: -1,
             name: "web".to_string(),
             output: None,
         }];
 
         assert!(backend.has_workspace_metadata(-1337));
         assert!(!backend.has_workspace_metadata(-1338));
+    }
+
+    #[test]
+    fn focusedmon_uses_event_workspace_name_when_cache_missing() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        backend.handle_event("focusedmon>>DP-1,web");
+
+        let snapshot = backend.workspace_snapshot.read();
+        assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
+        assert_eq!(
+            snapshot.per_output.get("DP-1").unwrap().active_workspace,
+            HashSet::from([-1337])
+        );
+        assert_eq!(*backend.focused_monitor.read(), Some("DP-1".to_string()));
+        assert_eq!(backend.monitor_workspaces.read().get("DP-1"), Some(&-1337));
+    }
+
+    #[test]
+    fn focusedmon_prefers_event_workspace_name_over_stale_cache() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1,
+            name: "web".to_string(),
+            output: None,
+        }];
+        backend
+            .monitor_workspaces
+            .write()
+            .insert("DP-1".to_string(), 1);
+
+        backend.handle_event("focusedmon>>DP-1,web");
+
+        let snapshot = backend.workspace_snapshot.read();
+        assert_eq!(snapshot.active_workspace, HashSet::from([-1337]));
+        assert_eq!(backend.monitor_workspaces.read().get("DP-1"), Some(&-1337));
     }
 }

--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -39,7 +39,7 @@ pub struct HyprlandBackend {
     event_socket_path: RwLock<Option<String>>,
     workspace_snapshot: RwLock<WorkspaceSnapshot>,
     focused_window: RwLock<Option<WindowInfo>>,
-    workspaces: RwLock<Vec<WorkspaceMeta>>,
+    workspaces: Arc<RwLock<Vec<WorkspaceMeta>>>,
     callbacks: Mutex<Option<(WorkspaceCallback, WindowCallback)>>,
     monitor_workspaces: RwLock<HashMap<String, i32>>,
     focused_monitor: RwLock<Option<String>>,
@@ -53,17 +53,6 @@ pub struct HyprlandBackend {
 
 impl HyprlandBackend {
     pub fn new(outputs: Option<Vec<String>>) -> Self {
-        // Pre-generate workspace metadata (Hyprland uses dynamic workspaces,
-        // but we expose 1-10 for consistent UI)
-        let workspaces: Vec<WorkspaceMeta> = (1..=DEFAULT_WORKSPACE_COUNT)
-            .map(|i| WorkspaceMeta {
-                id: i,
-                idx: i,
-                name: i.to_string(),
-                output: None, // Hyprland workspaces are global
-            })
-            .collect();
-
         Self {
             allowed_outputs: RwLock::new(outputs.unwrap_or_default()),
             running: Arc::new(AtomicBool::new(false)),
@@ -72,7 +61,7 @@ impl HyprlandBackend {
             event_socket_path: RwLock::new(None),
             workspace_snapshot: RwLock::new(WorkspaceSnapshot::default()),
             focused_window: RwLock::new(None),
-            workspaces: RwLock::new(workspaces),
+            workspaces: Arc::new(RwLock::new(Self::default_workspaces())),
             callbacks: Mutex::new(None),
             monitor_workspaces: RwLock::new(HashMap::new()),
             focused_monitor: RwLock::new(None),
@@ -168,6 +157,125 @@ impl HyprlandBackend {
         }
     }
 
+    fn default_workspaces() -> Vec<WorkspaceMeta> {
+        (1..=DEFAULT_WORKSPACE_COUNT)
+            .map(|i| WorkspaceMeta {
+                id: i,
+                idx: i,
+                name: i.to_string(),
+                output: None, // Hyprland workspaces are globally identified.
+            })
+            .collect()
+    }
+
+    fn workspace_identity(id: Option<i64>, raw_name: &str) -> Option<(i32, String)> {
+        if raw_name.starts_with("special:") {
+            return None;
+        }
+
+        if let Some(id) = id.and_then(|id| i32::try_from(id).ok())
+            && id != 0
+        {
+            // Hyprland IPC normally returns bare names (`web`). Accept the
+            // dispatcher form (`name:web`) defensively because callers use it
+            // when switching to named workspaces.
+            let name = if let Some(name) = raw_name.strip_prefix("name:")
+                && !name.is_empty()
+            {
+                name.to_string()
+            } else if raw_name.is_empty() {
+                id.to_string()
+            } else {
+                raw_name.to_string()
+            };
+            return Some((id, name));
+        }
+
+        None
+    }
+
+    fn workspace_identity_from_ipc(workspace: &Value) -> Option<(i32, String)> {
+        let raw_name = workspace.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let id = workspace.get("id").and_then(|v| v.as_i64());
+        Self::workspace_identity(id, raw_name)
+    }
+
+    fn workspace_meta_from_ipc(workspaces: &[Value]) -> Vec<WorkspaceMeta> {
+        let mut merged: HashMap<i32, WorkspaceMeta> = Self::default_workspaces()
+            .into_iter()
+            .map(|ws| (ws.id, ws))
+            .collect();
+
+        for ws in workspaces {
+            let Some((id, name)) = Self::workspace_identity_from_ipc(ws) else {
+                continue;
+            };
+            merged.insert(
+                id,
+                WorkspaceMeta {
+                    id,
+                    idx: id,
+                    name,
+                    output: None,
+                },
+            );
+        }
+
+        let mut workspaces: Vec<_> = merged.into_values().collect();
+        workspaces.sort_by(|a, b| match (a.id > 0, b.id > 0) {
+            (true, true) => a.idx.cmp(&b.idx),
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            // Hyprland assigns named workspace IDs downward from -1337; values
+            // closer to zero were created earlier and should appear first.
+            (false, false) => b.idx.cmp(&a.idx),
+        });
+        workspaces
+    }
+
+    fn update_workspace_metadata(&self, workspaces: &[Value]) -> bool {
+        let new_workspaces = Self::workspace_meta_from_ipc(workspaces);
+        let mut current = self.workspaces.write();
+        if *current == new_workspaces {
+            return false;
+        }
+        *current = new_workspaces;
+        true
+    }
+
+    fn workspace_id_from_snapshot(workspace: &Value) -> Option<i32> {
+        let raw_name = workspace.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let id = workspace.get("id").and_then(|v| v.as_i64());
+        Self::workspace_identity(id, raw_name).map(|(id, _)| id)
+    }
+
+    fn workspace_id_for_name(&self, name: &str) -> Option<i32> {
+        self.workspaces
+            .read()
+            .iter()
+            .find(|ws| ws.name == name)
+            .map(|ws| ws.id)
+    }
+
+    fn has_workspace_metadata(&self, workspace_id: i32) -> bool {
+        self.workspaces
+            .read()
+            .iter()
+            .any(|ws| ws.id == workspace_id)
+    }
+
+    fn workspace_switch_target(&self, workspace_id: i32) -> String {
+        if workspace_id < 0 {
+            let workspaces = self.workspaces.read();
+            if let Some(ws) = workspaces.iter().find(|ws| ws.id == workspace_id) {
+                return format!("name:{}", ws.name);
+            }
+            warn!("No Hyprland workspace found for named workspace id {workspace_id}");
+        }
+
+        workspace_id.to_string()
+    }
+
     /// Fetch monitor information from Hyprland.
     ///
     /// Updates `monitor_workspaces` with each monitor's active workspace,
@@ -185,15 +293,14 @@ impl HyprlandBackend {
                 let name = mon.get("name").and_then(|v| v.as_str());
                 let active_ws_id = mon
                     .get("activeWorkspace")
-                    .and_then(|ws| ws.get("id"))
-                    .and_then(|v| v.as_i64());
+                    .and_then(Self::workspace_id_from_snapshot);
                 let is_focused = mon
                     .get("focused")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
 
                 if let (Some(name), Some(ws_id)) = (name, active_ws_id) {
-                    monitor_ws.insert(name.to_string(), ws_id as i32);
+                    monitor_ws.insert(name.to_string(), ws_id);
                     if is_focused {
                         *focused_mon = Some(name.to_string());
                     }
@@ -219,6 +326,8 @@ impl HyprlandBackend {
         if let Some(workspaces) = self.query_json("workspaces")
             && let Some(workspaces) = workspaces.as_array()
         {
+            self.update_workspace_metadata(workspaces);
+
             let mut snapshot = self.workspace_snapshot.write();
             let monitor_ws = self.monitor_workspaces.read();
             let focused_mon = self.focused_monitor.read();
@@ -234,14 +343,11 @@ impl HyprlandBackend {
             }
 
             for ws in workspaces {
-                let id = ws.get("id").and_then(|v| v.as_i64());
+                let id = Self::workspace_id_from_snapshot(ws);
                 let windows = ws.get("windows").and_then(|v| v.as_i64());
                 let monitor = ws.get("monitor").and_then(|v| v.as_str());
 
-                if let (Some(id), Some(windows)) = (id, windows)
-                    && id > 0
-                {
-                    let id = id as i32;
+                if let (Some(id), Some(windows)) = (id, windows) {
                     let windows = windows as u32;
 
                     // Update global state
@@ -267,6 +373,7 @@ impl HyprlandBackend {
             if let Some(ref focused) = *focused_mon
                 && let Some(&active_ws) = monitor_ws.get(focused)
             {
+                snapshot.active_workspace.clear();
                 snapshot.active_workspace.insert(active_ws);
             }
         }
@@ -342,6 +449,8 @@ impl HyprlandBackend {
         if let Some(workspaces) = self.query_json("workspaces")
             && let Some(workspaces) = workspaces.as_array()
         {
+            let metadata_changed = self.update_workspace_metadata(workspaces);
+
             let mut snapshot = self.workspace_snapshot.write();
             let monitor_ws = self.monitor_workspaces.read();
             let focused_mon = self.focused_monitor.read();
@@ -349,6 +458,7 @@ impl HyprlandBackend {
             // Track previous state to detect changes
             let previous_active = snapshot.active_workspace.clone();
             let old_occupied = snapshot.occupied_workspaces.clone();
+            let old_per_output = snapshot.per_output.clone();
 
             snapshot.occupied_workspaces.clear();
             snapshot.window_counts.clear();
@@ -361,14 +471,11 @@ impl HyprlandBackend {
             }
 
             for ws in workspaces {
-                let id = ws.get("id").and_then(|v| v.as_i64());
+                let id = Self::workspace_id_from_snapshot(ws);
                 let windows = ws.get("windows").and_then(|v| v.as_i64());
                 let monitor = ws.get("monitor").and_then(|v| v.as_str());
 
-                if let (Some(id), Some(windows)) = (id, windows)
-                    && id > 0
-                {
-                    let id = id as i32;
+                if let (Some(id), Some(windows)) = (id, windows) {
                     let windows = windows as u32;
 
                     // Update global state
@@ -403,15 +510,21 @@ impl HyprlandBackend {
 
             let occupied_changed = snapshot.occupied_workspaces != old_occupied;
             let active_changed = snapshot.active_workspace != previous_active;
+            let per_output_changed = snapshot.per_output != old_per_output;
 
-            if occupied_changed || active_changed {
+            if metadata_changed || occupied_changed || active_changed || per_output_changed {
                 trace!(
-                    "refresh_occupied: occupied_changed={}, active_changed={} ({:?} -> {:?})",
-                    occupied_changed, active_changed, previous_active, snapshot.active_workspace
+                    "refresh_occupied: metadata_changed={}, occupied_changed={}, active_changed={} ({:?} -> {:?}), per_output_changed={}",
+                    metadata_changed,
+                    occupied_changed,
+                    active_changed,
+                    previous_active,
+                    snapshot.active_workspace,
+                    per_output_changed
                 );
             }
 
-            return occupied_changed || active_changed;
+            return metadata_changed || occupied_changed || active_changed || per_output_changed;
         }
         false
     }
@@ -482,9 +595,7 @@ impl HyprlandBackend {
                 .to_string();
             let workspace_id = active_window
                 .get("workspace")
-                .and_then(|ws| ws.get("id"))
-                .and_then(|v| v.as_i64())
-                .map(|id| id as i32);
+                .and_then(Self::workspace_id_from_snapshot);
             let output = active_window
                 .get("monitor")
                 .and_then(|v| v.as_str())
@@ -526,8 +637,16 @@ impl HyprlandBackend {
         match event {
             "workspace" => {
                 // workspace>>ID or workspace>>NAME
-                if let Ok(ws_id) = data.parse::<i32>() {
-                    workspace_changed = self.update_active_workspace(ws_id);
+                if let Some(ws_id) = data
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|id| i32::try_from(id).ok())
+                    .or_else(|| self.workspace_id_for_name(data))
+                {
+                    if !self.has_workspace_metadata(ws_id) {
+                        workspace_changed |= self.refresh_occupied();
+                    }
+                    workspace_changed |= self.update_active_workspace(ws_id);
                 } else {
                     // Named workspace - refetch state
                     debug!(
@@ -540,13 +659,21 @@ impl HyprlandBackend {
             }
             "workspacev2" => {
                 // workspacev2>>ID,NAME
-                if let Some(id_str) = data.split(',').next()
-                    && let Ok(ws_id) = id_str.parse::<i32>()
+                if let Some((id_str, name)) = data.split_once(',')
+                    && let Some(ws_id) = id_str
+                        .parse::<i64>()
+                        .ok()
+                        .and_then(|id| i32::try_from(id).ok())
+                        .or_else(|| self.workspace_id_for_name(name))
                 {
-                    workspace_changed = self.update_active_workspace(ws_id);
+                    if !self.has_workspace_metadata(ws_id) {
+                        workspace_changed |= self.refresh_occupied();
+                    }
+                    workspace_changed |= self.update_active_workspace(ws_id);
                 }
             }
-            "createworkspace" | "destroyworkspace" | "closewindow" | "movewindow" => {
+            "createworkspace" | "createworkspacev2" | "destroyworkspace" | "destroyworkspacev2"
+            | "renameworkspace" | "closewindow" | "movewindow" => {
                 workspace_changed = self.refresh_occupied();
             }
             "openwindow" => {
@@ -562,11 +689,10 @@ impl HyprlandBackend {
                         let addr = client.get("address").and_then(|v| v.as_str()).unwrap_or("");
                         if addr == data || addr == format!("0x{}", data) {
                             if let Some(ws) = client.get("workspace")
-                                && let Some(ws_id) = ws.get("id").and_then(|v| v.as_i64())
-                                && ws_id > 0
+                                && let Some(ws_id) = Self::workspace_id_from_snapshot(ws)
                             {
                                 let mut snapshot = self.workspace_snapshot.write();
-                                snapshot.urgent_workspaces.insert(ws_id as i32);
+                                snapshot.urgent_workspaces.insert(ws_id);
                                 workspace_changed = true;
                             }
                             break;
@@ -802,7 +928,8 @@ impl CompositorBackend for HyprlandBackend {
             .unwrap_or_else(|e| e.into_inner())
             .clone();
         let allowed_outputs = self.allowed_outputs.read().clone();
-        let workspaces = self.workspaces.read().clone();
+        // The manager-side backend uses this metadata for named workspace switching.
+        let workspaces = Arc::clone(&self.workspaces);
         let kb_callback = self
             .keyboard_layout_callback
             .lock()
@@ -824,7 +951,7 @@ impl CompositorBackend for HyprlandBackend {
             event_socket_path: RwLock::new(event_socket_path),
             workspace_snapshot: RwLock::new(WorkspaceSnapshot::default()),
             focused_window: RwLock::new(None),
-            workspaces: RwLock::new(workspaces),
+            workspaces,
             callbacks: Mutex::new(callbacks),
             monitor_workspaces: RwLock::new(HashMap::new()),
             focused_monitor: RwLock::new(None),
@@ -879,7 +1006,8 @@ impl CompositorBackend for HyprlandBackend {
     }
 
     fn switch_workspace(&self, workspace_id: i32) {
-        let _ = self.send_command(&format!("dispatch workspace {}", workspace_id));
+        let target = self.workspace_switch_target(workspace_id);
+        let _ = self.send_command(&format!("dispatch workspace {target}"));
     }
 
     fn quit_compositor(&self) {
@@ -928,5 +1056,122 @@ impl PartialEq for WindowInfo {
             && self.app_id == other.app_id
             && self.workspace_id == other.workspace_id
             && self.output == other.output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn workspace_meta_from_ipc_merges_names_with_defaults() {
+        let ipc = vec![
+            json!({ "id": 2, "name": "web", "windows": 1, "monitor": "DP-1" }),
+            json!({ "id": 11, "name": "chat", "windows": 0, "monitor": "HDMI-A-1" }),
+        ];
+
+        let workspaces = HyprlandBackend::workspace_meta_from_ipc(&ipc);
+
+        assert_eq!(workspaces.iter().find(|ws| ws.id == 1).unwrap().name, "1");
+        assert_eq!(workspaces.iter().find(|ws| ws.id == 2).unwrap().name, "web");
+        assert_eq!(
+            workspaces.iter().find(|ws| ws.id == 11).unwrap().name,
+            "chat"
+        );
+        assert!(workspaces.iter().all(|ws| ws.output.is_none()));
+    }
+
+    #[test]
+    fn workspace_meta_from_ipc_skips_special_workspaces() {
+        let ipc = vec![
+            json!({ "id": -99, "name": "special:magic" }),
+            json!({ "id": 4, "name": "" }),
+        ];
+
+        let workspaces = HyprlandBackend::workspace_meta_from_ipc(&ipc);
+
+        assert!(workspaces.iter().all(|ws| ws.name != "special:magic"));
+        assert_eq!(workspaces.iter().find(|ws| ws.id == 4).unwrap().name, "4");
+    }
+
+    #[test]
+    fn workspace_meta_from_ipc_preserves_named_workspace_ids() {
+        let ipc = vec![json!({
+            "id": -1337,
+            "name": "name:web",
+            "windows": 0,
+            "monitor": "DP-1"
+        })];
+
+        let workspaces = HyprlandBackend::workspace_meta_from_ipc(&ipc);
+        let web = workspaces.iter().find(|ws| ws.name == "web").unwrap();
+
+        assert_eq!(web.id, -1337);
+        assert_eq!(web.idx, -1337);
+        assert_eq!(
+            HyprlandBackend::workspace_id_from_snapshot(&ipc[0]),
+            Some(web.id)
+        );
+    }
+
+    #[test]
+    fn workspace_meta_from_ipc_sorts_numbered_before_named_by_id() {
+        let ipc = vec![
+            json!({ "id": -1337, "name": "name:web" }),
+            json!({ "id": 2, "name": "2" }),
+            json!({ "id": -1338, "name": "name:chat" }),
+        ];
+
+        let workspaces = HyprlandBackend::workspace_meta_from_ipc(&ipc);
+        let workspace_10_pos = workspaces.iter().position(|ws| ws.id == 10).unwrap();
+        let first_named_pos = workspaces.iter().position(|ws| ws.id == -1337).unwrap();
+        let second_named_pos = workspaces.iter().position(|ws| ws.id == -1338).unwrap();
+
+        assert!(workspace_10_pos < first_named_pos);
+        assert!(first_named_pos < second_named_pos);
+    }
+
+    #[test]
+    fn workspace_id_for_name_finds_named_workspace_id() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1337,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        assert_eq!(backend.workspace_id_for_name("web"), Some(-1337));
+        assert_eq!(backend.workspace_id_for_name("chat"), None);
+    }
+
+    #[test]
+    fn workspace_switch_target_formats_named_workspaces() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1337,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        assert_eq!(backend.workspace_switch_target(-1337), "name:web");
+        assert_eq!(backend.workspace_switch_target(3), "3");
+        assert_eq!(backend.workspace_switch_target(-9999), "-9999");
+    }
+
+    #[test]
+    fn has_workspace_metadata_checks_workspace_id() {
+        let backend = HyprlandBackend::new(None);
+        *backend.workspaces.write() = vec![WorkspaceMeta {
+            id: -1337,
+            idx: -1337,
+            name: "web".to_string(),
+            output: None,
+        }];
+
+        assert!(backend.has_workspace_metadata(-1337));
+        assert!(!backend.has_workspace_metadata(-1338));
     }
 }

--- a/crates/vibepanel/src/services/compositor/sway.rs
+++ b/crates/vibepanel/src/services/compositor/sway.rs
@@ -222,16 +222,22 @@ impl SwayBackend {
             return;
         };
 
-        let mut ws_list = shared.workspaces.write();
         let mut snapshot = shared.workspace_snapshot.write();
 
-        ws_list.clear();
         snapshot.active_workspace.clear();
         snapshot.occupied_workspaces.clear();
         snapshot.urgent_workspaces.clear();
         snapshot.window_counts.clear();
         snapshot.per_output.clear();
 
+        let ws_list = Self::workspace_meta_from_ipc(workspaces, &mut snapshot);
+        *shared.workspaces.write() = ws_list;
+    }
+
+    fn workspace_meta_from_ipc(
+        workspaces: &[Value],
+        snapshot: &mut WorkspaceSnapshot,
+    ) -> Vec<WorkspaceMeta> {
         let mut numbered: Vec<WorkspaceMeta> = Vec::new();
         let mut named: Vec<WorkspaceMeta> = Vec::new();
 
@@ -265,7 +271,7 @@ impl SwayBackend {
 
             let meta = WorkspaceMeta {
                 id: ws_id,
-                idx: 0, // Assigned below after sorting
+                idx: if num >= 0 { num } else { -1 },
                 name: if name.is_empty() {
                     num.to_string()
                 } else {
@@ -306,13 +312,11 @@ impl SwayBackend {
         numbered.sort_by_key(|ws| ws.id);
         named.sort_by(|a, b| a.name.cmp(&b.name));
 
+        let mut ws_list = Vec::with_capacity(numbered.len() + named.len());
         ws_list.extend(numbered);
         ws_list.extend(named);
 
-        // Assign 1-based positional index for display
-        for (i, ws) in ws_list.iter_mut().enumerate() {
-            ws.idx = (i + 1) as i32;
-        }
+        ws_list
     }
 
     /// Walk the tree to count windows per workspace and find the focused window.
@@ -947,5 +951,32 @@ impl CompositorBackend for SwayBackend {
 impl Drop for SwayBackend {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numbered_workspace_indexes_use_compositor_numbers_after_sorting() {
+        let workspaces = vec![
+            serde_json::json!({ "num": 10, "name": "10" }),
+            serde_json::json!({ "num": -1, "name": "web" }),
+            serde_json::json!({ "num": 0, "name": "0" }),
+            serde_json::json!({ "num": 1, "name": "1" }),
+        ];
+        let mut snapshot = WorkspaceSnapshot::default();
+
+        let ws_list = SwayBackend::workspace_meta_from_ipc(&workspaces, &mut snapshot);
+
+        assert_eq!(ws_list[0].id, 0);
+        assert_eq!(ws_list[0].idx, 0);
+        assert_eq!(ws_list[1].id, 1);
+        assert_eq!(ws_list[1].idx, 1);
+        assert_eq!(ws_list[2].id, 10);
+        assert_eq!(ws_list[2].idx, 10);
+        assert_eq!(ws_list[3].name, "web");
+        assert_eq!(ws_list[3].idx, -1);
     }
 }

--- a/crates/vibepanel/src/services/compositor/types.rs
+++ b/crates/vibepanel/src/services/compositor/types.rs
@@ -35,9 +35,12 @@ pub struct WorkspaceMeta {
     ///   assigned to named workspaces.
     /// - For MangoWC: same as `idx` (sequential 1-based tag index).
     pub id: i32,
-    /// Positional display index (1-based, per-output for Niri).
-    /// Used for display labels and ordering; not stable across workspace
-    /// destruction in compositors with dynamic workspaces (e.g. Niri).
+    /// Meaningful user-facing numeric index when one exists.
+    ///
+    /// Used for display labels and ordering. Negative values signal that the
+    /// workspace has no meaningful numeric index (for example, Hyprland named
+    /// workspaces). Widgets should treat `idx < 0` as unavailable and fall back
+    /// to `name`.
     pub idx: i32,
     /// Display name for the workspace.
     pub name: String,

--- a/crates/vibepanel/src/services/compositor/types.rs
+++ b/crates/vibepanel/src/services/compositor/types.rs
@@ -31,7 +31,9 @@ use std::sync::Arc;
 pub struct WorkspaceMeta {
     /// Stable unique identifier.
     /// - For Niri: the compositor's internal workspace ID (u64 cast to i32).
-    /// - For Hyprland/MangoWC: same as `idx` (sequential 1-based index).
+    /// - For Hyprland: the compositor's workspace ID, including negative IDs
+    ///   assigned to named workspaces.
+    /// - For MangoWC: same as `idx` (sequential 1-based tag index).
     pub id: i32,
     /// Positional display index (1-based, per-output for Niri).
     /// Used for display labels and ordering; not stable across workspace
@@ -50,7 +52,7 @@ pub struct WorkspaceMeta {
 /// This contains workspace state specific to a single output/monitor,
 /// used for compositors where workspace state varies per-output (like
 /// MangoWC's per-output window counts, or Niri's per-monitor workspaces).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PerOutputState {
     /// Active workspace IDs on this output.
     /// Most compositors have a single active workspace, but MangoWC/DWL
@@ -66,7 +68,7 @@ pub struct PerOutputState {
 ///
 /// This represents the current state across all workspaces,
 /// updated atomically when the compositor signals changes.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WorkspaceSnapshot {
     /// Currently active/focused workspace IDs.
     /// Most compositors have a single active workspace, but MangoWC/DWL
@@ -344,6 +346,20 @@ mod tests {
         assert!(!state.active_workspace.contains(&1));
         assert!(!state.active_workspace.contains(&3));
         assert_eq!(state.active_workspace.len(), 1);
+    }
+
+    #[test]
+    fn test_per_output_state_equality_tracks_output_changes() {
+        let mut first = PerOutputState::default();
+        first.active_workspace.insert(1);
+        first.occupied_workspaces.insert(1);
+        first.window_counts.insert(1, 2);
+
+        let mut second = first.clone();
+        assert_eq!(first, second);
+
+        second.window_counts.insert(1, 1);
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/vibepanel/src/services/workspace.rs
+++ b/crates/vibepanel/src/services/workspace.rs
@@ -21,8 +21,10 @@ use super::compositor::{CompositorManager, WorkspaceMeta, WorkspaceSnapshot};
 pub struct Workspace {
     /// Stable unique workspace ID (for identity, switching, and HashMap keys).
     pub id: i32,
-    /// Positional display index (1-based, per-output for Niri).
-    /// Used for display labels, ordering, and tooltip text.
+    /// Meaningful user-facing numeric index when one exists.
+    ///
+    /// Negative values mean no meaningful index exists; widgets should then
+    /// fall back to `name`.
     pub idx: i32,
     /// Display name for the workspace.
     pub name: String,

--- a/crates/vibepanel/src/widgets/workspaces.rs
+++ b/crates/vibepanel/src/widgets/workspaces.rs
@@ -6,10 +6,14 @@
 //! # Configuration
 //!
 //! - `label_type`: `"none"` (minimal dots, default), `"icons"` (●/○/◆ glyphs),
-//!   or `"numbers"` (workspace names).
+//!   or `"text"` (workspace names; legacy alias: `"numbers"`).
 //! - `separator`: string between indicators (non-minimal modes only).
 //! - `animate`: `true` (default) enables the `WorkspaceContainer` custom widget
 //!   for smooth transitions; `false` uses a plain GtkBox with no animation.
+//! - `filter_by_output`: `true` (default) uses this bar output's per-output
+//!   workspace state; `false` shows global/all-output workspace state, including
+//!   each output's current workspace. In all-output mode, active styling still
+//!   follows the compositor's globally focused workspace.
 //!
 //! # Architecture
 //!
@@ -709,8 +713,11 @@ fn compute_left_count(n: usize, active_idx: Option<usize>) -> usize {
 pub enum LabelType {
     /// Show icon glyphs (●, ○, ◆).
     Icons,
-    /// Show workspace numbers/names.
-    Numbers,
+    /// Show workspace labels/names.
+    ///
+    /// Historically configured as `label_type = "numbers"`; `"text"` is the
+    /// preferred value for new configs.
+    Text,
     /// Minimal - no text, just CSS styling.
     None,
 }
@@ -718,7 +725,7 @@ pub enum LabelType {
 impl LabelType {
     fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
-            "numbers" => LabelType::Numbers,
+            "text" | "numbers" => LabelType::Text,
             "none" => LabelType::None,
             _ => LabelType::Icons,
         }
@@ -760,11 +767,22 @@ pub struct WorkspacesConfig {
     /// Whether to animate circle↔pill transitions.
     /// `None` = not explicitly set by user (inherits from global `theme.animations`).
     pub animate: Option<bool>,
+    /// Whether to use this bar output's per-output workspace state.
+    ///
+    /// When `true`, active styling reflects the workspace active on this bar's
+    /// output. When `false`, the widget shows global/all-output workspace state,
+    /// including each output's current workspace, but active styling still
+    /// reflects the compositor's globally focused workspace.
+    pub filter_by_output: bool,
 }
 
 impl WidgetConfig for WorkspacesConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("workspaces", entry, &["label_type", "separator", "animate"]);
+        warn_unknown_options(
+            "workspaces",
+            entry,
+            &["label_type", "separator", "animate", "filter_by_output"],
+        );
 
         let label_type = entry
             .options
@@ -781,11 +799,18 @@ impl WidgetConfig for WorkspacesConfig {
             .to_string();
 
         let animate = entry.options.get("animate").and_then(|v| v.as_bool());
+        let defaults = Self::default();
+        let filter_by_output = entry
+            .options
+            .get("filter_by_output")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.filter_by_output);
 
         Self {
             label_type,
             separator,
             animate,
+            filter_by_output,
         }
     }
 }
@@ -796,6 +821,7 @@ impl Default for WorkspacesConfig {
             label_type: DEFAULT_LABEL_TYPE,
             separator: DEFAULT_SEPARATOR.to_string(),
             animate: None,
+            filter_by_output: true,
         }
     }
 }
@@ -817,11 +843,12 @@ impl WorkspacesWidget {
     /// * `output_id` - Optional output/monitor name. When set, the widget will:
     ///   - For Niri: only show workspaces belonging to this output.
     ///   - For MangoWC: show all workspaces but with per-output window counts.
-    ///   - For Hyprland: ignored (global workspace view).
+    ///   - For Hyprland: show workspaces associated with this output when available.
     pub fn new(config: WorkspacesConfig, output_id: Option<String>) -> Self {
         let base = BaseWidget::new(&[widget::WORKSPACES]);
 
         let label_type = config.label_type;
+        let filter_by_output = config.filter_by_output;
         // Per-widget animate flag takes precedence when explicitly set.
         // Falls back to the global theme.animations setting.
         let animate = config
@@ -863,7 +890,11 @@ impl WorkspacesWidget {
                 label_type,
                 &separator,
                 snapshot,
-                output_id.as_deref(),
+                if filter_by_output {
+                    output_id.as_deref()
+                } else {
+                    None
+                },
             );
         });
 
@@ -945,7 +976,7 @@ fn create_single_indicator(label_type: LabelType, workspace: &Workspace) -> Widg
     } else {
         let label_text = match label_type {
             LabelType::Icons => ICON_EMPTY,
-            LabelType::Numbers => &workspace.name,
+            LabelType::Text => &workspace.name,
             LabelType::None => unreachable!(),
         };
         let label = Label::new(Some(label_text));
@@ -1159,12 +1190,45 @@ fn classify_change(
     }
 }
 
+fn collect_display_ids(
+    workspaces: &[Workspace],
+    active_workspaces: &HashSet<i32>,
+    snapshot: &WorkspaceServiceSnapshot,
+    include_all_output_active: bool,
+) -> HashSet<i32> {
+    let mut display_ids: HashSet<i32> = workspaces
+        .iter()
+        .filter(|ws| ws.occupied)
+        .map(|ws| ws.id)
+        .collect();
+
+    // Include active workspaces (supports multi-tag view).
+    display_ids.extend(active_workspaces.iter());
+
+    if include_all_output_active {
+        // In all-output mode, show each output's current workspace even when it
+        // is empty. Styling still uses `active_workspaces`, so only the
+        // compositor's globally focused workspace gets the active class.
+        for per_output in snapshot.per_output.values() {
+            display_ids.extend(per_output.active_workspace.iter());
+        }
+    }
+
+    display_ids
+}
+
 /// Update workspace indicators based on the current snapshot.
 ///
-/// When `output_id` is provided:
+/// When `output_id` is provided (i.e. `filter_by_output = true`):
 /// - Uses per-output workspace data if available.
 /// - For Niri: only shows workspaces belonging to this output.
 /// - For MangoWC: shows all workspaces with per-output window counts.
+/// - For Hyprland: shows workspaces currently associated with this output.
+///
+/// When `output_id` is not provided (i.e. `filter_by_output = false`), uses
+/// global/all-output workspace data and also displays each output's current
+/// workspace. Active styling still follows the compositor's globally focused
+/// workspace.
 #[allow(clippy::too_many_arguments)]
 fn update_indicators(
     container: &GtkBox,
@@ -1208,20 +1272,13 @@ fn update_indicators(
         source, output_id, active_workspaces
     );
 
-    // Display occupied + active workspaces.
-    let mut display_ids: std::collections::HashSet<i32> = workspaces
-        .iter()
-        .filter(|ws| ws.occupied)
-        .map(|ws| ws.id)
-        .collect();
+    let display_ids =
+        collect_display_ids(workspaces, active_workspaces, snapshot, output_id.is_none());
 
     trace!(
         "workspace widget: occupied_ids={:?}, adding active={:?}",
         display_ids, active_workspaces
     );
-
-    // Include active workspaces (supports multi-tag view).
-    display_ids.extend(active_workspaces.iter());
 
     let display_workspaces: Vec<_> = workspaces
         .iter()
@@ -1455,7 +1512,7 @@ fn update_indicators(
             }
         }
 
-        // Update icon text (Icons/Numbers mode only).
+        // Update icon/text label (Icons/Text mode only).
         // The indicator is an Overlay wrapping the inner label.
         if let Some(label) = (label_type != LabelType::None)
             .then(|| {
@@ -1476,7 +1533,7 @@ fn update_indicators(
                         label.set_text(ICON_EMPTY);
                     }
                 }
-                LabelType::Numbers => {
+                LabelType::Text => {
                     label.set_text(&workspace.name);
                     let now_long = workspace.name.len() > 2;
                     let was_long = indicator.has_css_class(widget::WORKSPACE_INDICATOR_LONG);
@@ -1624,7 +1681,8 @@ fn build_tooltip(workspace: &Workspace) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use crate::services::workspace::PerOutputWorkspaces;
+    use std::collections::{HashMap, HashSet};
     use toml::Value;
 
     fn make_widget_entry(name: &str, options: HashMap<String, Value>) -> WidgetEntry {
@@ -1640,6 +1698,7 @@ mod tests {
         let config = WorkspacesConfig::from_entry(&entry);
         assert_eq!(config.label_type, LabelType::None);
         assert_eq!(config.separator, "");
+        assert!(config.filter_by_output);
     }
 
     #[test]
@@ -1652,8 +1711,17 @@ mod tests {
         options.insert("separator".to_string(), Value::String("|".to_string()));
         let entry = make_widget_entry("workspaces", options);
         let config = WorkspacesConfig::from_entry(&entry);
-        assert_eq!(config.label_type, LabelType::Numbers);
+        assert_eq!(config.label_type, LabelType::Text);
         assert_eq!(config.separator, "|");
+    }
+
+    #[test]
+    fn test_workspace_config_text_alias() {
+        let mut options = HashMap::new();
+        options.insert("label_type".to_string(), Value::String("text".to_string()));
+        let entry = make_widget_entry("workspaces", options);
+        let config = WorkspacesConfig::from_entry(&entry);
+        assert_eq!(config.label_type, LabelType::Text);
     }
 
     #[test]
@@ -1669,7 +1737,8 @@ mod tests {
     fn test_label_type_from_str() {
         assert_eq!(LabelType::from_str("icons"), LabelType::Icons);
         assert_eq!(LabelType::from_str("ICONS"), LabelType::Icons);
-        assert_eq!(LabelType::from_str("numbers"), LabelType::Numbers);
+        assert_eq!(LabelType::from_str("text"), LabelType::Text);
+        assert_eq!(LabelType::from_str("numbers"), LabelType::Text);
         assert_eq!(LabelType::from_str("none"), LabelType::None);
         assert_eq!(LabelType::from_str("unknown"), LabelType::Icons); // default
     }
@@ -1688,6 +1757,55 @@ mod tests {
         let entry = make_widget_entry("workspaces", options);
         let config = WorkspacesConfig::from_entry(&entry);
         assert_eq!(config.animate, Some(false));
+    }
+
+    #[test]
+    fn test_workspace_config_filter_by_output_disabled() {
+        let mut options = HashMap::new();
+        options.insert("filter_by_output".to_string(), Value::Boolean(false));
+        let entry = make_widget_entry("workspaces", options);
+        let config = WorkspacesConfig::from_entry(&entry);
+        assert!(!config.filter_by_output);
+    }
+
+    #[test]
+    fn test_global_display_includes_each_outputs_current_workspace() {
+        let active_workspaces = HashSet::from([2]);
+        let workspaces = vec![
+            make_workspace(2, "2", true, false, false, None),
+            make_workspace(4, "4", false, true, false, Some(1)),
+            make_workspace(8, "8", false, false, false, None),
+        ];
+        let snapshot = WorkspaceServiceSnapshot {
+            active_workspace: active_workspaces.clone(),
+            occupied_workspaces: HashSet::from([4]),
+            window_counts: HashMap::from([(4, 1)]),
+            workspaces: workspaces.clone(),
+            per_output: HashMap::from([
+                (
+                    "eDP-1".to_string(),
+                    PerOutputWorkspaces {
+                        active_workspace: HashSet::from([2]),
+                        workspaces: vec![],
+                    },
+                ),
+                (
+                    "HDMI-A-1".to_string(),
+                    PerOutputWorkspaces {
+                        active_workspace: HashSet::from([8]),
+                        workspaces: vec![],
+                    },
+                ),
+            ]),
+        };
+
+        let display_ids = collect_display_ids(&workspaces, &active_workspaces, &snapshot, true);
+
+        assert!(display_ids.contains(&2));
+        assert!(display_ids.contains(&4));
+        assert!(display_ids.contains(&8));
+        assert_eq!(active_workspaces, HashSet::from([2]));
+        assert!(!workspaces.iter().find(|ws| ws.id == 8).unwrap().active);
     }
 
     // -- compute_left_count tests --

--- a/crates/vibepanel/src/widgets/workspaces.rs
+++ b/crates/vibepanel/src/widgets/workspaces.rs
@@ -840,7 +840,8 @@ impl WorkspacesWidget {
     /// # Arguments
     ///
     /// * `config` - Widget configuration (label type, separator).
-    /// * `output_id` - Optional output/monitor name. When set, the widget will:
+    /// * `output_id` - Optional output/monitor name. When set and
+    ///   `filter_by_output = true`, the widget will:
     ///   - For Niri: only show workspaces belonging to this output.
     ///   - For MangoWC: show all workspaces but with per-output window counts.
     ///   - For Hyprland: show workspaces associated with this output when available.
@@ -1652,9 +1653,12 @@ fn update_indicators(
 fn build_tooltip(workspace: &Workspace) -> String {
     let mut parts = Vec::new();
 
-    // Niri can have custom workspace names separate from the index.
+    // Negative IDs are synthetic/named workspaces (Sway/Hyprland); their IDs
+    // are implementation details, so show the name without an index prefix.
     let idx_str = workspace.idx.to_string();
-    if workspace.name != idx_str {
+    if workspace.id < 0 {
+        parts.push(format!("Workspace {}", workspace.name));
+    } else if workspace.name != idx_str {
         parts.push(format!("Workspace {}: {}", workspace.idx, workspace.name));
     } else {
         parts.push(format!("Workspace {}", workspace.name));
@@ -1917,6 +1921,12 @@ mod tests {
             build_tooltip(&ws),
             "Workspace 1: browser • Active • 5 windows"
         );
+    }
+
+    #[test]
+    fn test_build_tooltip_named_workspace_hides_negative_id() {
+        let ws = make_workspace(-1337, "web", true, true, false, Some(2));
+        assert_eq!(build_tooltip(&ws), "Workspace web • Active • 2 windows");
     }
 
     // -- classify_change tests --

--- a/crates/vibepanel/src/widgets/workspaces.rs
+++ b/crates/vibepanel/src/widgets/workspaces.rs
@@ -6,7 +6,8 @@
 //! # Configuration
 //!
 //! - `label_type`: `"none"` (minimal dots, default), `"icons"` (●/○/◆ glyphs),
-//!   or `"text"` (workspace names; legacy alias: `"numbers"`).
+//!   `"name"` (workspace names; legacy alias: `"numbers"`), or `"index"`
+//!   (meaningful numeric index, falling back to name when none exists).
 //! - `separator`: string between indicators (non-minimal modes only).
 //! - `animate`: `true` (default) enables the `WorkspaceContainer` custom widget
 //!   for smooth transitions; `false` uses a plain GtkBox with no animation.
@@ -110,7 +111,7 @@ use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use gtk4::{Align, Box as GtkBox, CssProvider, GestureClick, Label, Overlay, Widget};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
@@ -715,9 +716,12 @@ pub enum LabelType {
     Icons,
     /// Show workspace labels/names.
     ///
-    /// Historically configured as `label_type = "numbers"`; `"text"` is the
+    /// Historically configured as `label_type = "numbers"`; `"name"` is the
     /// preferred value for new configs.
-    Text,
+    Name,
+    /// Show a meaningful workspace index when available, otherwise the
+    /// workspace name (e.g. for Hyprland named workspaces).
+    Index,
     /// Minimal - no text, just CSS styling.
     None,
 }
@@ -725,10 +729,33 @@ pub enum LabelType {
 impl LabelType {
     fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
-            "text" | "numbers" => LabelType::Text,
+            "icons" => LabelType::Icons,
+            "name" | "numbers" => LabelType::Name,
+            "index" => LabelType::Index,
             "none" => LabelType::None,
-            _ => LabelType::Icons,
+            other => {
+                warn!(
+                    "unknown workspace label_type {:?}, falling back to {:?}",
+                    other, DEFAULT_LABEL_TYPE
+                );
+                DEFAULT_LABEL_TYPE
+            }
         }
+    }
+}
+
+fn workspace_label_text(label_type: LabelType, workspace: &Workspace) -> String {
+    match label_type {
+        LabelType::Icons => ICON_EMPTY.to_string(),
+        LabelType::Name => workspace.name.clone(),
+        LabelType::Index => {
+            if workspace.idx >= 0 {
+                workspace.idx.to_string()
+            } else {
+                workspace.name.clone()
+            }
+        }
+        LabelType::None => String::new(),
     }
 }
 
@@ -859,7 +886,8 @@ impl WorkspacesWidget {
     ///   `filter_by_output = true`, the widget will:
     ///   - For Niri: only show workspaces belonging to this output.
     ///   - For MangoWC: show all workspaces but with per-output window counts.
-    ///   - For Hyprland: show workspaces associated with this output when available.
+    ///   - For Hyprland: show the workspace currently active on this output,
+    ///     plus workspaces reported with windows on this output.
     pub fn new(config: WorkspacesConfig, output_id: Option<String>) -> Self {
         let base = BaseWidget::new(&[widget::WORKSPACES]);
 
@@ -992,19 +1020,15 @@ fn create_single_indicator(label_type: LabelType, workspace: &Workspace) -> Widg
         let (o, rh) = wrap_with_ripple(&dot);
         (o, rh, false)
     } else {
-        let label_text = match label_type {
-            LabelType::Icons => ICON_EMPTY,
-            LabelType::Text => &workspace.name,
-            LabelType::None => unreachable!(),
-        };
-        let label = Label::new(Some(label_text));
+        let label_text = workspace_label_text(label_type, workspace);
+        let label = Label::new(Some(&label_text));
         // Optical centering: glyphs ●/○/◆ appear left-heavy at 0.5;
         // 0.55 nudges them to look visually centered in the pill.
         label.set_xalign(0.55);
         label.set_ellipsize(EllipsizeMode::End);
         label.set_single_line_mode(true);
         let (o, rh) = wrap_with_ripple(&label);
-        (o, rh, label_text.len() > 2)
+        (o, rh, label_text.chars().count() > 2)
     };
 
     // Sizing, state, and visual classes go on the overlay — it is the
@@ -1217,6 +1241,8 @@ fn collect_display_ids(
 ) -> HashSet<i32> {
     let mut display_ids: HashSet<i32> = workspaces
         .iter()
+        // `window_count.is_some()` filters out synthetic placeholders and only
+        // includes empty workspaces explicitly reported by the compositor.
         .filter(|ws| ws.occupied || (show_unoccupied && ws.window_count.is_some()))
         .map(|ws| ws.id)
         .collect();
@@ -1242,7 +1268,8 @@ fn collect_display_ids(
 /// - Uses per-output workspace data if available.
 /// - For Niri: only shows workspaces belonging to this output.
 /// - For MangoWC: shows all workspaces with per-output window counts.
-/// - For Hyprland: shows workspaces currently associated with this output.
+/// - For Hyprland: shows the workspace currently active on this output,
+///   plus workspaces reported with windows on this output.
 ///
 /// When `output_id` is not provided (i.e. `filter_by_output = false`), uses
 /// global/all-output workspace data and also displays each output's current
@@ -1537,7 +1564,7 @@ fn update_indicators(
             }
         }
 
-        // Update icon/text label (Icons/Text mode only).
+        // Update icon/name/index label.
         // The indicator is an Overlay wrapping the inner label.
         if let Some(label) = (label_type != LabelType::None)
             .then(|| {
@@ -1558,9 +1585,10 @@ fn update_indicators(
                         label.set_text(ICON_EMPTY);
                     }
                 }
-                LabelType::Text => {
-                    label.set_text(&workspace.name);
-                    let now_long = workspace.name.len() > 2;
+                LabelType::Name | LabelType::Index => {
+                    let label_text = workspace_label_text(label_type, workspace);
+                    label.set_text(&label_text);
+                    let now_long = label_text.chars().count() > 2;
                     let was_long = indicator.has_css_class(widget::WORKSPACE_INDICATOR_LONG);
                     if now_long != was_long {
                         if now_long {
@@ -1740,17 +1768,26 @@ mod tests {
         options.insert("separator".to_string(), Value::String("|".to_string()));
         let entry = make_widget_entry("workspaces", options);
         let config = WorkspacesConfig::from_entry(&entry);
-        assert_eq!(config.label_type, LabelType::Text);
+        assert_eq!(config.label_type, LabelType::Name);
         assert_eq!(config.separator, "|");
     }
 
     #[test]
-    fn test_workspace_config_text_alias() {
+    fn test_workspace_config_name() {
         let mut options = HashMap::new();
-        options.insert("label_type".to_string(), Value::String("text".to_string()));
+        options.insert("label_type".to_string(), Value::String("name".to_string()));
         let entry = make_widget_entry("workspaces", options);
         let config = WorkspacesConfig::from_entry(&entry);
-        assert_eq!(config.label_type, LabelType::Text);
+        assert_eq!(config.label_type, LabelType::Name);
+    }
+
+    #[test]
+    fn test_workspace_config_index() {
+        let mut options = HashMap::new();
+        options.insert("label_type".to_string(), Value::String("index".to_string()));
+        let entry = make_widget_entry("workspaces", options);
+        let config = WorkspacesConfig::from_entry(&entry);
+        assert_eq!(config.label_type, LabelType::Index);
     }
 
     #[test]
@@ -1766,10 +1803,33 @@ mod tests {
     fn test_label_type_from_str() {
         assert_eq!(LabelType::from_str("icons"), LabelType::Icons);
         assert_eq!(LabelType::from_str("ICONS"), LabelType::Icons);
-        assert_eq!(LabelType::from_str("text"), LabelType::Text);
-        assert_eq!(LabelType::from_str("numbers"), LabelType::Text);
+        assert_eq!(LabelType::from_str("name"), LabelType::Name);
+        assert_eq!(LabelType::from_str("numbers"), LabelType::Name);
+        assert_eq!(LabelType::from_str("index"), LabelType::Index);
         assert_eq!(LabelType::from_str("none"), LabelType::None);
-        assert_eq!(LabelType::from_str("unknown"), LabelType::Icons); // default
+        assert_eq!(LabelType::from_str("unknown"), DEFAULT_LABEL_TYPE);
+    }
+
+    #[test]
+    fn test_workspace_label_text_name_and_index() {
+        let named = make_workspace(4, "Discord", false, true, false, Some(1));
+        assert_eq!(workspace_label_text(LabelType::Name, &named), "Discord");
+        assert_eq!(workspace_label_text(LabelType::Index, &named), "4");
+
+        let named_without_index = make_workspace(0, "web", false, false, false, Some(0));
+        assert_eq!(
+            workspace_label_text(LabelType::Index, &named_without_index),
+            "0"
+        );
+
+        let named_without_index = Workspace {
+            idx: -1,
+            ..named_without_index
+        };
+        assert_eq!(
+            workspace_label_text(LabelType::Index, &named_without_index),
+            "web"
+        );
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/workspaces.rs
+++ b/crates/vibepanel/src/widgets/workspaces.rs
@@ -774,6 +774,8 @@ pub struct WorkspacesConfig {
     /// including each output's current workspace, but active styling still
     /// reflects the compositor's globally focused workspace.
     pub filter_by_output: bool,
+    /// Whether to show compositor-reported workspaces without windows.
+    pub show_unoccupied: bool,
 }
 
 impl WidgetConfig for WorkspacesConfig {
@@ -781,7 +783,13 @@ impl WidgetConfig for WorkspacesConfig {
         warn_unknown_options(
             "workspaces",
             entry,
-            &["label_type", "separator", "animate", "filter_by_output"],
+            &[
+                "label_type",
+                "separator",
+                "animate",
+                "filter_by_output",
+                "show_unoccupied",
+            ],
         );
 
         let label_type = entry
@@ -805,12 +813,18 @@ impl WidgetConfig for WorkspacesConfig {
             .get("filter_by_output")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.filter_by_output);
+        let show_unoccupied = entry
+            .options
+            .get("show_unoccupied")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.show_unoccupied);
 
         Self {
             label_type,
             separator,
             animate,
             filter_by_output,
+            show_unoccupied,
         }
     }
 }
@@ -822,6 +836,7 @@ impl Default for WorkspacesConfig {
             separator: DEFAULT_SEPARATOR.to_string(),
             animate: None,
             filter_by_output: true,
+            show_unoccupied: false,
         }
     }
 }
@@ -850,6 +865,7 @@ impl WorkspacesWidget {
 
         let label_type = config.label_type;
         let filter_by_output = config.filter_by_output;
+        let show_unoccupied = config.show_unoccupied;
         // Per-widget animate flag takes precedence when explicitly set.
         // Falls back to the global theme.animations setting.
         let animate = config
@@ -891,6 +907,7 @@ impl WorkspacesWidget {
                 label_type,
                 &separator,
                 snapshot,
+                show_unoccupied,
                 if filter_by_output {
                     output_id.as_deref()
                 } else {
@@ -1195,11 +1212,12 @@ fn collect_display_ids(
     workspaces: &[Workspace],
     active_workspaces: &HashSet<i32>,
     snapshot: &WorkspaceServiceSnapshot,
+    show_unoccupied: bool,
     include_all_output_active: bool,
 ) -> HashSet<i32> {
     let mut display_ids: HashSet<i32> = workspaces
         .iter()
-        .filter(|ws| ws.occupied)
+        .filter(|ws| ws.occupied || (show_unoccupied && ws.window_count.is_some()))
         .map(|ws| ws.id)
         .collect();
 
@@ -1239,6 +1257,7 @@ fn update_indicators(
     label_type: LabelType,
     separator: &str,
     snapshot: &WorkspaceServiceSnapshot,
+    show_unoccupied: bool,
     output_id: Option<&str>,
 ) {
     let (workspaces, active_workspaces, source): (&[Workspace], &HashSet<i32>, &str) = if let Some(
@@ -1273,8 +1292,13 @@ fn update_indicators(
         source, output_id, active_workspaces
     );
 
-    let display_ids =
-        collect_display_ids(workspaces, active_workspaces, snapshot, output_id.is_none());
+    let display_ids = collect_display_ids(
+        workspaces,
+        active_workspaces,
+        snapshot,
+        show_unoccupied,
+        output_id.is_none(),
+    );
 
     trace!(
         "workspace widget: occupied_ids={:?}, adding active={:?}",
@@ -1703,6 +1727,7 @@ mod tests {
         assert_eq!(config.label_type, LabelType::None);
         assert_eq!(config.separator, "");
         assert!(config.filter_by_output);
+        assert!(!config.show_unoccupied);
     }
 
     #[test]
@@ -1773,6 +1798,15 @@ mod tests {
     }
 
     #[test]
+    fn test_workspace_config_show_unoccupied_enabled() {
+        let mut options = HashMap::new();
+        options.insert("show_unoccupied".to_string(), Value::Boolean(true));
+        let entry = make_widget_entry("workspaces", options);
+        let config = WorkspacesConfig::from_entry(&entry);
+        assert!(config.show_unoccupied);
+    }
+
+    #[test]
     fn test_global_display_includes_each_outputs_current_workspace() {
         let active_workspaces = HashSet::from([2]);
         let workspaces = vec![
@@ -1803,13 +1837,41 @@ mod tests {
             ]),
         };
 
-        let display_ids = collect_display_ids(&workspaces, &active_workspaces, &snapshot, true);
+        let display_ids =
+            collect_display_ids(&workspaces, &active_workspaces, &snapshot, false, true);
 
         assert!(display_ids.contains(&2));
         assert!(display_ids.contains(&4));
         assert!(display_ids.contains(&8));
         assert_eq!(active_workspaces, HashSet::from([2]));
         assert!(!workspaces.iter().find(|ws| ws.id == 8).unwrap().active);
+    }
+
+    #[test]
+    fn test_show_unoccupied_includes_reported_empty_workspaces() {
+        let active_workspaces = HashSet::from([1]);
+        let workspaces = vec![
+            make_workspace(1, "1", true, false, false, Some(0)),
+            make_workspace(2, "2", false, true, false, Some(1)),
+            make_workspace(3, "3", false, false, false, Some(0)),
+            make_workspace(4, "4", false, false, false, None),
+        ];
+        let snapshot = WorkspaceServiceSnapshot {
+            active_workspace: active_workspaces.clone(),
+            occupied_workspaces: HashSet::from([2]),
+            window_counts: HashMap::from([(1, 0), (2, 1), (3, 0)]),
+            workspaces: workspaces.clone(),
+            per_output: HashMap::new(),
+        };
+
+        let default_ids =
+            collect_display_ids(&workspaces, &active_workspaces, &snapshot, false, false);
+        assert_eq!(default_ids, HashSet::from([1, 2]));
+
+        let show_unoccupied_ids =
+            collect_display_ids(&workspaces, &active_workspaces, &snapshot, true, false);
+        assert_eq!(show_unoccupied_ids, HashSet::from([1, 2, 3]));
+        assert!(!show_unoccupied_ids.contains(&4));
     }
 
     // -- compute_left_count tests --

--- a/crates/vibepanel/src/widgets/workspaces.rs
+++ b/crates/vibepanel/src/widgets/workspaces.rs
@@ -1705,10 +1705,10 @@ fn update_indicators(
 fn build_tooltip(workspace: &Workspace) -> String {
     let mut parts = Vec::new();
 
-    // Negative IDs are synthetic/named workspaces (Sway/Hyprland); their IDs
-    // are implementation details, so show the name without an index prefix.
+    // Negative indexes mean the compositor has no meaningful numeric label, so
+    // show the name without an index prefix.
     let idx_str = workspace.idx.to_string();
-    if workspace.id < 0 {
+    if workspace.idx < 0 {
         parts.push(format!("Workspace {}", workspace.name));
     } else if workspace.name != idx_str {
         parts.push(format!("Workspace {}: {}", workspace.idx, workspace.name));


### PR DESCRIPTION
  Adds support for Hyprland named workspaces and adds `filter_by_output` and `show_unoccupied` options for the workspaces widget. Also renames `label_type = "numbers"` to `"name"` and introduces a new `"index"` value (`"numbers"` is kept as an alias for backwards compatibility).

  `filter_by_output` mirrors the option of the same name on the taskbar widget and defaults to `true` (current behavior, per-output workspaces). When set to `false` the widget shows the global workspace list.

  `show_unoccupied` shows workspaces reported by the compositor that don't necessarily have windows on them.

  `label_type = "index"` prefers the compositor's numeric workspace index when one exists, falling back to the workspace name (useful with Hyprland named workspaces, which have negative IDs).

  Closes #109