### PR TITLE
feat(osd): add optional value

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,6 +86,7 @@ weight = 400       # Material icon stroke weight (100-700)
 [osd]
 enabled = true
 position = "bottom" # "bottom", "top", "left", "right"
+show_value = false  # Show current value after the bar
 
 [advanced]
 # compositor = "auto"  # "auto", "hyprland", "niri", "mango"

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -502,8 +502,8 @@ impl Config {
 
         lines.push("\nOSD:".to_string());
         lines.push(format!(
-            "  enabled: {}, position: {}, timeout: {}ms",
-            self.osd.enabled, self.osd.position, self.osd.timeout_ms
+            "  enabled: {}, position: {}, timeout: {}ms, show_value: {}",
+            self.osd.enabled, self.osd.position, self.osd.timeout_ms, self.osd.show_value
         ));
 
         lines.join("\n")
@@ -1236,6 +1236,9 @@ pub struct OsdConfig {
     /// OSD position: "bottom", "left", "right".
     pub position: String,
 
+    /// Whether to show the current value as text next to the bar.
+    pub show_value: bool,
+
     /// How long the OSD stays visible (milliseconds).
     pub timeout_ms: u32,
 }
@@ -1245,6 +1248,7 @@ impl Default for OsdConfig {
         Self {
             enabled: true,
             position: "bottom".to_string(),
+            show_value: false,
             timeout_ms: 1500,
         }
     }

--- a/crates/vibepanel-core/tests/config_integration.rs
+++ b/crates/vibepanel-core/tests/config_integration.rs
@@ -247,12 +247,14 @@ fn test_validation_accepts_valid_enum_values() {
         
         [osd]
         position = "bottom"
+        show_value = true
         
         [widgets]
         center = ["clock"]
     "#;
 
     let config: Config = toml::from_str(toml).unwrap();
+    assert!(config.osd.show_value, "OSD show_value should parse");
     config
         .validate()
         .expect("Valid config should pass validation");

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -906,6 +906,9 @@ pub mod osd {
     /// OSD slider (`.osd-slider`).
     pub const SLIDER: &str = "osd-slider";
 
+    /// OSD value label (`.osd-value`).
+    pub const VALUE: &str = "osd-value";
+
     /// Unavailable state content (`.osd-unavailable`).
     pub const UNAVAILABLE: &str = "osd-unavailable";
 

--- a/crates/vibepanel/src/widgets/css/osd.rs
+++ b/crates/vibepanel/src/widgets/css/osd.rs
@@ -45,6 +45,23 @@ pub fn css() -> &'static str {
     box-shadow: none;
 }
 
+.osd-value {
+    font-size: var(--font-size-base);
+    min-width: 2em;
+}
+
+.osd-horizontal .osd-value {
+    padding-top: 2px;
+}
+
+.osd-vertical .osd-value {
+    margin-top: 6px;
+}
+
+.osd-vertical .osd-icon {
+    margin-bottom: 4px;
+}
+
 /* OSD unavailable state - colors via vp-muted */
 .osd-unavailable-icon {
     color: var(--color-foreground-disabled);

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -26,7 +26,7 @@ use vibepanel_core::config::OsdConfig;
 
 use crate::services::audio::AudioSnapshot;
 use crate::services::brightness::BrightnessSnapshot;
-use crate::services::icons::IconsService;
+use crate::services::icons::{IconHandle, IconsService};
 use crate::services::ipc::IpcMessage;
 use crate::services::surfaces::SurfaceStyleManager;
 
@@ -55,7 +55,9 @@ pub struct OsdWidget {
     root: GtkBox,
     /// Normal content: icon + slider in a row
     normal_content: GtkBox,
+    icon_handle: IconHandle,
     scale: Scale,
+    value_label: Label,
     /// Unavailable content: big icon + message centered
     unavailable_content: GtkBox,
     unavailable_icon: Image,
@@ -63,7 +65,7 @@ pub struct OsdWidget {
 }
 
 impl OsdWidget {
-    pub fn new(orientation: Orientation, icon_size: i32) -> Self {
+    pub fn new(orientation: Orientation, icon_size: i32, show_value: bool) -> Self {
         let root = GtkBox::new(Orientation::Vertical, 0);
         root.add_css_class(osd::WIDGET);
 
@@ -71,12 +73,12 @@ impl OsdWidget {
         let normal_content = GtkBox::new(orientation, 4);
         normal_content.add_css_class(osd::NORMAL);
 
-        let icon_image = Image::from_icon_name("audio-volume-medium-symbolic");
-        icon_image.set_pixel_size(icon_size);
-        icon_image.add_css_class(osd::ICON);
-        icon_image.set_valign(Align::Center);
-        icon_image.set_halign(Align::Center);
-        normal_content.append(&icon_image);
+        let icon_handle =
+            IconsService::global().create_icon("audio-volume-medium-symbolic", &[osd::ICON]);
+        let icon_widget = icon_handle.widget();
+        icon_widget.set_size_request(icon_size, icon_size);
+        icon_widget.set_valign(Align::Center);
+        icon_widget.set_halign(Align::Center);
 
         // Slider (display only)
         let scale = Scale::with_range(orientation, 0.0, 100.0, 1.0);
@@ -94,7 +96,23 @@ impl OsdWidget {
             scale.set_inverted(true);
         }
 
-        normal_content.append(&scale);
+        let value_label = Label::new(Some("0"));
+        value_label.add_css_class(osd::VALUE);
+        value_label.set_valign(Align::Center);
+        value_label.set_halign(Align::Center);
+        value_label.set_visible(show_value);
+
+        // Vertical: value on top, icon on bottom. Horizontal: icon left, value right.
+        if orientation == Orientation::Vertical {
+            normal_content.append(&value_label);
+            normal_content.append(&scale);
+            normal_content.append(&icon_widget);
+        } else {
+            normal_content.append(&icon_widget);
+            normal_content.append(&scale);
+            normal_content.append(&value_label);
+        }
+
         root.append(&normal_content);
 
         // === Unavailable content: centered icon + label ===
@@ -120,7 +138,9 @@ impl OsdWidget {
         Self {
             root,
             normal_content,
+            icon_handle,
             scale,
+            value_label,
             unavailable_content,
             unavailable_icon,
             unavailable_label,
@@ -134,6 +154,7 @@ impl OsdWidget {
     pub fn set_value(&self, value: u32) {
         let v = value.clamp(0, 100) as f64;
         self.scale.set_value(v);
+        self.value_label.set_text(&(v as u32).to_string());
         // Show normal content, hide unavailable
         self.normal_content.set_visible(true);
         self.unavailable_content.set_visible(false);
@@ -150,15 +171,7 @@ impl OsdWidget {
     }
 
     pub fn set_icon(&self, icon_name: &str) {
-        // Try IconsService first (for theme integration).
-        let icons = IconsService::global();
-        let handle = icons.create_icon(icon_name, &[osd::ICON]);
-        // The icon handle sets size via CSS or internally, just use it
-        // Replace first child of normal_content with themed icon
-        if let Some(first_child) = self.normal_content.first_child() {
-            self.normal_content.remove(&first_child);
-        }
-        self.normal_content.prepend(&handle.widget());
+        self.icon_handle.set_icon(icon_name);
     }
 }
 
@@ -235,7 +248,7 @@ impl OsdOverlay {
         );
 
         // Child OSD widget.
-        let osd_widget = OsdWidget::new(orientation, 24);
+        let osd_widget = OsdWidget::new(orientation, 24, osd_config.show_value);
         container.append(osd_widget.widget());
         window.set_child(Some(&container));
 


### PR DESCRIPTION
Adds `osd.show_value`config option(default false) that displays the current numeric value next to the bar in the OSD, as well as some minor visual adjustments in the the OSD.

New CSS class to target the value label: `.osd-value`

Closes #111 

<img width="452" height="105" alt="image" src="https://github.com/user-attachments/assets/18761be0-1f54-46fe-b845-ce77b77b9883" />
