### PR TITLE
fix(notifications): various bug fixes for notifcations

### DIFF
--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -97,6 +97,9 @@ pub struct Notification {
     pub image_path: Option<String>,
     /// Optional raw image data hint (e.g. freedesktop image-data)
     pub image_data: Option<NotificationImage>,
+    /// Whether the notification is transient: skip popover history and persistence,
+    /// only fire the toast.
+    pub transient: bool,
 }
 
 /// Raw image data for a notification, parsed from the
@@ -145,6 +148,7 @@ impl From<PersistedNotification> for Notification {
             desktop_entry: p.desktop_entry,
             image_path: p.image_path,
             image_data: None, // Binary data is not persisted
+            transient: false, // Transient notifications are never persisted
         }
     }
 }
@@ -521,6 +525,7 @@ impl NotificationService {
         let mut desktop_entry: Option<String> = None;
         let mut image_path: Option<String> = None;
         let mut image_data: Option<NotificationImage> = None;
+        let mut transient = false;
         for j in 0..hints_variant.n_children() {
             let entry = hints_variant.child_value(j);
             if entry.n_children() >= 2
@@ -575,6 +580,18 @@ impl NotificationService {
                             });
                         }
                     }
+                    "transient" => {
+                        // Spec allows boolean or numeric (any non-zero) values.
+                        if let Some(v) = actual_value.get::<bool>() {
+                            transient = v;
+                        } else if let Some(v) = actual_value.get::<u8>() {
+                            transient = v != 0;
+                        } else if let Some(v) = actual_value.get::<i32>() {
+                            transient = v != 0;
+                        } else if let Some(v) = actual_value.get::<u32>() {
+                            transient = v != 0;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -616,6 +633,7 @@ impl NotificationService {
             desktop_entry,
             image_path,
             image_data,
+            transient,
         };
 
         debug!(
@@ -766,10 +784,13 @@ impl NotificationService {
         // Load existing state to preserve VPN state
         let mut persisted = state::load();
 
-        // Update notification state
+        // Update notification state. Transient notifications bypass persistence.
         let notifications = self.notifications.borrow();
-        let mut history: Vec<PersistedNotification> =
-            notifications.values().map(|n| n.to_persisted()).collect();
+        let mut history: Vec<PersistedNotification> = notifications
+            .values()
+            .filter(|n| !n.transient)
+            .map(|n| n.to_persisted())
+            .collect();
 
         // Sort by timestamp descending (most recent first)
         history.sort_by(|a, b| {

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -243,11 +243,6 @@ impl NotificationService {
         self.backend_available.get()
     }
 
-    /// Get the number of active notifications.
-    pub fn count(&self) -> usize {
-        self.notifications.borrow().len()
-    }
-
     /// Check if notifications are muted (toasts suppressed).
     pub fn is_muted(&self) -> bool {
         self.muted.get()
@@ -272,6 +267,28 @@ impl NotificationService {
     /// Get all notifications as a list.
     pub fn notifications(&self) -> Vec<Notification> {
         self.notifications.borrow().values().cloned().collect()
+    }
+
+    /// Get history-facing notifications (excludes transients).
+    ///
+    /// Transients are toast-only per the freedesktop spec and must not appear in
+    /// the popover, the badge count, or any other persistent UI surface.
+    pub fn history_notifications(&self) -> Vec<Notification> {
+        self.notifications
+            .borrow()
+            .values()
+            .filter(|n| !n.transient)
+            .cloned()
+            .collect()
+    }
+
+    /// Count of history-facing notifications (excludes transients).
+    pub fn history_count(&self) -> usize {
+        self.notifications
+            .borrow()
+            .values()
+            .filter(|n| !n.transient)
+            .count()
     }
 
     /// Get a notification by ID.

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -5,7 +5,7 @@
 //! via the standard callback mechanism.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use gtk4::gio::{self, prelude::*};
@@ -175,9 +175,6 @@ pub struct NotificationService {
     callbacks: RefCell<Vec<NotificationCallback>>,
     /// Whether the service is ready
     ready: Cell<bool>,
-
-    /// IDs of notifications restored from persistence (should not trigger toasts)
-    restored_ids: RefCell<HashSet<u32>>,
 }
 
 impl NotificationService {
@@ -188,11 +185,9 @@ impl NotificationService {
 
         // Restore notifications from persisted state
         let mut notifications = HashMap::new();
-        let mut restored_ids = HashSet::new();
         let mut max_id: u32 = 0;
         for pn in &notification_state.history {
             max_id = max_id.max(pn.id);
-            restored_ids.insert(pn.id);
             notifications.insert(pn.id, Notification::from(pn.clone()));
         }
 
@@ -215,7 +210,6 @@ impl NotificationService {
             muted: Cell::new(notification_state.muted),
             callbacks: RefCell::new(Vec::new()),
             ready: Cell::new(false),
-            restored_ids: RefCell::new(restored_ids),
         });
 
         Self::init_dbus(&service);
@@ -283,14 +277,6 @@ impl NotificationService {
     /// Get a notification by ID.
     pub fn get(&self, id: u32) -> Option<Notification> {
         self.notifications.borrow().get(&id).cloned()
-    }
-
-    /// Get IDs of notifications that were restored from persistence.
-    ///
-    /// These notifications should not trigger toast popups since they were
-    /// already seen in a previous session.
-    pub fn restored_ids(&self) -> HashSet<u32> {
-        self.restored_ids.borrow().clone()
     }
 
     /// Close a notification by ID (user dismissed).

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -269,10 +269,7 @@ impl NotificationService {
         self.notifications.borrow().values().cloned().collect()
     }
 
-    /// Get history-facing notifications (excludes transients).
-    ///
-    /// Transients are toast-only per the freedesktop spec and must not appear in
-    /// the popover, the badge count, or any other persistent UI surface.
+    /// Notifications excluding transients (which are toast-only per spec).
     pub fn history_notifications(&self) -> Vec<Notification> {
         self.notifications
             .borrow()
@@ -282,7 +279,6 @@ impl NotificationService {
             .collect()
     }
 
-    /// Count of history-facing notifications (excludes transients).
     pub fn history_count(&self) -> usize {
         self.notifications
             .borrow()
@@ -664,12 +660,8 @@ impl NotificationService {
         // Return the notification ID
         invocation.return_value(Some(&(id,).to_variant()));
 
-        // Muted transients have nowhere to go: the popover never shows them and
-        // no toast is created to call back, so without this they would linger in
-        // the in-memory map forever, inflating counts and consuming a slot in
-        // the eviction limit. The ID is still returned to the caller (spec
-        // compliance) and a NotificationClosed signal is emitted via
-        // close_internal so well-behaved clients learn the notification is gone.
+        // Muted transients never get a toast and never appear in the popover,
+        // so without this they'd linger in the map until evicted.
         if is_transient && self.is_muted() {
             self.close_internal(id, CLOSE_REASON_DISMISSED);
         }
@@ -712,12 +704,8 @@ impl NotificationService {
         self.notify_listeners();
     }
 
-    /// Enforce the maximum notification limit by removing old notifications.
-    ///
-    /// Only history (non-transient) notifications count toward the limit and
-    /// are eligible for eviction. Transients are toast-only ephemera; they
-    /// must not push real history out, nor be evicted themselves (their
-    /// lifetime is owned by the toast manager).
+    /// Trim oldest history once the cap is exceeded. Transients are owned by
+    /// the toast manager — they don't count toward the cap and aren't evicted.
     fn enforce_notification_limit(&self) {
         let mut notifications = self.notifications.borrow_mut();
 
@@ -831,5 +819,177 @@ impl NotificationService {
 impl Drop for NotificationService {
     fn drop(&mut self) {
         debug!("NotificationService dropped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Redirect XDG_STATE_HOME to a per-process tempdir so save_state writes
+    /// don't clobber the developer's real notification state.
+    fn redirect_state_home() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let tmp =
+                std::env::temp_dir().join(format!("vibepanel-notif-test-{}", std::process::id()));
+            // SAFETY: This runs exactly once before any test reads the env var,
+            // and the redirect is harmless to any other test in this binary -
+            // they'll just see a clean per-process state file location.
+            unsafe {
+                std::env::set_var("XDG_STATE_HOME", &tmp);
+            }
+        });
+    }
+
+    fn make_service() -> Rc<NotificationService> {
+        redirect_state_home();
+        Rc::new(NotificationService {
+            bus: RefCell::new(None),
+            registration_id: RefCell::new(None),
+            notifications: RefCell::new(HashMap::new()),
+            next_id: Cell::new(1),
+            backend_available: Cell::new(false),
+            muted: Cell::new(false),
+            callbacks: RefCell::new(Vec::new()),
+            ready: Cell::new(false),
+        })
+    }
+
+    fn make_notification(id: u32, transient: bool, timestamp: f64) -> Notification {
+        Notification {
+            id,
+            app_name: "test".to_string(),
+            app_icon: String::new(),
+            summary: String::new(),
+            body: String::new(),
+            actions: Vec::new(),
+            urgency: URGENCY_NORMAL,
+            timestamp,
+            expire_timeout: -1,
+            desktop_entry: None,
+            image_path: None,
+            image_data: None,
+            transient,
+        }
+    }
+
+    /// Mirror of the post-insert tail in handle_notify, which we can't call
+    /// directly because it consumes D-Bus types.
+    fn simulate_handle_notify(svc: &NotificationService, n: Notification) {
+        let id = n.id;
+        let is_transient = n.transient;
+        svc.notifications.borrow_mut().insert(id, n);
+        svc.enforce_notification_limit();
+        svc.save_state();
+        svc.notify_listeners();
+        if is_transient && svc.is_muted() {
+            svc.close_internal(id, CLOSE_REASON_DISMISSED);
+        }
+    }
+
+    #[test]
+    fn muted_transient_is_dropped_from_map() {
+        let svc = make_service();
+        svc.muted.set(true);
+
+        simulate_handle_notify(&svc, make_notification(1, true, 1.0));
+
+        assert!(
+            !svc.notifications.borrow().contains_key(&1),
+            "muted transient should not linger in the map"
+        );
+    }
+
+    #[test]
+    fn unmuted_transient_remains_until_toast_lifecycle_ends() {
+        let svc = make_service();
+        // muted = false (default)
+
+        simulate_handle_notify(&svc, make_notification(1, true, 1.0));
+
+        assert!(
+            svc.notifications.borrow().contains_key(&1),
+            "unmuted transient must stay in the map - the toast manager closes it on dismiss/timeout"
+        );
+    }
+
+    #[test]
+    fn muted_non_transient_remains_in_map() {
+        let svc = make_service();
+        svc.muted.set(true);
+
+        simulate_handle_notify(&svc, make_notification(1, false, 1.0));
+
+        assert!(
+            svc.notifications.borrow().contains_key(&1),
+            "muted non-transients are stored as history (only toasts are suppressed)"
+        );
+    }
+
+    #[test]
+    fn enforce_limit_excludes_transients_from_count() {
+        let svc = make_service();
+        // Fill exactly to the cap with history, then add transients on top.
+        for i in 0..(MAX_NOTIFICATIONS as u32) {
+            svc.notifications
+                .borrow_mut()
+                .insert(i + 1, make_notification(i + 1, false, i as f64));
+        }
+        for i in 0..50u32 {
+            let id = MAX_NOTIFICATIONS as u32 + 100 + i;
+            svc.notifications
+                .borrow_mut()
+                .insert(id, make_notification(id, true, (1000 + i) as f64));
+        }
+
+        svc.enforce_notification_limit();
+
+        assert_eq!(
+            svc.notifications.borrow().len(),
+            MAX_NOTIFICATIONS + 50,
+            "transients should not trigger eviction even when total > cap"
+        );
+    }
+
+    #[test]
+    fn enforce_limit_evicts_oldest_history_only() {
+        let svc = make_service();
+        // 102 history (timestamps 0..102) + 5 transients with very old timestamps.
+        for i in 0..102u32 {
+            svc.notifications
+                .borrow_mut()
+                .insert(i + 1, make_notification(i + 1, false, i as f64));
+        }
+        for i in 0..5u32 {
+            let id = 1000 + i;
+            // Older than any history - would be first evicted if transients counted.
+            svc.notifications
+                .borrow_mut()
+                .insert(id, make_notification(id, true, -100.0 - i as f64));
+        }
+
+        svc.enforce_notification_limit();
+
+        let map = svc.notifications.borrow();
+        // History over the cap (ids 1, 2 = oldest two) should be evicted.
+        assert!(
+            !map.contains_key(&1),
+            "oldest history (id=1) should be evicted"
+        );
+        assert!(
+            !map.contains_key(&2),
+            "second-oldest history (id=2) should be evicted"
+        );
+        assert!(map.contains_key(&3), "third-oldest history must survive");
+        // All transients survive despite older timestamps.
+        for i in 0..5u32 {
+            assert!(
+                map.contains_key(&(1000 + i)),
+                "transient id={} must not be evicted",
+                1000 + i
+            );
+        }
     }
 }

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -713,21 +713,27 @@ impl NotificationService {
     }
 
     /// Enforce the maximum notification limit by removing old notifications.
+    ///
+    /// Only history (non-transient) notifications count toward the limit and
+    /// are eligible for eviction. Transients are toast-only ephemera; they
+    /// must not push real history out, nor be evicted themselves (their
+    /// lifetime is owned by the toast manager).
     fn enforce_notification_limit(&self) {
         let mut notifications = self.notifications.borrow_mut();
-        if notifications.len() <= MAX_NOTIFICATIONS {
+
+        let history_count = notifications.values().filter(|n| !n.transient).count();
+        if history_count <= MAX_NOTIFICATIONS {
             return;
         }
 
-        // Collect (id, timestamp) pairs and sort by timestamp ascending (oldest first)
         let mut by_time: Vec<(u32, f64)> = notifications
             .iter()
+            .filter(|(_, n)| !n.transient)
             .map(|(id, n)| (*id, n.timestamp))
             .collect();
         by_time.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-        // Remove oldest notifications until we're at the limit
-        let to_remove = notifications.len() - MAX_NOTIFICATIONS;
+        let to_remove = history_count - MAX_NOTIFICATIONS;
         for (id, _) in by_time.into_iter().take(to_remove) {
             notifications.remove(&id);
             debug!(

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -648,6 +648,8 @@ impl NotificationService {
             notification.urgency
         );
 
+        let is_transient = notification.transient;
+
         self.notifications.borrow_mut().insert(id, notification);
 
         // Enforce notification limit to prevent unbounded memory growth.
@@ -661,6 +663,16 @@ impl NotificationService {
 
         // Return the notification ID
         invocation.return_value(Some(&(id,).to_variant()));
+
+        // Muted transients have nowhere to go: the popover never shows them and
+        // no toast is created to call back, so without this they would linger in
+        // the in-memory map forever, inflating counts and consuming a slot in
+        // the eviction limit. The ID is still returned to the caller (spec
+        // compliance) and a NotificationClosed signal is emitted via
+        // close_internal so well-behaved clients learn the notification is gone.
+        if is_transient && self.is_muted() {
+            self.close_internal(id, CLOSE_REASON_DISMISSED);
+        }
     }
 
     fn handle_close_notification(&self, params: &Variant, invocation: gio::DBusMethodInvocation) {

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -68,7 +68,7 @@ struct NotificationsWidgetInner {
 
 impl NotificationsWidgetInner {
     fn on_service_update(&self, service: &NotificationService) {
-        let count = service.count();
+        let count = service.history_count();
         debug!(
             "NotificationsWidget: on_service_update called, count={}",
             count
@@ -87,9 +87,9 @@ impl NotificationsWidgetInner {
             self.badge.set_visible(false);
         }
 
-        // Check for critical notifications
+        // Check for critical notifications among history (transients are toast-only)
         let has_critical = service
-            .notifications()
+            .history_notifications()
             .iter()
             .any(|n| n.urgency == URGENCY_CRITICAL);
 
@@ -140,9 +140,10 @@ impl NotificationsWidgetInner {
         // Only rebuild the popover when the notification list changed;
         // mute-only updates are handled in-place by the popover button.
         // Compare (id, timestamp) so a replaces_id update (same id, newer ts)
-        // is also treated as a content change.
+        // is also treated as a content change. Transients are excluded since
+        // the popover never shows them.
         let mut current_ids: Vec<(u32, f64)> = service
-            .notifications()
+            .history_notifications()
             .iter()
             .map(|n| (n.id, n.timestamp))
             .collect();
@@ -181,11 +182,11 @@ impl NotificationsWidgetInner {
             "NotificationsWidget: calculate_unread_count - active_toast_ids={:?}, last_seen={}, notifications_count={}",
             active_toast_ids,
             last_seen,
-            service.notifications().len()
+            service.history_count()
         );
 
         service
-            .notifications()
+            .history_notifications()
             .iter()
             .filter(|n| {
                 // Skip if currently shown as toast

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -16,7 +16,7 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{Align, Application, Box as GtkBox, Orientation, Overlay, Widget};
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
@@ -49,7 +49,10 @@ struct NotificationsWidgetInner {
     icon_handle: IconHandle,
     badge: Widget,
     container: GtkBox,
-    known_ids: RefCell<HashSet<u32>>,
+    /// Last-seen notification ids mapped to their timestamp. A bump in timestamp
+    /// for an existing id means the notification was replaced via replaces_id and
+    /// the toast should be re-shown with the new content.
+    known_ids: RefCell<HashMap<u32, f64>>,
     toast_manager: RefCell<Option<Rc<NotificationToastManager>>>,
     last_seen_timestamp: Cell<f64>,
     app: RefCell<Option<Application>>,
@@ -208,26 +211,42 @@ impl NotificationsWidgetInner {
             return;
         }
 
+        // Snapshot current id -> timestamp so we can detect both new notifications
+        // and replacements (same id, newer timestamp via replaces_id).
+        let current: HashMap<u32, f64> = service
+            .notifications()
+            .iter()
+            .map(|n| (n.id, n.timestamp))
+            .collect();
+
         // Don't show toasts when muted
         if service.is_muted() {
             // Still update known IDs so we don't show stale toasts when unmuted
-            let current_ids: HashSet<u32> = service.notifications().iter().map(|n| n.id).collect();
-            *self.known_ids.borrow_mut() = current_ids;
+            *self.known_ids.borrow_mut() = current;
             return;
         }
 
-        let current_ids: HashSet<u32> = service.notifications().iter().map(|n| n.id).collect();
-        let known_ids = self.known_ids.borrow().clone();
+        let known = self.known_ids.borrow().clone();
 
-        let new_ids: HashSet<u32> = current_ids.difference(&known_ids).cloned().collect();
+        // Identify ids to (re)toast: brand-new ids, plus replacements where the
+        // timestamp has advanced since we last toasted.
+        let to_toast: Vec<u32> = current
+            .iter()
+            .filter(|(id, ts)| match known.get(id) {
+                None => true,
+                Some(prev_ts) => *ts > prev_ts,
+            })
+            .map(|(id, _)| *id)
+            .collect();
+
         // Note: We intentionally do NOT close toasts when notifications are removed.
         // Some apps (like Telegram) send a notification and then immediately close it,
         // expecting the notification daemon to still show it briefly. If we closed the
         // toast here, users would never see the notification.
         // Toasts will close naturally via their timeout or user dismissal.
 
-        // Show toasts for new notifications
-        if !new_ids.is_empty() {
+        // Show toasts for new and replaced notifications
+        if !to_toast.is_empty() {
             // Try to get the application from the widget's root window
             let app = self.get_application();
 
@@ -236,7 +255,7 @@ impl NotificationsWidgetInner {
             // proper initialization with callbacks.
 
             if let (Some(toast_manager), Some(app)) = (&*self.toast_manager.borrow(), app) {
-                for id in &new_ids {
+                for id in &to_toast {
                     if let Some(notification) = service.get(*id) {
                         toast_manager.show(&app, &notification);
                     }
@@ -244,8 +263,8 @@ impl NotificationsWidgetInner {
             }
         }
 
-        // Update known IDs
-        *self.known_ids.borrow_mut() = current_ids;
+        // Update known IDs (with current timestamps)
+        *self.known_ids.borrow_mut() = current;
     }
 
     /// Get the GTK Application from the widget's root window.
@@ -317,7 +336,7 @@ impl NotificationsWidget {
             icon_handle,
             badge: badge.upcast(),
             container: base.widget().clone(),
-            known_ids: RefCell::new(HashSet::new()),
+            known_ids: RefCell::new(HashMap::new()),
             toast_manager: RefCell::new(None),
             last_seen_timestamp: Cell::new(0.0),
             app: RefCell::new(None),
@@ -369,8 +388,16 @@ impl NotificationsWidget {
     fn bind_service(&self) {
         let service = NotificationService::global();
 
-        // Initialize known_ids with restored notifications so they don't trigger toasts
-        *self.inner.known_ids.borrow_mut() = service.restored_ids();
+        // Initialize known_ids with restored notifications so they don't trigger toasts.
+        // We seed with their persisted timestamps so any later update (e.g. via
+        // replaces_id) is detected as a replacement.
+        let restored = service.restored_ids();
+        *self.inner.known_ids.borrow_mut() = service
+            .notifications()
+            .iter()
+            .filter(|n| restored.contains(&n.id))
+            .map(|n| (n.id, n.timestamp))
+            .collect();
 
         // Clone inner Rc for the callback - this is safe because Rc handles
         // the reference counting properly

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -57,8 +57,10 @@ struct NotificationsWidgetInner {
     last_seen_timestamp: Cell<f64>,
     app: RefCell<Option<Application>>,
     menu_handle: RefCell<Option<Rc<MenuHandle>>>,
-    /// Last known notification IDs; used to skip popover rebuilds on mute-only changes.
-    last_notif_ids: RefCell<Vec<u32>>,
+    /// Last known (id, timestamp) snapshot. Used to skip popover rebuilds on
+    /// mute-only changes while still detecting replacements (same id, newer
+    /// timestamp via replaces_id) as a content change.
+    last_notif_ids: RefCell<Vec<(u32, f64)>>,
     /// When set, the popover dismiss handler already removed the row in-place,
     /// so `on_service_update` should skip `refresh_if_visible`.
     suppress_rebuild: Rc<Cell<bool>>,
@@ -137,8 +139,14 @@ impl NotificationsWidgetInner {
 
         // Only rebuild the popover when the notification list changed;
         // mute-only updates are handled in-place by the popover button.
-        let mut current_ids: Vec<u32> = service.notifications().iter().map(|n| n.id).collect();
-        current_ids.sort_unstable();
+        // Compare (id, timestamp) so a replaces_id update (same id, newer ts)
+        // is also treated as a content change.
+        let mut current_ids: Vec<(u32, f64)> = service
+            .notifications()
+            .iter()
+            .map(|n| (n.id, n.timestamp))
+            .collect();
+        current_ids.sort_unstable_by_key(|a| a.0);
         let list_changed = *self.last_notif_ids.borrow() != current_ids;
         *self.last_notif_ids.borrow_mut() = current_ids;
 

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -396,14 +396,13 @@ impl NotificationsWidget {
     fn bind_service(&self) {
         let service = NotificationService::global();
 
-        // Initialize known_ids with restored notifications so they don't trigger toasts.
-        // We seed with their persisted timestamps so any later update (e.g. via
-        // replaces_id) is detected as a replacement.
-        let restored = service.restored_ids();
+        // Seed known_ids with whatever the service has at bind time (the
+        // persistence-restored set, since DBus deliveries can't run before this
+        // point). The persisted timestamps let later updates via replaces_id be
+        // detected as replacements.
         *self.inner.known_ids.borrow_mut() = service
             .notifications()
             .iter()
-            .filter(|n| restored.contains(&n.id))
             .map(|n| (n.id, n.timestamp))
             .collect();
 

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -87,7 +87,6 @@ impl NotificationsWidgetInner {
             self.badge.set_visible(false);
         }
 
-        // Check for critical notifications among history (transients are toast-only)
         let has_critical = service
             .history_notifications()
             .iter()
@@ -137,11 +136,9 @@ impl NotificationsWidgetInner {
             }
         }
 
-        // Only rebuild the popover when the notification list changed;
-        // mute-only updates are handled in-place by the popover button.
-        // Compare (id, timestamp) so a replaces_id update (same id, newer ts)
-        // is also treated as a content change. Transients are excluded since
-        // the popover never shows them.
+        // Only rebuild the popover when the notification list changed; mute-only
+        // updates are handled in-place by the popover button. Compare (id, ts)
+        // so a replaces_id update (same id, newer ts) is also a content change.
         let mut current_ids: Vec<(u32, f64)> = service
             .history_notifications()
             .iter()

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -4,6 +4,8 @@
 //! notifications_toast.rs and notifications_popover.rs.
 
 use gtk4::Image;
+use gtk4::gdk;
+use gtk4::gdk_pixbuf::Pixbuf;
 
 use crate::services::icons::get_app_icon_name;
 use crate::services::notification::{Notification, NotificationImage};
@@ -238,6 +240,23 @@ fn try_parse_tag(s: &str) -> Option<(String, usize, TagBalance)> {
     }
 }
 
+/// Load an Image widget from a filesystem path, decoding scaled to `size` so we
+/// never pull a multi-megapixel source (e.g. a 4K wallpaper passed as --icon)
+/// through the GTK main thread at full resolution.
+fn load_scaled_image_from_path(path: &str, size: i32) -> Image {
+    if let Ok(pixbuf) = Pixbuf::from_file_at_scale(path, size, size, true) {
+        let texture = gdk::Texture::for_pixbuf(&pixbuf);
+        let image = Image::from_paintable(Some(&texture));
+        image.set_pixel_size(size);
+        image
+    } else {
+        // Fall back to GTK's own loader; matches original behavior on failure.
+        let image = Image::from_file(path);
+        image.set_pixel_size(size);
+        image
+    }
+}
+
 /// Create an Image widget for a notification, preferring avatar data
 /// from image-data/image-path hints when available.
 pub fn create_notification_image_widget(notification: &Notification) -> Image {
@@ -255,19 +274,18 @@ pub fn create_notification_image_widget(notification: &Notification) -> Image {
 
     // Note: image-path can be either an actual file path OR an icon theme name
     if let Some(ref path) = notification.image_path {
-        let image = if let Some(file_path) = path.strip_prefix("file://") {
+        if let Some(file_path) = path.strip_prefix("file://") {
             // file:// URI - load from filesystem
-            Image::from_file(file_path)
+            return load_scaled_image_from_path(file_path, NOTIFICATION_ICON_SIZE);
         } else if path.starts_with('/') {
             // Absolute path - load from filesystem
-            Image::from_file(path)
+            return load_scaled_image_from_path(path, NOTIFICATION_ICON_SIZE);
         } else {
             // Icon theme name - use icon theme lookup
-            Image::from_icon_name(path)
-        };
-
-        image.set_pixel_size(NOTIFICATION_ICON_SIZE);
-        return image;
+            let image = Image::from_icon_name(path);
+            image.set_pixel_size(NOTIFICATION_ICON_SIZE);
+            return image;
+        }
     }
 
     // Finally, fall back to icon theme / desktop entry logic
@@ -350,16 +368,12 @@ fn create_notification_icon(app_icon: &str, app_name: &str, desktop_entry: Optio
 
     // Handle file:// URIs
     if let Some(file_path) = icon_name.strip_prefix("file://") {
-        let icon = Image::from_file(file_path);
-        icon.set_pixel_size(NOTIFICATION_ICON_SIZE);
-        return icon;
+        return load_scaled_image_from_path(file_path, NOTIFICATION_ICON_SIZE);
     }
 
     // Handle absolute file paths
     if icon_name.starts_with('/') {
-        let icon = Image::from_file(&icon_name);
-        icon.set_pixel_size(NOTIFICATION_ICON_SIZE);
-        return icon;
+        return load_scaled_image_from_path(&icon_name, NOTIFICATION_ICON_SIZE);
     }
 
     // It's an icon theme name

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -259,7 +259,12 @@ fn populate_notification_list(
         return;
     }
 
-    let mut notifications = service.notifications();
+    // Transient notifications bypass the popover history per the freedesktop spec.
+    let mut notifications: Vec<Notification> = service
+        .notifications()
+        .into_iter()
+        .filter(|n| !n.transient)
+        .collect();
 
     if notifications.is_empty() {
         add_empty_state(list, "No notifications");

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -210,8 +210,9 @@ fn build_header(on_close: Option<ClosePopoverCallback>) -> GtkBox {
 
     header.append(&mute_btn);
 
-    // Clear all button (only when there are notifications)
-    let count = service.count();
+    // Clear all button (only when there are history notifications - transients
+    // never appear in the popover, so they shouldn't gate the clear-all button).
+    let count = service.history_count();
 
     if count > 0 {
         let clear_btn = crate::widgets::base::vp_button();
@@ -260,11 +261,7 @@ fn populate_notification_list(
     }
 
     // Transient notifications bypass the popover history per the freedesktop spec.
-    let mut notifications: Vec<Notification> = service
-        .notifications()
-        .into_iter()
-        .filter(|n| !n.transient)
-        .collect();
+    let mut notifications: Vec<Notification> = service.history_notifications();
 
     if notifications.is_empty() {
         add_empty_state(list, "No notifications");

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -210,8 +210,7 @@ fn build_header(on_close: Option<ClosePopoverCallback>) -> GtkBox {
 
     header.append(&mute_btn);
 
-    // Clear all button (only when there are history notifications - transients
-    // never appear in the popover, so they shouldn't gate the clear-all button).
+    // Clear all button (only when there are history notifications)
     let count = service.history_count();
 
     if count > 0 {

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -395,8 +395,7 @@ fn build_notification_row(
     if !notification.body.is_empty() {
         // Sanitize markup and clean up for display
         let body_markup = sanitize_body_markup(&notification.body);
-        let body_clean = body_markup.replace('\n', " ");
-        let body_clean = body_clean.trim();
+        let body_clean = body_markup.trim();
         let needs_expansion = body_clean.chars().count() > BODY_TRUNCATE_THRESHOLD;
 
         let body_label = Label::new(None);

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -125,15 +125,16 @@ impl NotificationToast {
     }
 
     /// Refresh the toast's content, dismiss/action wiring, and timer to reflect a
-    /// notification that was replaced via `replaces_id`. Position and the height
-    /// the manager already measured are preserved; if the new content has a
-    /// different intrinsic height, repositioning happens on the next pass.
+    /// notification that was replaced via `replaces_id`. The on-screen position
+    /// is preserved; height is re-measured after layout so neighbour toasts can
+    /// reposition if the new content is a different size.
     pub fn update(
         self: &Rc<Self>,
         notification: &Notification,
         on_dismiss: ToastCallback,
         on_action: ToastActionCallback,
         on_timeout: ToastCallback,
+        on_height_measured: ToastCallback,
     ) {
         // Drop the existing timeout before scheduling a fresh one - replacement
         // resets the auto-dismiss countdown.
@@ -143,6 +144,21 @@ impl NotificationToast {
 
         self.build_content(notification, on_dismiss, on_action);
         self.schedule_timeout(notification, on_timeout);
+
+        // The window is already mapped, so connect_map won't fire again. Defer a
+        // re-measurement to the next idle so GTK has time to lay out the new
+        // child; if the height changed, the manager repositions the stack.
+        let toast_weak = Rc::downgrade(self);
+        let notification_id = notification.id;
+        glib::idle_add_local_once(move || {
+            if let Some(toast) = toast_weak.upgrade() {
+                let height = toast.window.height();
+                if height > 0 && height != toast.height.get() {
+                    toast.height.set(height);
+                    on_height_measured(notification_id);
+                }
+            }
+        });
     }
 
     fn schedule_timeout(self: &Rc<Self>, notification: &Notification, on_timeout: ToastCallback) {
@@ -478,6 +494,14 @@ impl NotificationToastManager {
             }
         });
 
+        // When toast height is measured, reposition all toasts. Constructed up
+        // front because both the in-place update path and the new-toast path
+        // need it.
+        let manager_for_height = Rc::clone(self);
+        let on_height_measured: Rc<dyn Fn(u32)> = Rc::new(move |_id| {
+            manager_for_height.reposition_toasts();
+        });
+
         // If a toast for this id is already on screen, mutate it in place so a
         // notification replaced via `replaces_id` updates the existing toast
         // (text, actions, timer) rather than stacking a new one on top.
@@ -488,6 +512,7 @@ impl NotificationToastManager {
                 on_dismiss,
                 Rc::clone(&self.on_action),
                 on_timeout,
+                on_height_measured,
             );
             return;
         }
@@ -504,12 +529,6 @@ impl NotificationToastManager {
             }
             y_offset
         };
-
-        // When toast height is measured, reposition all toasts
-        let manager_for_height = Rc::clone(self);
-        let on_height_measured: Rc<dyn Fn(u32)> = Rc::new(move |_id| {
-            manager_for_height.reposition_toasts();
-        });
 
         let toast = NotificationToast::new(
             app,

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -98,51 +98,7 @@ impl NotificationToast {
         });
 
         toast.build_content(notification, on_dismiss.clone(), on_action);
-
-        // Set up timeout
-        let timeout_ms = if notification.urgency == URGENCY_CRITICAL {
-            TOAST_TIMEOUT_CRITICAL_MS
-        } else if notification.expire_timeout > 0 {
-            notification.expire_timeout as u32
-        } else {
-            TOAST_TIMEOUT_MS
-        };
-
-        debug!(
-            "NotificationToast: id={} timeout_ms={} (urgency={}, expire_timeout={})",
-            notification.id, timeout_ms, notification.urgency, notification.expire_timeout
-        );
-
-        if timeout_ms > 0 {
-            let toast_weak = Rc::downgrade(&toast);
-            let on_timeout = on_timeout.clone();
-            let notification_id = notification.id;
-            let source_id = glib::timeout_add_local_once(
-                std::time::Duration::from_millis(timeout_ms as u64),
-                move || {
-                    debug!(
-                        "NotificationToast: timeout fired for id={}",
-                        notification_id
-                    );
-                    if let Some(toast) = toast_weak.upgrade() {
-                        debug!(
-                            "NotificationToast: toast still alive, closing window for id={}",
-                            notification_id
-                        );
-                        // Clear the source ID since it's already been removed by glib
-                        toast.timeout_source.borrow_mut().take();
-                        on_timeout(toast.notification_id);
-                        toast.window.close();
-                    } else {
-                        debug!(
-                            "NotificationToast: toast was dropped, cannot close for id={}",
-                            notification_id
-                        );
-                    }
-                },
-            );
-            *toast.timeout_source.borrow_mut() = Some(source_id);
-        }
+        toast.schedule_timeout(notification, on_timeout);
 
         // Measure actual height after window is mapped and laid out.
         // We use idle_add to defer measurement until after GTK has completed layout.
@@ -164,6 +120,74 @@ impl NotificationToast {
         });
 
         toast
+    }
+
+    /// Refresh the toast's content, dismiss/action wiring, and timer to reflect a
+    /// notification that was replaced via `replaces_id`. Position and the height
+    /// the manager already measured are preserved; if the new content has a
+    /// different intrinsic height, repositioning happens on the next pass.
+    pub fn update(
+        self: &Rc<Self>,
+        notification: &Notification,
+        on_dismiss: ToastCallback,
+        on_action: ToastActionCallback,
+        on_timeout: ToastCallback,
+    ) {
+        // Drop the existing timeout before scheduling a fresh one - replacement
+        // resets the auto-dismiss countdown.
+        if let Some(source_id) = self.timeout_source.borrow_mut().take() {
+            source_id.remove();
+        }
+
+        self.build_content(notification, on_dismiss, on_action);
+        self.schedule_timeout(notification, on_timeout);
+    }
+
+    fn schedule_timeout(self: &Rc<Self>, notification: &Notification, on_timeout: ToastCallback) {
+        let timeout_ms = if notification.urgency == URGENCY_CRITICAL {
+            TOAST_TIMEOUT_CRITICAL_MS
+        } else if notification.expire_timeout > 0 {
+            notification.expire_timeout as u32
+        } else {
+            TOAST_TIMEOUT_MS
+        };
+
+        debug!(
+            "NotificationToast: id={} timeout_ms={} (urgency={}, expire_timeout={})",
+            notification.id, timeout_ms, notification.urgency, notification.expire_timeout
+        );
+
+        if timeout_ms == 0 {
+            return;
+        }
+
+        let toast_weak = Rc::downgrade(self);
+        let notification_id = notification.id;
+        let source_id = glib::timeout_add_local_once(
+            std::time::Duration::from_millis(timeout_ms as u64),
+            move || {
+                debug!(
+                    "NotificationToast: timeout fired for id={}",
+                    notification_id
+                );
+                if let Some(toast) = toast_weak.upgrade() {
+                    debug!(
+                        "NotificationToast: toast still alive, closing window for id={}",
+                        notification_id
+                    );
+                    // Clear the source ID since it's already been removed by glib
+                    toast.timeout_source.borrow_mut().take();
+                    on_timeout(toast.notification_id);
+                    toast.window.close();
+                } else {
+                    debug!(
+                        "NotificationToast: toast was dropped, cannot close for id={}",
+                        notification_id
+                    );
+                }
+            },
+        );
+        *self.timeout_source.borrow_mut() = Some(source_id);
     }
 
     fn build_content(
@@ -431,9 +455,29 @@ impl NotificationToastManager {
     }
 
     pub fn show(self: &Rc<Self>, app: &Application, notification: &Notification) {
-        // If toast already exists, close it first
-        if self.toasts.borrow().contains_key(&notification.id) {
-            self.remove_toast(notification.id);
+        let manager = Rc::clone(self);
+        let on_dismiss: Rc<dyn Fn(u32)> = Rc::new(move |id| {
+            manager.remove_toast(id);
+        });
+
+        // When toast times out, we need to remove it and notify the widget to update badge
+        let manager_for_timeout = Rc::clone(self);
+        let on_timeout: Rc<dyn Fn(u32)> = Rc::new(move |id| {
+            manager_for_timeout.remove_toast(id);
+        });
+
+        // If a toast for this id is already on screen, mutate it in place so a
+        // notification replaced via `replaces_id` updates the existing toast
+        // (text, actions, timer) rather than stacking a new one on top.
+        let existing = self.toasts.borrow().get(&notification.id).cloned();
+        if let Some(toast) = existing {
+            toast.update(
+                notification,
+                on_dismiss,
+                Rc::clone(&self.on_action),
+                on_timeout,
+            );
+            return;
         }
 
         // Calculate initial margin from existing toasts
@@ -448,17 +492,6 @@ impl NotificationToastManager {
             }
             y_offset
         };
-
-        let manager = Rc::clone(self);
-        let on_dismiss: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            manager.remove_toast(id);
-        });
-
-        // When toast times out, we need to remove it and notify the widget to update badge
-        let manager_for_timeout = Rc::clone(self);
-        let on_timeout: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            manager_for_timeout.remove_toast(id);
-        });
 
         // When toast height is measured, reposition all toasts
         let manager_for_height = Rc::clone(self);

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -474,24 +474,27 @@ impl NotificationToastManager {
 
     pub fn show(self: &Rc<Self>, app: &Application, notification: &Notification) {
         // Transient notifications must be removed from the service when their toast
-        // disappears (dismiss or timeout) so they never leak into the popover history.
+        // disappears (dismiss or timeout) so they never leak into the popover
+        // history. Close the service entry *before* tearing down the toast so the
+        // synchronous on_service_update fired by `service.close` does the work;
+        // the deferred update from `remove_toast` then sees no change and no-ops.
         let is_transient = notification.transient;
 
         let manager = Rc::clone(self);
         let on_dismiss: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            manager.remove_toast(id);
             if is_transient {
                 NotificationService::global().close(id);
             }
+            manager.remove_toast(id);
         });
 
         // When toast times out, we need to remove it and notify the widget to update badge
         let manager_for_timeout = Rc::clone(self);
         let on_timeout: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            manager_for_timeout.remove_toast(id);
             if is_transient {
                 NotificationService::global().close(id);
             }
+            manager_for_timeout.remove_toast(id);
         });
 
         // When toast height is measured, reposition all toasts. Constructed up

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -14,7 +14,9 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use tracing::debug;
 
-use crate::services::notification::{Notification, URGENCY_CRITICAL, URGENCY_LOW};
+use crate::services::notification::{
+    Notification, NotificationService, URGENCY_CRITICAL, URGENCY_LOW,
+};
 
 /// Type alias for toast notification callbacks.
 type ToastCallback = Rc<dyn Fn(u32)>;
@@ -455,15 +457,25 @@ impl NotificationToastManager {
     }
 
     pub fn show(self: &Rc<Self>, app: &Application, notification: &Notification) {
+        // Transient notifications must be removed from the service when their toast
+        // disappears (dismiss or timeout) so they never leak into the popover history.
+        let is_transient = notification.transient;
+
         let manager = Rc::clone(self);
         let on_dismiss: Rc<dyn Fn(u32)> = Rc::new(move |id| {
             manager.remove_toast(id);
+            if is_transient {
+                NotificationService::global().close(id);
+            }
         });
 
         // When toast times out, we need to remove it and notify the widget to update badge
         let manager_for_timeout = Rc::clone(self);
         let on_timeout: Rc<dyn Fn(u32)> = Rc::new(move |id| {
             manager_for_timeout.remove_toast(id);
+            if is_transient {
+                NotificationService::global().close(id);
+            }
         });
 
         // If a toast for this id is already on screen, mutate it in place so a


### PR DESCRIPTION
Fixes various bugs for notifications reported in #112 

- Transient notifications are now honored, they show a toast but are excluded from the popover history
- Replacing a notification by reusing its id now updates the existing toast in place rather than stacking a new one
- Newlines in popover notification bodies are preserved
- File-backed notification icons (--icon=/path/to/image) are now decoded at the display size via Pixbuf::from_file_at_scale, avoiding a full-resolution decode on the main thread when many such notifications are open.

Closes #112