### PR TITLE
feat(theme): add outline support for bar, widgets and surfaces

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,7 @@ position = "top"         # "top" or "bottom"
 size = 32
 border_radius = 30
 background_opacity = 0.0 # 0.0 = transparent (islands), 1.0 = solid
+# outline = true         # Override theme.outline for the bar (omit = inherit)
 
 [widgets]
 left = ["workspaces", "window_title"]
@@ -32,11 +33,13 @@ right = [
 border_radius = 40
 background_opacity = 1.0
 # popover_background_opacity = 0.9  # Override popover opacity (default: max of bar and widget opacity)
+# outline = true                    # Override theme.outline for widgets (omit = inherit)
 
 # Per-widget options use [widgets.<name>] sections.
 # Example:
 #   [widgets.clock]
 #   format = "%H:%M"
+#   outline_color = "accent"  # Per-widget outline color: "subtle" | "accent" | "foreground" | "#rrggbb"
 #
 #   [widgets.battery]
 #   disabled = true
@@ -79,6 +82,10 @@ mode = "dark" # "auto", "dark", "light", "gtk"
 #animations = true  # Enable/disable all CSS transitions and animations
 #ripple = true      # Enable/disable Material Design ripple effect on click
 #blur = false       # Enable compositor blur via ext-background-effect-v1 (requires niri with blur)
+#outline = false             # Decorative outline on bar, widgets, and surfaces (CSS border)
+#outline_width = 1           # Outline width in pixels (0..=4; 0 disables visibly)
+#outline_color = "accent"    # "subtle" | "accent" | "foreground" | "#rrggbb"
+#outline_opacity = 1.0        # 0.0 = transparent, 1.0 = opaque
 
 [theme.icons]
 theme = "material" # "material" or "gtk"

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -41,6 +41,32 @@ const VALID_BAR_POSITIONS: &[&str] = &["top", "bottom"];
 /// Known valid values for osd.position.
 const VALID_OSD_POSITIONS: &[&str] = &["bottom", "left", "right", "top"];
 
+/// Known symbolic values for outline_color.
+///
+/// Symbolic names map to existing theme tokens at CSS render time (see
+/// `theme::resolve_outline_color`). Hex literals (`#rgb` / `#rrggbb`) are also
+/// accepted.
+const VALID_OUTLINE_COLOR_SYMBOLS: &[&str] = &["subtle", "accent", "foreground"];
+
+/// Maximum outline width in pixels.
+///
+/// Outlines are intended for visual edge definition (1px is the typical case);
+/// thicker decorative borders should be done via user CSS.
+const MAX_OUTLINE_WIDTH: u32 = 4;
+
+/// Validate an outline color value against the symbolic + hex contract.
+///
+/// Accepts: "subtle", "accent", "foreground", or a hex color (`#rgb` / `#rrggbb`).
+fn is_valid_outline_color(value: &str) -> bool {
+    if VALID_OUTLINE_COLOR_SYMBOLS.contains(&value) {
+        return true;
+    }
+    if let Some(hex) = value.strip_prefix('#') {
+        return (hex.len() == 3 || hex.len() == 6) && hex.chars().all(|c| c.is_ascii_hexdigit());
+    }
+    false
+}
+
 /// Embedded default configuration TOML, compiled into the binary.
 pub const DEFAULT_CONFIG_TOML: &str = include_str!("../../../config.toml");
 
@@ -331,6 +357,43 @@ impl Config {
             ));
         }
 
+        // Outline validation (theme-level)
+        if self.theme.outline_width > MAX_OUTLINE_WIDTH {
+            errors.push(format!(
+                "theme.outline_width: invalid value '{}', must be between 0 and {}",
+                self.theme.outline_width, MAX_OUTLINE_WIDTH
+            ));
+        }
+
+        if !(0.0..=1.0).contains(&self.theme.outline_opacity) {
+            errors.push(format!(
+                "theme.outline_opacity: invalid value '{}', must be between 0.0 and 1.0",
+                self.theme.outline_opacity
+            ));
+        }
+
+        if !is_valid_outline_color(&self.theme.outline_color) {
+            errors.push(format!(
+                "theme.outline_color: invalid value '{}', expected one of: {}, or a hex color like '#3584e4'",
+                self.theme.outline_color,
+                VALID_OUTLINE_COLOR_SYMBOLS.join(", ")
+            ));
+        }
+
+        // Per-widget outline_color validation
+        for (name, opts) in &self.widgets.widget_configs {
+            if let Some(ref color) = opts.outline_color
+                && !is_valid_outline_color(color)
+            {
+                errors.push(format!(
+                    "widgets.{}.outline_color: invalid value '{}', expected one of: {}, or a hex color like '#3584e4'",
+                    name,
+                    color,
+                    VALID_OUTLINE_COLOR_SYMBOLS.join(", ")
+                ));
+            }
+        }
+
         if errors.is_empty() {
             Ok(())
         } else {
@@ -574,6 +637,12 @@ pub struct BarConfig {
     /// Bar background opacity (0.0 = fully transparent, 1.0 = fully opaque).
     /// Default: 0.0 (transparent bar for "islands" look).
     pub background_opacity: f64,
+
+    /// Bar outline override. When omitted, inherits `theme.outline`.
+    /// `true` forces an outline on the bar; `false` suppresses it even when
+    /// the theme default is enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outline: Option<bool>,
 }
 
 impl Default for BarConfig {
@@ -590,6 +659,7 @@ impl Default for BarConfig {
             outputs: Vec::new(),
             background_color: None,
             background_opacity: 0.0,
+            outline: None,
         }
     }
 }
@@ -654,6 +724,12 @@ pub struct WidgetsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub popover_background_opacity: Option<f64>,
 
+    /// Widget outline override. When omitted, inherits `theme.outline`.
+    /// `true` forces outlines on widget islands/groups; `false` suppresses
+    /// them even when the theme default is enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outline: Option<bool>,
+
     /// Per-widget configuration tables.
     /// Keys are widget names, values are widget-specific options.
     #[serde(flatten)]
@@ -670,6 +746,7 @@ impl Default for WidgetsConfig {
             background_color: None,
             background_opacity: 1.0,
             popover_background_opacity: None,
+            outline: None,
             widget_configs: HashMap::new(),
         }
     }
@@ -964,6 +1041,16 @@ pub struct WidgetOptions {
     #[serde(default)]
     pub background_color: Option<String>,
 
+    /// Outline color override for this widget.
+    ///
+    /// Accepts the same values as `theme.outline_color`: `"subtle"`,
+    /// `"accent"`, `"foreground"`, or a hex color (`#rgb` / `#rrggbb`).
+    /// Applies to the widget on the bar, the widget-item / merge-group
+    /// chrome, and the widget's popover. Width and opacity remain
+    /// theme-level only in v1.
+    #[serde(default)]
+    pub outline_color: Option<String>,
+
     /// Shell command to execute on right-click. Runs via `sh -c`.
     #[serde(default)]
     pub on_click_right: Option<String>,
@@ -1172,6 +1259,20 @@ pub struct ThemeConfig {
     /// Default: false
     pub blur: bool,
 
+    /// Decorative outline (CSS border) on the bar, widgets, and surfaces.
+    /// Per-section overrides: `bar.outline`, `widgets.outline`. Default: false.
+    pub outline: bool,
+
+    /// Outline width in pixels (0..=4). 0 disables visibly. Default: 1.
+    pub outline_width: u32,
+
+    /// Outline color: `"subtle"`, `"accent"`, `"foreground"`, or hex (`#rgb` /
+    /// `#rrggbb`). Default: "accent".
+    pub outline_color: String,
+
+    /// Outline opacity (0.0..=1.0). Default: 1.0.
+    pub outline_opacity: f64,
+
     /// State colors (success, warning, urgent).
     pub states: ThemeStates,
 
@@ -1195,6 +1296,10 @@ impl Default for ThemeConfig {
             ripple: true,
             shadows: true,
             blur: false,
+            outline: false,
+            outline_width: 1,
+            outline_color: "accent".to_string(),
+            outline_opacity: 1.0,
             states: ThemeStates::default(),
             typography: ThemeTypography::default(),
             icons: ThemeIconsConfig::default(),
@@ -2371,6 +2476,97 @@ mod tests {
         assert_eq!(
             config.theme.wallpaper,
             Some("/home/user/wall.png".to_string())
+        );
+    }
+
+    // ===== Outline configuration =====
+
+    #[test]
+    fn test_outline_section_overrides_round_trip() {
+        // Catches a regression in #[serde(default)] / field renames that
+        // would silently drop user overrides on parse.
+        let toml = r#"
+            [theme]
+            outline = true
+
+            [bar]
+            outline = false
+
+            [widgets]
+            outline = true
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.theme.outline);
+        assert_eq!(config.bar.outline, Some(false));
+        assert_eq!(config.widgets.outline, Some(true));
+    }
+
+    #[test]
+    fn test_is_valid_outline_color() {
+        // Symbolic + 3/6-char hex accepted; everything else rejected.
+        for ok in [
+            "subtle",
+            "accent",
+            "foreground",
+            "#fff",
+            "#ffffff",
+            "#3584e4",
+        ] {
+            assert!(is_valid_outline_color(ok), "expected '{}' to be valid", ok);
+        }
+        for bad in ["", "Subtle", "red", "#gg", "#12345", "ffffff"] {
+            assert!(
+                !is_valid_outline_color(bad),
+                "expected '{}' to be invalid",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_outline_rejects_invalid_values() {
+        // One test per validated field; each asserts the error path mentions
+        // the field by name so user-facing messages don't silently regress.
+        let cases: &[(&dyn Fn(&mut Config), &str)] = &[
+            (&|c| c.theme.outline_width = 5, "outline_width"),
+            (&|c| c.theme.outline_opacity = 1.5, "outline_opacity"),
+            (
+                &|c| c.theme.outline_color = "rebeccapurple".to_string(),
+                "outline_color",
+            ),
+        ];
+        for (mutate, field) in cases {
+            let mut config = Config::default();
+            mutate(&mut config);
+            let err = config.validate().unwrap_err();
+            assert!(
+                format!("{:?}", err).contains(field),
+                "error for '{}' missing field name: {:?}",
+                field,
+                err
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_per_widget_outline_color_rejects_invalid() {
+        // Per-widget validation walks a different code path (loop over
+        // widget_configs); separate test so regressions there don't hide
+        // behind the theme-level cases above.
+        let mut config = Config::default();
+        config.widgets.widget_configs.insert(
+            "clock".to_string(),
+            WidgetOptions {
+                outline_color: Some("not-a-color".to_string()),
+                ..Default::default()
+            },
+        );
+        let err = config.validate().unwrap_err();
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("widgets.clock.outline_color"),
+            "error should mention widget path: {}",
+            msg
         );
     }
 }

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -1045,9 +1045,9 @@ pub struct WidgetOptions {
     ///
     /// Accepts the same values as `theme.outline_color`: `"subtle"`,
     /// `"accent"`, `"foreground"`, or a hex color (`#rgb` / `#rrggbb`).
-    /// Applies to the widget on the bar, the widget-item / merge-group
-    /// chrome, and the widget's popover. Width and opacity remain
-    /// theme-level only in v1.
+    /// Applies to standalone widgets on the bar and the widget's popover
+    /// surface. In merge groups, the group pill uses the first widget's
+    /// outline color. Width and opacity remain theme-level only in v1.
     #[serde(default)]
     pub outline_color: Option<String>,
 
@@ -2524,6 +2524,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::type_complexity)]
     fn test_validate_outline_rejects_invalid_values() {
         // One test per validated field; each asserts the error path mentions
         // the field by name so user-facing messages don't silently regress.

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -122,6 +122,28 @@ pub fn parse_hex_color(color: &str) -> Option<(u8, u8, u8)> {
     Some((r, g, b))
 }
 
+/// Resolve an outline color value to a CSS color expression.
+///
+/// Symbolic names map to existing theme tokens (`subtle` → `--color-border-subtle`,
+/// `accent` → `--color-accent-primary`, `foreground` → `--color-foreground-primary`)
+/// so the outline tracks the active theme polarity automatically. Hex colors
+/// (`#rgb` / `#rrggbb`) are normalized to the lowercase 6-character form.
+///
+/// Unrecognized values fall through unchanged — validation runs at config-load
+/// time, so unrecognized values shouldn't reach this function in practice.
+pub fn resolve_outline_color(value: &str) -> String {
+    match value {
+        "subtle" => "var(--color-border-subtle)".to_string(),
+        "accent" => "var(--color-accent-primary)".to_string(),
+        "foreground" => "var(--color-foreground-primary)".to_string(),
+        hex if hex.starts_with('#') => match parse_hex_color(hex) {
+            Some((r, g, b)) => format!("#{:02x}{:02x}{:02x}", r, g, b),
+            None => hex.to_string(),
+        },
+        other => other.to_string(),
+    }
+}
+
 /// Calculate relative luminance per WCAG formula (0.0 = black, 1.0 = white).
 pub fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
     fn channel(c: u8) -> f64 {
@@ -367,6 +389,25 @@ pub struct ThemePalette {
 
     // Sizes
     pub sizes: ThemeSizes,
+
+    // Outline (theme-level inputs, resolved for CSS emission)
+    /// Configured outline width in pixels (always present; per-scope visibility
+    /// is gated separately via the `*_outline_enabled` flags).
+    pub outline_width_px: u32,
+    /// Resolved outline color as a CSS color expression (e.g.,
+    /// `var(--color-border-subtle)` or `#aabbcc`).
+    pub outline_color_resolved: String,
+    /// Outline opacity as an integer percentage (0-100).
+    pub outline_opacity_pct: u32,
+    /// Effective outline state for the bar (theme default + `bar.outline` override).
+    pub bar_outline_enabled: bool,
+    /// Effective outline state for widgets/widget groups (theme default +
+    /// `widgets.outline` override).
+    pub widget_outline_enabled: bool,
+    /// Effective outline state for surfaces (popovers, OSD, toasts, tray, media,
+    /// Quick Settings). In v1 this just mirrors `theme.outline` — per-surface
+    /// overrides may be added later.
+    pub surface_outline_enabled: bool,
 
     // Internal: config values needed for computation
     bar_radius_percent: u32,
@@ -616,6 +657,25 @@ impl ThemePalette {
     --shadow-soft: {shadow_soft};
     --shadow-strong: {shadow_strong};
 
+    /* ===== Outlines =====
+     * Base values are theme-level. Per-scope `--*-outline-width` resolves
+     * to `var(--outline-width)` when the scope's outline is enabled, or
+     * `0px` when disabled. Color and opacity are simple aliases in v1;
+     * per-scope overrides can specialize them later without renaming.
+     */
+    --outline-width: {outline_width}px;
+    --outline-color: {outline_color};
+    --outline-opacity: {outline_opacity}%;
+    --bar-outline-width: {bar_outline_width};
+    --bar-outline-color: var(--outline-color);
+    --bar-outline-opacity: var(--outline-opacity);
+    --widget-outline-width: {widget_outline_width};
+    --widget-outline-color: var(--outline-color);
+    --widget-outline-opacity: var(--outline-opacity);
+    --surface-outline-width: {surface_outline_width};
+    --surface-outline-color: var(--outline-color);
+    --surface-outline-opacity: var(--outline-opacity);
+
     /* ===== Slider Tracks ===== */
     --color-slider-track: {slider_track};
     --color-slider-track-disabled: {slider_track_disabled};
@@ -722,6 +782,24 @@ impl ThemePalette {
             border_subtle = self.border_subtle,
             shadow_soft = self.shadow_soft,
             shadow_strong = self.shadow_strong,
+            outline_width = self.outline_width_px,
+            outline_color = self.outline_color_resolved,
+            outline_opacity = self.outline_opacity_pct,
+            bar_outline_width = if self.bar_outline_enabled {
+                "var(--outline-width)"
+            } else {
+                "0px"
+            },
+            widget_outline_width = if self.widget_outline_enabled {
+                "var(--outline-width)"
+            } else {
+                "0px"
+            },
+            surface_outline_width = if self.surface_outline_enabled {
+                "var(--outline-width)"
+            } else {
+                "0px"
+            },
             slider_track = self.slider_track,
             slider_track_disabled = self.slider_track_disabled,
             row_critical_bg = self.row_critical_background,
@@ -805,6 +883,12 @@ impl ThemePalette {
     ///
     /// Generates rules like `.widget.clock, .clock-popover { --widget-background-color: #f5c2e7; }`.
     /// Widget names are normalized to CSS conventions (underscores → hyphens).
+    ///
+    /// Per-widget `outline_color` is emitted as both `--widget-outline-color`
+    /// (for the in-bar widget body) and `--surface-outline-color` (for the
+    /// matching `.<name>-popover` surface, since GTK4 popovers render in
+    /// separate windows and a CSS-variable scope on `.widget.<name>` would
+    /// not propagate to them).
     pub fn generate_per_widget_css(config: &Config) -> String {
         let mut css = String::new();
 
@@ -823,6 +907,12 @@ impl ThemePalette {
                         widget_name
                     );
                 }
+            }
+
+            if let Some(ref color) = options.outline_color {
+                let resolved = resolve_outline_color(color);
+                rules.push(format!("--widget-outline-color: {};", resolved));
+                rules.push(format!("--surface-outline-color: {};", resolved));
             }
 
             if !rules.is_empty() {
@@ -863,6 +953,26 @@ impl ThemePalette {
         self.state_success = config.theme.states.success.clone();
         self.state_warning = config.theme.states.warning.clone();
         self.state_urgent = config.theme.states.urgent.clone();
+
+        // Outline configuration. Per-scope `Option<bool>` overrides inherit
+        // from `theme.outline` when omitted. Width and opacity are theme-level
+        // only in v1; effective visibility on a surface is `enabled && width > 0`.
+        //
+        // Bar outline in islands mode (`bar.background_opacity == 0.0`):
+        // when the user has not set an explicit `bar.outline`, suppress the
+        // outline so we don't draw a 1px rectangle around an invisible bar
+        // (an "outline framing nothing" surrounding the floating widgets).
+        // An explicit `bar.outline = true` still wins — users who want that
+        // framing look can opt in.
+        self.outline_width_px = config.theme.outline_width;
+        self.outline_color_resolved = resolve_outline_color(&config.theme.outline_color);
+        self.outline_opacity_pct = (config.theme.outline_opacity * 100.0).round() as u32;
+        self.bar_outline_enabled = config
+            .bar
+            .outline
+            .unwrap_or(config.theme.outline && config.bar.background_opacity > 0.0);
+        self.widget_outline_enabled = config.widgets.outline.unwrap_or(config.theme.outline);
+        self.surface_outline_enabled = config.theme.outline;
 
         // Handle auto mode (wallpaper-adaptive Material You theming) first,
         // since it sets backgrounds, foregrounds, accent, and state colors directly.
@@ -1427,6 +1537,12 @@ impl Default for ThemePalette {
             surface_border_radius: 0,
             radius_pill: 0,
             sizes: ThemeSizes::default(),
+            outline_width_px: 1,
+            outline_color_resolved: "var(--color-accent-primary)".to_string(),
+            outline_opacity_pct: 100,
+            bar_outline_enabled: false,
+            widget_outline_enabled: false,
+            surface_outline_enabled: false,
             bar_radius_percent: 30,
             widget_radius_percent: 40,
             bar_size: 32,
@@ -2283,6 +2399,196 @@ mod tests {
         assert!(
             palette.is_dark_mode,
             "low luminance should produce dark fallback when material_theme is None"
+        );
+    }
+
+    // ===== Outline =====
+
+    #[test]
+    fn test_resolve_outline_color_hex_normalizes_to_lowercase_six() {
+        // Real parsing logic: 3-char hex expands to 6-char, mixed case folds.
+        assert_eq!(resolve_outline_color("#FFF"), "#ffffff");
+        assert_eq!(resolve_outline_color("#3584E4"), "#3584e4");
+        assert_eq!(resolve_outline_color("#abc"), "#aabbcc");
+    }
+
+    #[test]
+    fn test_outline_enabled_propagates_to_all_scopes() {
+        // Catches "forgot to wire a scope" regressions in the cascade.
+        let mut config = Config::default();
+        config.theme.outline = true;
+        // Default bar opacity is 0.0 (islands mode), which suppresses the
+        // inherited bar outline; raise it to verify the propagation path.
+        config.bar.background_opacity = 1.0;
+        let palette = ThemePalette::from_config(&config, None, None);
+        assert!(palette.bar_outline_enabled);
+        assert!(palette.widget_outline_enabled);
+        assert!(palette.surface_outline_enabled);
+    }
+
+    #[test]
+    fn test_outline_override_matrix() {
+        // Per-section `Option<bool>` overrides must win over the theme default
+        // in either direction, and only affect their own scope. surface_outline
+        // has no per-section override in v1 so it always tracks theme.outline.
+        struct Case {
+            theme: bool,
+            bar_override: Option<bool>,
+            widgets_override: Option<bool>,
+            expect_bar: bool,
+            expect_widget: bool,
+            expect_surface: bool,
+        }
+        let cases = [
+            Case {
+                theme: true,
+                bar_override: Some(false),
+                widgets_override: None,
+                expect_bar: false,
+                expect_widget: true,
+                expect_surface: true,
+            },
+            Case {
+                theme: false,
+                bar_override: Some(true),
+                widgets_override: None,
+                expect_bar: true,
+                expect_widget: false,
+                expect_surface: false,
+            },
+            Case {
+                theme: true,
+                bar_override: None,
+                widgets_override: Some(false),
+                expect_bar: true,
+                expect_widget: false,
+                expect_surface: true,
+            },
+            Case {
+                theme: false,
+                bar_override: None,
+                widgets_override: Some(true),
+                expect_bar: false,
+                expect_widget: true,
+                expect_surface: false,
+            },
+        ];
+        for (i, c) in cases.iter().enumerate() {
+            let mut config = Config::default();
+            config.theme.outline = c.theme;
+            // Avoid islands-mode bar suppression contaminating the matrix —
+            // that interaction has its own dedicated test below.
+            config.bar.background_opacity = 1.0;
+            config.bar.outline = c.bar_override;
+            config.widgets.outline = c.widgets_override;
+            let p = ThemePalette::from_config(&config, None, None);
+            assert_eq!(p.bar_outline_enabled, c.expect_bar, "case {} bar", i);
+            assert_eq!(
+                p.widget_outline_enabled, c.expect_widget,
+                "case {} widget",
+                i
+            );
+            assert_eq!(
+                p.surface_outline_enabled, c.expect_surface,
+                "case {} surface",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_islands_mode_outline_suppression() {
+        // In islands mode (bar.background_opacity == 0) the bar surface is
+        // invisible, so an inherited bar outline would frame nothing — suppress
+        // it. Explicit `bar.outline = Some(true)` must still win for users who
+        // want a framing look around their islands. Other scopes inherit
+        // normally regardless.
+        let mut inherited = Config::default();
+        inherited.theme.outline = true;
+        inherited.bar.background_opacity = 0.0;
+        let p = ThemePalette::from_config(&inherited, None, None);
+        assert!(
+            !p.bar_outline_enabled,
+            "inherited bar outline must be suppressed"
+        );
+        assert!(p.widget_outline_enabled);
+        assert!(p.surface_outline_enabled);
+
+        let mut explicit = Config::default();
+        explicit.theme.outline = false;
+        explicit.bar.background_opacity = 0.0;
+        explicit.bar.outline = Some(true);
+        let p = ThemePalette::from_config(&explicit, None, None);
+        assert!(
+            p.bar_outline_enabled,
+            "explicit bar.outline = true must win"
+        );
+    }
+
+    #[test]
+    fn test_css_vars_block_emits_outline_variables() {
+        // CSS variable names are the contract with widgets/css/*.rs and
+        // services/surfaces.rs — there is no compile-time check across that
+        // boundary, so renames here would silently break the feature.
+        let mut config = Config::default();
+        config.theme.outline = true;
+        config.theme.outline_width = 2;
+        config.theme.outline_color = "accent".to_string();
+        config.theme.outline_opacity = 0.5;
+        config.bar.background_opacity = 1.0;
+        let css = ThemePalette::from_config(&config, None, None).css_vars_block();
+
+        for needle in [
+            "--outline-width: 2px;",
+            "--outline-color: var(--color-accent-primary);",
+            "--outline-opacity: 50%;",
+            "--bar-outline-width: var(--outline-width);",
+            "--widget-outline-width: var(--outline-width);",
+            "--surface-outline-width: var(--outline-width);",
+        ] {
+            assert!(css.contains(needle), "missing CSS var: {}", needle);
+        }
+    }
+
+    #[test]
+    fn test_css_vars_block_outline_disabled_emits_zero_width() {
+        // When a scope is disabled its `--*-outline-width` resolves to 0px so
+        // the consumer's `border: var(--*-outline-width) ...` renders nothing.
+        let css = ThemePalette::from_config(&Config::default(), None, None).css_vars_block();
+        for needle in [
+            "--bar-outline-width: 0px;",
+            "--widget-outline-width: 0px;",
+            "--surface-outline-width: 0px;",
+        ] {
+            assert!(css.contains(needle), "missing CSS var: {}", needle);
+        }
+    }
+
+    #[test]
+    fn test_per_widget_outline_color_emits_both_variables() {
+        // Widget popovers are separate GTK4 windows — CSS variables don't
+        // inherit across the window boundary, so a per-widget outline_color
+        // must be emitted on BOTH the bar-body selector (--widget-outline-color)
+        // and the popover selector (--surface-outline-color).
+        use crate::config::WidgetOptions;
+
+        let mut config = Config::default();
+        config.widgets.widget_configs.insert(
+            "clock".to_string(),
+            WidgetOptions {
+                outline_color: Some("accent".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let css = ThemePalette::generate_per_widget_css(&config);
+        assert!(
+            css.contains("--widget-outline-color: var(--color-accent-primary);"),
+            "missing widget outline color"
+        );
+        assert!(
+            css.contains("--surface-outline-color: var(--color-accent-primary);"),
+            "missing surface outline color (popover would not pick up the override)"
         );
     }
 }

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -464,6 +464,11 @@ fn build_widget_or_group(
             let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
             surface.add_css_class(class::WIDGET);
             surface.add_css_class(class::WIDGET_GROUP);
+            // First widget's per-widget style (outline_color, background_color)
+            // applies to the group surface so the shared border uses the right color.
+            if let Some(first) = group.first() {
+                surface.add_css_class(&first.name.replace('_', "-"));
+            }
             surface.set_overflow(gtk4::Overflow::Hidden);
             surface.set_hexpand(true);
             surface.set_vexpand(true);

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -325,12 +325,28 @@ impl Dispatch<wayland_client::protocol::wl_region::WlRegion, ()> for BlurState {
 /// clamps to a pill shape or falls back to a plain rectangle.
 /// Non-positive `width` or `height` return an empty vec (per Wayland protocol,
 /// non-positive dimensions are invalid for `wl_region.add`).
+#[cfg(test)]
 fn compute_rounded_rect_rects(
     x: i32,
     y: i32,
     width: i32,
     height: i32,
     radius: i32,
+) -> Vec<(i32, i32, i32, i32)> {
+    compute_rounded_rect_rects_with_corner_inset(x, y, width, height, radius, 0)
+}
+
+/// Compute rounded-rect scanlines, optionally trimming only the rounded corner
+/// rows inward.  Used when an outline is visible: the compositor blur region is
+/// made slightly more conservative at corners so rectangular scanline edges do
+/// not peek through semi-transparent CSS borders.
+fn compute_rounded_rect_rects_with_corner_inset(
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    radius: i32,
+    corner_inset: i32,
 ) -> Vec<(i32, i32, i32, i32)> {
     if width <= 0 || height <= 0 {
         return Vec::new();
@@ -355,6 +371,7 @@ fn compute_rounded_rect_rects(
         rects.push((x, y + radius, width, height - 2 * radius));
     }
 
+    let corner_inset = corner_inset.max(0);
     let r = radius as f64;
     for i in 0..radius as usize {
         let dy = r - 0.5 - i as f64;
@@ -363,6 +380,7 @@ fn compute_rounded_rect_rects(
         } else {
             (r - (r * r - dy * dy).sqrt()).round() as i32
         };
+        let inset = (inset + corner_inset).min((width - 1) / 2);
         let row_w = (width - 2 * inset).max(1);
         rects.push((x + inset, y + i as i32, row_w, 1));
         rects.push((x + inset, y + height - 1 - i as i32, row_w, 1));
@@ -371,19 +389,21 @@ fn compute_rounded_rect_rects(
     rects
 }
 
-/// Add a rounded rectangle to a `wl_region` using scanline rasterization.
-///
-/// Delegates to [`compute_rounded_rect_rects`] for the geometry, then feeds
-/// each rectangle to `region.add()`.
-fn add_rounded_rect_to_region(
+/// Add a rounded rectangle to a `wl_region`, trimming rounded corner rows
+/// inward by 1 logical pixel when an outline is visible.
+fn add_rounded_rect_to_region_with_outline(
     region: &wayland_client::protocol::wl_region::WlRegion,
     x: i32,
     y: i32,
     width: i32,
     height: i32,
     radius: i32,
+    outline_visible: bool,
 ) {
-    for (rx, ry, rw, rh) in compute_rounded_rect_rects(x, y, width, height, radius) {
+    let corner_inset = if outline_visible { 1 } else { 0 };
+    for (rx, ry, rw, rh) in
+        compute_rounded_rect_rects_with_corner_inset(x, y, width, height, radius, corner_inset)
+    {
         region.add(rx, ry, rw, rh);
     }
 }
@@ -722,6 +742,7 @@ impl BackgroundEffectManager {
         surface_root: &gtk4::Widget,
         content: &gtk4::Widget,
         radius_fn: impl Fn() -> i32 + Clone + 'static,
+        outline_visible_fn: impl Fn() -> bool + Clone + 'static,
     ) {
         let Some(gdk_surface) = surface_root.native().and_then(|n| n.surface()) else {
             return;
@@ -743,17 +764,24 @@ impl BackgroundEffectManager {
             let root_weak = root_weak.clone();
             let content_weak = content_weak.clone();
             let radius_fn = radius_fn.clone();
+            let outline_visible_fn = outline_visible_fn.clone();
             move |_: &gdk4_wayland::gdk::Surface, _: &glib::ParamSpec| {
                 let root_weak = root_weak.clone();
                 let content_weak = content_weak.clone();
                 let radius_fn = radius_fn.clone();
+                let outline_visible_fn = outline_visible_fn.clone();
                 glib::idle_add_local_once(move || {
                     if let Some(rc) = root_weak.upgrade()
                         && let Some(cc) = content_weak.upgrade()
                         && crate::services::config_manager::ConfigManager::global().blur_enabled()
                         && let Some(blur) = Self::global()
                     {
-                        blur.apply_blur_surface(&rc, &cc, radius_fn);
+                        blur.apply_blur_surface_with_outline(
+                            &rc,
+                            &cc,
+                            radius_fn,
+                            outline_visible_fn,
+                        );
                     }
                 });
             }
@@ -822,7 +850,15 @@ impl BackgroundEffectManager {
         let w = width - margin_start - margin_end;
         let h = height - margin_top - margin_bottom;
 
-        add_rounded_rect_to_region(&region, x, y, w, h, radius);
+        add_rounded_rect_to_region_with_outline(
+            &region,
+            x,
+            y,
+            w,
+            h,
+            radius,
+            crate::services::config_manager::ConfigManager::global().surface_outline_visible(),
+        );
 
         effect.set_blur_region(Some(&region));
         region.destroy();
@@ -879,9 +915,12 @@ impl BackgroundEffectManager {
 
         // Opaque/translucent bar: blur only the bar_box bounds, not the full surface.
         // Using apply_blur_surface so compute_bounds accounts for any margin/padding.
-        self.apply_blur_surface(window, bar_box, || {
-            crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32
-        });
+        self.apply_blur_surface_with_outline(
+            window,
+            bar_box,
+            || crate::services::config_manager::ConfigManager::global().bar_border_radius() as i32,
+            || crate::services::config_manager::ConfigManager::global().bar_outline_visible(),
+        );
     }
 
     /// Apply blur regions for individual widget islands on a transparent bar.
@@ -911,9 +950,11 @@ impl BackgroundEffectManager {
         let radius =
             crate::services::config_manager::ConfigManager::global().widget_border_radius() as i32;
 
+        let outline_visible =
+            crate::services::config_manager::ConfigManager::global().widget_outline_visible();
         let region = compositor.create_region(&self.qh, ());
         for &(x, y, w, h) in islands {
-            add_rounded_rect_to_region(&region, x, y, w, h, radius);
+            add_rounded_rect_to_region_with_outline(&region, x, y, w, h, radius, outline_visible);
         }
 
         effect.set_blur_region(Some(&region));
@@ -1013,13 +1054,14 @@ impl BackgroundEffectManager {
         let y = margin_top as f64 + dy;
 
         let region = compositor.create_region(&self.qh, ());
-        add_rounded_rect_to_region(
+        add_rounded_rect_to_region_with_outline(
             &region,
             x.round() as i32,
             y.round() as i32,
             scaled_w.round() as i32,
             scaled_h.round() as i32,
             radius,
+            crate::services::config_manager::ConfigManager::global().surface_outline_visible(),
         );
 
         effect.set_blur_region(Some(&region));
@@ -1076,6 +1118,18 @@ impl BackgroundEffectManager {
         content: &impl gtk4::prelude::IsA<gtk4::Widget>,
         radius_fn: impl Fn() -> i32 + Clone + 'static,
     ) {
+        self.apply_blur_surface_with_outline(surface_root, content, radius_fn, || {
+            crate::services::config_manager::ConfigManager::global().surface_outline_visible()
+        });
+    }
+
+    fn apply_blur_surface_with_outline(
+        &self,
+        surface_root: &impl gtk4::prelude::IsA<gtk4::Widget>,
+        content: &impl gtk4::prelude::IsA<gtk4::Widget>,
+        radius_fn: impl Fn() -> i32 + Clone + 'static,
+        outline_visible_fn: impl Fn() -> bool + Clone + 'static,
+    ) {
         let Some(info) = SurfaceInfo::from_widget(surface_root) else {
             debug!("apply_blur_surface: no wl_surface, skipping");
             return;
@@ -1103,7 +1157,12 @@ impl BackgroundEffectManager {
             // Install a resize watcher so we re-try once the surface gets a
             // real size.  The watcher also handles subsequent resizes after
             // the initial apply succeeds.
-            Self::install_surface_resize_watcher(surface_root_widget, content_widget, radius_fn);
+            Self::install_surface_resize_watcher(
+                surface_root_widget,
+                content_widget,
+                radius_fn,
+                outline_visible_fn,
+            );
             return;
         }
 
@@ -1119,7 +1178,15 @@ impl BackgroundEffectManager {
 
         let region = compositor.create_region(&self.qh, ());
         let radius = radius_fn();
-        add_rounded_rect_to_region(&region, bx, by, bw, bh, radius);
+        add_rounded_rect_to_region_with_outline(
+            &region,
+            bx,
+            by,
+            bw,
+            bh,
+            radius,
+            outline_visible_fn(),
+        );
 
         effect.set_blur_region(Some(&region));
         region.destroy();
@@ -1136,7 +1203,12 @@ impl BackgroundEffectManager {
         // surface dimensions change after initial layout.  The idempotency
         // guard inside ensures this is a no-op when the deferred path
         // already installed one.
-        Self::install_surface_resize_watcher(surface_root_widget, content_widget, radius_fn);
+        Self::install_surface_resize_watcher(
+            surface_root_widget,
+            content_widget,
+            radius_fn,
+            outline_visible_fn,
+        );
 
         debug!(
             "Applied blur surface: {}x{} at ({},{}) r={} (surface {}x{})",
@@ -1147,7 +1219,7 @@ impl BackgroundEffectManager {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_rounded_rect_rects;
+    use super::{compute_rounded_rect_rects, compute_rounded_rect_rects_with_corner_inset};
 
     /// Helper: compute total pixel area covered by non-overlapping scanline rects.
     fn total_area(rects: &[(i32, i32, i32, i32)]) -> i64 {
@@ -1304,6 +1376,33 @@ mod tests {
                     "overlap detected for {w}x{h} r={radius}: sum={sum_area} pixels={pixel_count}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn zero_corner_inset_matches_default_rasterization() {
+        let default = compute_rounded_rect_rects(3, 7, 40, 24, 8);
+        let inset_zero = compute_rounded_rect_rects_with_corner_inset(3, 7, 40, 24, 8, 0);
+        assert_eq!(default, inset_zero);
+    }
+
+    #[test]
+    fn corner_inset_trims_only_corner_scanlines() {
+        let base = compute_rounded_rect_rects(0, 0, 40, 30, 8);
+        let inset = compute_rounded_rect_rects_with_corner_inset(0, 0, 40, 30, 8, 1);
+
+        assert_eq!(base.len(), inset.len());
+        assert_eq!(base[0], inset[0], "central rect should remain unchanged");
+
+        for (before, after) in base.iter().skip(1).zip(inset.iter().skip(1)) {
+            assert_eq!(before.1, after.1, "y should not move");
+            assert_eq!(before.3, after.3, "scanline height should stay 1");
+            assert!(after.0 >= before.0, "left edge should move inward or stay");
+            assert!(
+                after.0 + after.2 <= before.0 + before.2,
+                "right edge should move inward or stay"
+            );
+            assert!(after.2 > 0, "scanline width must stay positive");
         }
     }
 

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -400,6 +400,9 @@ fn add_rounded_rect_to_region_with_outline(
     radius: i32,
     outline_visible: bool,
 ) {
+    // 1px inset hides the staircase artifact at the anti-aliased rounded-corner
+    // edge. This doesn't scale with outline_width — the artifact is always at the
+    // outermost sub-pixel row; wider outlines simply cover more area inward.
     let corner_inset = if outline_visible { 1 } else { 0 };
     for (rx, ry, rw, rh) in
         compute_rounded_rect_rects_with_corner_inset(x, y, width, height, radius, corner_inset)

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -251,6 +251,24 @@ impl ConfigManager {
         self.palette.borrow().widget_border_radius
     }
 
+    /// Whether the bar outline is effectively visible.
+    pub fn bar_outline_visible(&self) -> bool {
+        let palette = self.palette.borrow();
+        palette.bar_outline_enabled && palette.outline_width_px > 0
+    }
+
+    /// Whether widget island outlines are effectively visible.
+    pub fn widget_outline_visible(&self) -> bool {
+        let palette = self.palette.borrow();
+        palette.widget_outline_enabled && palette.outline_width_px > 0
+    }
+
+    /// Whether floating surface outlines are effectively visible.
+    pub fn surface_outline_visible(&self) -> bool {
+        let palette = self.palette.borrow();
+        palette.surface_outline_enabled && palette.outline_width_px > 0
+    }
+
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).
     ///
     /// This is derived from the widget border radius configuration.
@@ -933,10 +951,12 @@ fn config_theme_changed(old: &Config, new: &Config) -> bool {
         || old.bar.background_opacity != new.bar.background_opacity
         || old.bar.border_radius != new.bar.border_radius
         || old.bar.size != new.bar.size
+        || old.bar.outline != new.bar.outline
         || old.widgets.background_color != new.widgets.background_color
         || old.widgets.background_opacity != new.widgets.background_opacity
         || old.widgets.popover_background_opacity != new.widgets.popover_background_opacity
         || old.widgets.border_radius != new.widgets.border_radius
+        || old.widgets.outline != new.widgets.outline
         || old.advanced.pango_font_rendering != new.advanced.pango_font_rendering
         // Per-widget style overrides (background_color, etc.)
         || per_widget_styles_changed(old, new)
@@ -1173,6 +1193,34 @@ mod tests {
 
         let mut new = old.clone();
         new.widgets.popover_background_opacity = Some(0.9);
+        assert!(config_theme_changed(&old, &new));
+    }
+
+    #[test]
+    fn test_config_theme_changed_detects_bar_outline_override() {
+        // bar.outline = Option<bool> override; toggling it must trigger a
+        // theme reload so the bar's --bar-outline-width updates live.
+        let old = Config::default();
+
+        let mut new = old.clone();
+        new.bar.outline = Some(true);
+        assert!(config_theme_changed(&old, &new));
+
+        let mut new = old.clone();
+        new.bar.outline = Some(false);
+        assert!(config_theme_changed(&old, &new));
+    }
+
+    #[test]
+    fn test_config_theme_changed_detects_widgets_outline_override() {
+        let old = Config::default();
+
+        let mut new = old.clone();
+        new.widgets.outline = Some(true);
+        assert!(config_theme_changed(&old, &new));
+
+        let mut new = old.clone();
+        new.widgets.outline = Some(false);
         assert!(config_theme_changed(&old, &new));
     }
 

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -254,19 +254,25 @@ impl ConfigManager {
     /// Whether the bar outline is effectively visible.
     pub fn bar_outline_visible(&self) -> bool {
         let palette = self.palette.borrow();
-        palette.bar_outline_enabled && palette.outline_width_px > 0
+        palette.bar_outline_enabled
+            && palette.outline_width_px > 0
+            && palette.outline_opacity_pct > 0
     }
 
     /// Whether widget island outlines are effectively visible.
     pub fn widget_outline_visible(&self) -> bool {
         let palette = self.palette.borrow();
-        palette.widget_outline_enabled && palette.outline_width_px > 0
+        palette.widget_outline_enabled
+            && palette.outline_width_px > 0
+            && palette.outline_opacity_pct > 0
     }
 
     /// Whether floating surface outlines are effectively visible.
     pub fn surface_outline_visible(&self) -> bool {
         let palette = self.palette.borrow();
-        palette.surface_outline_enabled && palette.outline_width_px > 0
+        palette.surface_outline_enabled
+            && palette.outline_width_px > 0
+            && palette.outline_opacity_pct > 0
     }
 
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -405,7 +405,7 @@ popover.widget-menu.background > contents {{
     background-color: transparent;
     background: transparent;
     background-image: none;
-    border: none;
+    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
     border-radius: {radius};
     font-family: {font};
     font-size: var(--font-size);
@@ -472,6 +472,7 @@ popover.widget-menu.background * {{
 {selector} {{
     background-color: {bg};
     background-image: none;
+    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
     border-radius: {radius};
     font-family: {font};
     font-size: var(--font-size);

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -56,6 +56,7 @@ sectioned-bar.bar {{
     padding-top: var(--bar-padding-y);
     padding-bottom: var(--bar-padding-y-bottom);
     background: var(--color-background-bar);
+    border: var(--bar-outline-width) solid color-mix(in srgb, var(--bar-outline-color) var(--bar-outline-opacity), transparent);
     border-radius: var(--radius-bar);
     font-family: var(--font-family);
     font-size: var(--font-size);
@@ -71,6 +72,7 @@ sectioned-bar.bar {{
 /* Widget — visual surface */
 .widget {{
     background-color: {widget_bg};
+    border: var(--widget-outline-width) solid color-mix(in srgb, var(--widget-outline-color) var(--widget-outline-opacity), transparent);
     border-radius: var(--radius-widget);
 }}
 
@@ -112,6 +114,7 @@ sectioned-bar.bar {{
 .widget-group > .content > .widget-item > .widget {{
     background-color: transparent;
     box-shadow: none;
+    border: none;
 }}
 
 /* Halve the visible inter-item gap at every seam inside a group. Each

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -122,6 +122,7 @@ label link:active {{
 /* color-mix() is inline here so per-widget popover --widget-background-color overrides work via CSS scoping */
 .vp-surface-popover {{
     background-color: {popover_bg};
+    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
     border-radius: var(--radius-surface);
     box-shadow: var(--shadow-soft);
     padding: 16px;


### PR DESCRIPTION
Adds an optional CSS border (outline) around the bar, widgets, and surfaces. 
<img width="232" height="68" alt="image" src="https://github.com/user-attachments/assets/efc9ecf3-68bd-4586-af08-dc26a8cc7432" />

This serves two purposes: the first is purely aesthetic, some people prefer the look and I want to expose it from toml rather than just CSS.  

The second is to hide jagged compositor blur edges at rounded corners, since wl_region only supports axis-aligned rectangles, the blur isn't as nicely rounded and creates a staircase effect. When an outline is active, the blur region is trimmed by 1px at corners so the jagged edges hide behind the border.
<img width="59" height="57" alt="screenshot-2026-05-02_13-14-13" src="https://github.com/user-attachments/assets/458f3702-39b3-4781-be19-169e305a5a95" />
<img width="64" height="63" alt="screenshot-2026-05-02_13-13-30" src="https://github.com/user-attachments/assets/3a82d6e3-6c36-4e7f-8137-8511b6dca87a" />

Config:
```toml
[theme]
outline = true              # default: false
outline_width = 1           # 0-4, default: 1
outline_color = "accent"    # "accent", "foreground", "subtle" or hex, default "accent"
outline_opacity = 0.5       # 0.0-1.0, default: 1.0

[bar]
outline = true              # override theme default (optional)

[widgets]
outline = false             # override theme default (optional)

[widgets.battery]
outline_color = "foreground" # per-widget color override
```

CSS variables: `--outline-width`, `--outline-color`, `--outline-opacity` at `:root`, plus per-scope `--bar-outline-width`, `--widget-outline-width`, `--surface-outline-width` that resolve to `var(--outline-width)` or 0px

Per surface override other than bar/widget is excluded in v1