### PR TITLE
fix(widgets): outline scalebox animation

### DIFF
--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -25,10 +25,10 @@ const SUBTLE_MULTIPLIER: f64 = 0.5;
 const CLICK_CATCHER_OPACITY: f64 = 0.005;
 
 // Border opacities (subtle borders that don't compete with content)
-const BORDER_OPACITY_DARK: f64 = 0.10;
-const BORDER_OPACITY_LIGHT: f64 = 0.12;
+pub const BORDER_OPACITY_DARK: f64 = 0.10;
+pub const BORDER_OPACITY_LIGHT: f64 = 0.12;
 // GTK mode: average of dark/light since we can't know the theme at build time
-const BORDER_OPACITY_GTK: f64 = 0.11;
+pub const BORDER_OPACITY_GTK: f64 = 0.11;
 
 // Shadow configuration (layered shadows for natural look)
 const SHADOW_OPACITY_DARK: f64 = 0.40;

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -25,11 +25,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use gtk4::glib;
+use gtk4::{glib, prelude::*};
 use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
 use std::collections::HashSet;
 use tracing::{debug, error, info, warn};
 
+use vibepanel_core::theme::{BORDER_OPACITY_DARK, BORDER_OPACITY_GTK, BORDER_OPACITY_LIGHT};
 use vibepanel_core::{Config, ThemePalette, ThemeSizes};
 
 use super::callbacks::{CallbackId, Callbacks};
@@ -269,10 +270,109 @@ impl ConfigManager {
 
     /// Whether floating surface outlines are effectively visible.
     pub fn surface_outline_visible(&self) -> bool {
+        self.surface_outline_width() > 0.0
+    }
+
+    /// Resolve the current floating-surface outline as a concrete RGBA color.
+    ///
+    /// Custom GSK drawing cannot consume CSS variables or `color-mix()` tokens,
+    /// so this mirrors the supported `outline_color` symbolic values with the
+    /// already-computed palette colors. Per-widget overrides from
+    /// `[widgets.<name>]` take precedence over the global `theme.outline_color`.
+    /// This mirrors config/palette-driven outlines, not arbitrary user CSS overrides.
+    pub fn surface_outline_rgba_for_widget(
+        &self,
+        widget_name: &str,
+        widget: &impl IsA<gtk4::Widget>,
+    ) -> gtk4::gdk::RGBA {
+        let config = self.config.borrow();
+        let color = config
+            .widgets
+            .get_options(widget_name)
+            .and_then(|opts| opts.outline_color.as_deref())
+            .unwrap_or(&config.theme.outline_color)
+            .to_owned();
+        let alpha = (config.theme.outline_opacity as f32).clamp(0.0, 1.0);
+        drop(config);
+
+        self.resolve_outline_rgba(&color, alpha, widget)
+    }
+
+    fn resolve_outline_rgba(
+        &self,
+        color: &str,
+        alpha: f32,
+        widget: &impl IsA<gtk4::Widget>,
+    ) -> gtk4::gdk::RGBA {
+        let palette = self
+            .popover_palette
+            .borrow()
+            .clone()
+            .unwrap_or_else(|| self.palette.borrow().clone());
+        let is_subtle = color == "subtle";
+        let color = match color {
+            "subtle" => palette.border_subtle.as_str(),
+            "accent" => palette.accent_primary.as_str(),
+            "foreground" => palette.foreground_primary.as_str(),
+            value => value,
+        };
+
+        gtk4::gdk::RGBA::parse(color)
+            .map(|rgba| rgba.with_alpha(rgba.alpha() * alpha))
+            .unwrap_or_else(|_| {
+                // GTK mode stores some palette colors as CSS tokens. Resolve
+                // simple named colors through the widget style context so the
+                // animated outline matches the resting CSS outline.
+                if let Some(name) = color.strip_prefix('@') {
+                    // GTK4 has no non-deprecated replacement for resolving
+                    // runtime @token colors from the active theme.
+                    #[allow(deprecated)]
+                    if let Some(rgba) = widget.style_context().lookup_color(name) {
+                        return rgba.with_alpha(rgba.alpha() * alpha);
+                    }
+                }
+
+                if is_subtle && palette.is_gtk_mode {
+                    // Same GTK4 limitation as above, but `subtle` stores this
+                    // inside a color-mix() expression instead of a bare token.
+                    #[allow(deprecated)]
+                    if let Some(rgba) = widget.style_context().lookup_color("window_fg_color") {
+                        return rgba.with_alpha(rgba.alpha() * alpha * BORDER_OPACITY_GTK as f32);
+                    }
+                }
+
+                let fallback = if palette.is_dark_mode {
+                    gtk4::gdk::RGBA::WHITE
+                } else {
+                    gtk4::gdk::RGBA::BLACK
+                };
+                // GTK color-mix() values such as the subtle outline are not
+                // parseable here; approximate the baked-in non-GTK subtle alpha.
+                let subtle_factor = if is_subtle {
+                    if palette.is_dark_mode {
+                        BORDER_OPACITY_DARK as f32
+                    } else {
+                        BORDER_OPACITY_LIGHT as f32
+                    }
+                } else {
+                    1.0
+                };
+                fallback.with_alpha(alpha * subtle_factor)
+            })
+    }
+
+    /// Effective floating-surface outline width in logical pixels.
+    /// Width is palette-independent; only outline color follows the popover palette.
+    pub fn surface_outline_width(&self) -> f32 {
         let palette = self.palette.borrow();
-        palette.surface_outline_enabled
+        if palette.surface_outline_enabled
             && palette.outline_width_px > 0
             && palette.outline_opacity_pct > 0
+        {
+            palette.outline_width_px as f32
+        } else {
+            0.0
+        }
     }
 
     /// Get the pill radius (used for rounded indicators, thumbnails, etc.).

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -14,8 +14,10 @@ use gtk4::prelude::*;
 use tracing::debug;
 use vibepanel_core::SurfaceStyles;
 
+use crate::services::config_manager::ConfigManager;
 use crate::styles::{icon, surface};
 use crate::widgets::css::{POPOVER_BG_WITH_OPACITY, WIDGET_BG_WITH_OPACITY};
+use crate::widgets::scale_box::ScaleBox;
 
 // GTK 4.10 deprecated widget-scoped style contexts but didn't provide a replacement.
 // We need widget-scoped CSS to style individual surfaces without affecting the entire
@@ -162,6 +164,37 @@ impl SurfaceStyleManager {
         } else {
             0
         }
+    }
+
+    /// Apply the temporary ScaleBox outline used while floating surfaces animate.
+    ///
+    /// The real CSS border is suppressed only when there is a GSK outline to
+    /// draw, so disabled outlines keep their normal resting CSS appearance.
+    pub fn apply_animated_surface_outline(
+        &self,
+        shell: &ScaleBox,
+        widget_name: &str,
+        active: bool,
+    ) {
+        let config = ConfigManager::global();
+        let width = config.surface_outline_width();
+        let color = if active && width > 0.0 {
+            debug_assert!(
+                shell.child_has_css_class(surface::SURFACE_POPOVER),
+                "animated surface outline suppression expects a popover surface child"
+            );
+            config.surface_outline_rgba_for_widget(widget_name, shell)
+        } else {
+            gtk4::gdk::RGBA::TRANSPARENT
+        };
+
+        shell.set_animated_outline(
+            active,
+            config.surface_border_radius() as f32,
+            width,
+            color,
+            surface::SUPPRESS_CSS_OUTLINE,
+        );
     }
 
     /// Apply shadow-aware margins to a popover/overlay container.

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -697,6 +697,10 @@ pub mod surface {
     /// Deprecated: use [`POPOVER`]. Internal popover surface marker (`.vp-surface-popover`).
     pub const SURFACE_POPOVER: &str = "vp-surface-popover";
 
+    /// Temporarily hide the CSS-painted outline while `ScaleBox` draws it on
+    /// the moving clip boundary during grow animation.
+    pub const SUPPRESS_CSS_OUTLINE: &str = "vp-suppress-css-outline";
+
     /// Deprecated: use [`POPOVER`]. Popover styling (`.widget-menu`).
     ///
     /// Still applied to native `gtk4::Popover` shells for CSS reset rules

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -131,6 +131,11 @@ label link:active {{
     color: var(--color-foreground-primary);
 }}
 
+/* Mirrors the generated surface rule for static popover styles. */
+.vp-surface-popover.vp-suppress-css-outline {{
+    border-color: transparent;
+}}
+
 popover.widget-menu,
 box.popover-wrapper,
 box.widget-menu-wrapper {{

--- a/crates/vibepanel/src/widgets/css/quick_settings.rs
+++ b/crates/vibepanel/src/widgets/css/quick_settings.rs
@@ -16,11 +16,6 @@ window.quick-settings-window {{
     background: transparent;
 }}
 
-/* QS window container - internal padding between container edge and content */
-.qs-window-container {{
-    padding-top: 4px;
-}}
-
 /* Click catcher overlay */
 .vp-click-catcher {{
     background: var(--color-click-catcher-overlay);

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -170,6 +170,12 @@ impl AnimState {
     }
 }
 
+pub(crate) fn snap_anim_shell(shell: &ScaleBox, widget_name: &str, opacity: f64, scale: f64) {
+    shell.set_opacity(opacity);
+    shell.set_scale(scale);
+    SurfaceStyleManager::global().apply_animated_surface_outline(shell, widget_name, false);
+}
+
 /// Calculate the margin for a popover on the bar-adjacent edge.
 ///
 /// When the bar has a visible background (opacity > 0), the popover needs to
@@ -649,8 +655,7 @@ impl LayerShellPopover {
         // If animations are disabled, snap closed immediately.
         if !ConfigManager::global().animations_enabled() {
             if let Some(ref shell) = anim_shell {
-                shell.set_opacity(0.0);
-                shell.set_scale(ANIM_SCALE_FROM);
+                snap_anim_shell(shell, &self.widget_name, 0.0, ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             // No explicit blur removal needed — unmapping suspends
@@ -710,6 +715,13 @@ impl LayerShellPopover {
         }
 
         anim_shell.set_child(&content);
+        if self.anim_state.borrow().active {
+            SurfaceStyleManager::global().apply_animated_surface_outline(
+                &anim_shell,
+                &self.widget_name,
+                true,
+            );
+        }
 
         SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
     }
@@ -779,8 +791,7 @@ impl LayerShellPopover {
         {
             // Snap-close without animation to avoid recursion.
             if let Some(ref shell) = *self.anim_shell.borrow() {
-                shell.set_opacity(0.0);
-                shell.set_scale(ANIM_SCALE_FROM);
+                snap_anim_shell(shell, &self.widget_name, 0.0, ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             if let Some(ref window) = *self.window.borrow() {
@@ -889,8 +900,7 @@ impl LayerShellPopover {
                 } else {
                     // Animations disabled — snap open immediately.
                     if let Some(ref shell) = *popover.anim_shell.borrow() {
-                        shell.set_opacity(1.0);
-                        shell.set_scale(1.0);
+                        snap_anim_shell(shell, &popover.widget_name, 1.0, 1.0);
                     }
                 }
             }
@@ -1028,9 +1038,6 @@ impl LayerShellPopover {
             return;
         };
 
-        // Cache the current border radius for the duration of this animation.
-        anim_shell.set_radius(ConfigManager::global().surface_border_radius() as f32);
-
         let start_time_us = anim_shell
             .frame_clock()
             .map(|fc| fc.frame_time())
@@ -1043,6 +1050,15 @@ impl LayerShellPopover {
             anim_shell.opacity(),
         );
 
+        // Prepare first so reversal paths can reuse the existing tick callback;
+        // then ensure the current child has animation-outline styling even if no
+        // new callback is needed.
+        SurfaceStyleManager::global().apply_animated_surface_outline(
+            &anim_shell,
+            &self.widget_name,
+            true,
+        );
+
         if !need_tick {
             return;
         }
@@ -1052,6 +1068,7 @@ impl LayerShellPopover {
         let window = self.window.borrow().as_ref().cloned();
         let shell_for_scale = anim_shell.clone();
         let on_close = self.on_close.borrow().clone();
+        let widget_name = self.widget_name.clone();
 
         anim_shell.add_tick_callback(move |shell, frame_clock| {
             // Generation check — bail if a newer cycle started.
@@ -1093,8 +1110,7 @@ impl LayerShellPopover {
 
                 if direction == AnimDirection::Closing {
                     // Close complete — remove content and hide window.
-                    shell.set_opacity(0.0);
-                    shell_for_scale.set_scale(ANIM_SCALE_FROM);
+                    snap_anim_shell(&shell_for_scale, &widget_name, 0.0, ANIM_SCALE_FROM);
                     shell_for_scale.remove_child();
                     if let Some(ref w) = window {
                         w.set_visible(false);
@@ -1105,8 +1121,7 @@ impl LayerShellPopover {
                     }
                 } else {
                     // Open complete — ensure we're at exactly 1.0.
-                    shell.set_opacity(1.0);
-                    shell_for_scale.set_scale(1.0);
+                    snap_anim_shell(&shell_for_scale, &widget_name, 1.0, 1.0);
                 }
                 return ControlFlow::Break;
             }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -448,12 +448,10 @@ impl QuickSettingsWindow {
         outer.add_css_class(qs::WINDOW_CONTAINER);
         outer.add_css_class(surface::NO_FOCUS);
 
-        // Apply surface styles - background now controlled via CSS variables
         outer.add_css_class("quick-settings-popover");
         outer.add_css_class(surface::POPOVER);
         outer.add_css_class(surface::SURFACE_POPOVER);
         outer.add_css_class(surface::WIDGET_MENU);
-        SurfaceStyleManager::global().apply_surface_styles(&outer, true);
 
         let content = GtkBox::new(Orientation::Vertical, 0);
         content.add_css_class(qs::CONTROL_CENTER);

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -32,7 +32,7 @@ use crate::styles::{qs, state, surface};
 use crate::widgets::layer_shell_popover::{
     ANIM_SCALE_FROM, AnimDirection, AnimState, Dismissible, calculate_bar_exclusive_zone,
     calculate_popover_bar_margin, calculate_popover_right_margin, create_click_catcher,
-    is_keynav_key, popover_bar_edge, popover_keyboard_mode, setup_esc_handler,
+    is_keynav_key, popover_bar_edge, popover_keyboard_mode, setup_esc_handler, snap_anim_shell,
 };
 use crate::widgets::scale_box::ScaleBox;
 
@@ -111,6 +111,9 @@ const QUICK_SETTINGS_DEFAULT_RIGHT_MARGIN: i32 = 8;
 const CARD_ROW_SPACING: i32 = 8;
 const CARD_ROW_GAP: i32 = 8;
 const AUDIO_SECTION_TOP_MARGIN: i32 = 12;
+/// Config key for the quick-settings widget, used for per-widget
+/// outline_color overrides in the animated outline path.
+const QUICK_SETTINGS_WIDGET: &str = "quick_settings";
 
 /// Full Quick Settings window.
 ///
@@ -1459,8 +1462,7 @@ impl QuickSettingsWindow {
                     if ConfigManager::global().animations_enabled() {
                         qs.start_animation(AnimDirection::Opening, generation);
                     } else {
-                        qs.anim_shell.set_opacity(1.0);
-                        qs.anim_shell.set_scale(1.0);
+                        snap_anim_shell(&qs.anim_shell, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
                     }
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
@@ -1492,8 +1494,7 @@ impl QuickSettingsWindow {
                     if ConfigManager::global().animations_enabled() {
                         qs.start_animation(AnimDirection::Opening, generation);
                     } else {
-                        qs.anim_shell.set_opacity(1.0);
-                        qs.anim_shell.set_scale(1.0);
+                        snap_anim_shell(&qs.anim_shell, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
                     }
 
                     let snapshot = NetworkService::global().snapshot();
@@ -1616,8 +1617,12 @@ impl QuickSettingsWindow {
 
         if !ConfigManager::global().animations_enabled() {
             // Animations disabled — snap closed immediately.
-            self.anim_shell.set_opacity(0.0);
-            self.anim_shell.set_scale(ANIM_SCALE_FROM);
+            snap_anim_shell(
+                &self.anim_shell,
+                QUICK_SETTINGS_WIDGET,
+                0.0,
+                ANIM_SCALE_FROM,
+            );
             self.is_animating_out.set(false);
             self.reset_ui_state();
             // No explicit blur removal needed — unmapping suspends
@@ -1677,10 +1682,6 @@ impl QuickSettingsWindow {
     /// close), the current progress is captured and the animation reverses from
     /// that point with proportional timing — no snapping.
     fn start_animation(&self, direction: AnimDirection, generation: u32) {
-        // Cache the current border radius for the duration of this animation.
-        self.anim_shell
-            .set_radius(ConfigManager::global().surface_border_radius() as f32);
-
         let start_time_us = self
             .anim_shell
             .frame_clock()
@@ -1692,6 +1693,15 @@ impl QuickSettingsWindow {
             generation,
             start_time_us,
             self.anim_shell.opacity(),
+        );
+
+        // Prepare first so reversal paths can reuse the existing tick callback;
+        // then ensure the current child has animation-outline styling even if no
+        // new callback is needed.
+        SurfaceStyleManager::global().apply_animated_surface_outline(
+            &self.anim_shell,
+            QUICK_SETTINGS_WIDGET,
+            true,
         );
 
         if !need_tick {
@@ -1745,8 +1755,7 @@ impl QuickSettingsWindow {
                     anim_state.borrow_mut().active = false;
 
                     if direction == AnimDirection::Closing {
-                        shell.set_opacity(0.0);
-                        shell_clone.set_scale(ANIM_SCALE_FROM);
+                        snap_anim_shell(&shell_clone, QUICK_SETTINGS_WIDGET, 0.0, ANIM_SCALE_FROM);
                         if let Some(window) = window_weak.upgrade()
                             && let Some(qs) = get_qs_window_data(&window)
                         {
@@ -1755,8 +1764,7 @@ impl QuickSettingsWindow {
                             qs.window.set_visible(false);
                         }
                     } else {
-                        shell.set_opacity(1.0);
-                        shell_clone.set_scale(1.0);
+                        snap_anim_shell(&shell_clone, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
                     }
                     return ControlFlow::Break;
                 }

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -6,6 +6,10 @@
 //! without any scale transforms in the render tree (which are observed to
 //! cause unbounded memory growth in GTK4).
 //!
+//! `ScaleBox` can also draw an optional outline on the animated clip boundary.
+//! CSS borders live on the full-size child and would otherwise be clipped away
+//! until the final frame of the grow-in animation.
+//!
 //! Only calls `queue_draw()` on scale changes — no layout or CSS resolution.
 
 use gtk4::glib;
@@ -16,14 +20,28 @@ use std::cell::Cell;
 mod imp {
     use super::*;
 
-    #[derive(Default)]
     pub struct ScaleBox {
         /// Current scale factor (1.0 = normal size).
         pub(super) scale: Cell<f64>,
         /// Border radius for the rounded clip (pixels).
         pub(super) radius: Cell<f32>,
+        /// Optional animated outline width (pixels). 0 disables drawing.
+        pub(super) outline_width: Cell<f32>,
+        pub(super) outline_color: Cell<gtk4::gdk::RGBA>,
         /// The single child widget.
         pub(super) child: glib::WeakRef<gtk4::Widget>,
+    }
+
+    impl Default for ScaleBox {
+        fn default() -> Self {
+            Self {
+                scale: Cell::default(),
+                radius: Cell::default(),
+                outline_width: Cell::default(),
+                outline_color: Cell::new(gtk4::gdk::RGBA::TRANSPARENT),
+                child: glib::WeakRef::new(),
+            }
+        }
     }
 
     #[glib::object_subclass]
@@ -82,8 +100,15 @@ mod imp {
             let s = self.scale.get();
             let widget = self.obj();
 
-            if (s - 1.0).abs() < f64::EPSILON {
+            if s >= 1.0 {
                 widget.snapshot_child(&child, snapshot);
+                let rect = gtk4::graphene::Rect::new(
+                    0.0,
+                    0.0,
+                    widget.width() as f32,
+                    widget.height() as f32,
+                );
+                self.snapshot_outline(snapshot, rect, self.radius.get());
                 return;
             }
             if s <= 0.0 {
@@ -111,6 +136,32 @@ mod imp {
             snapshot.push_rounded_clip(&rounded);
             widget.snapshot_child(&child, snapshot);
             snapshot.pop();
+
+            self.snapshot_outline(snapshot, rect, radius);
+        }
+    }
+
+    impl ScaleBox {
+        fn snapshot_outline(
+            &self,
+            snapshot: &gtk4::Snapshot,
+            rect: gtk4::graphene::Rect,
+            radius: f32,
+        ) {
+            let width = self.outline_width.get();
+            let color = self.outline_color.get();
+            if width <= 0.0 || color.alpha() <= 0.0 {
+                return;
+            }
+
+            let outline = gtk4::gsk::RoundedRect::new(
+                rect,
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+                gtk4::graphene::Size::new(radius, radius),
+            );
+            snapshot.append_border(&outline, &[width; 4], &[color; 4]);
         }
     }
 }
@@ -141,7 +192,7 @@ impl ScaleBox {
     }
 
     /// Set the border radius used for the rounded clip (pixels).
-    pub fn set_radius(&self, radius: f32) {
+    fn set_radius(&self, radius: f32) {
         let imp = self.imp();
         if (imp.radius.get() - radius).abs() < f32::EPSILON {
             return;
@@ -150,14 +201,67 @@ impl ScaleBox {
         self.queue_draw();
     }
 
+    fn set_outline(&self, width: f32, color: gtk4::gdk::RGBA) {
+        let imp = self.imp();
+        let width = width.max(0.0);
+        let changed = (imp.outline_width.get() - width).abs() >= f32::EPSILON
+            || imp.outline_color.get() != color;
+        if !changed {
+            return;
+        }
+
+        imp.outline_width.set(width);
+        imp.outline_color.set(color);
+        self.queue_draw();
+    }
+
+    /// Toggle the outline used during scale-clip animations.
+    ///
+    /// CSS borders on the child remain at full child bounds, while this GSK
+    /// outline follows the animated clip. The child class temporarily hides
+    /// the duplicate CSS border during the handoff.
+    pub fn set_animated_outline(
+        &self,
+        active: bool,
+        radius: f32,
+        width: f32,
+        color: gtk4::gdk::RGBA,
+        suppress_child_class: &str,
+    ) {
+        let imp = self.imp();
+        self.set_radius(radius);
+
+        if !active || width <= 0.0 {
+            if let Some(child) = imp.child.upgrade() {
+                child.remove_css_class(suppress_child_class);
+            }
+            self.set_outline(0.0, gtk4::gdk::RGBA::TRANSPARENT);
+            return;
+        }
+
+        if let Some(child) = imp.child.upgrade() {
+            child.add_css_class(suppress_child_class);
+        }
+        self.set_outline(width, color);
+    }
+
+    /// Whether the managed child currently has `class`.
+    pub fn child_has_css_class(&self, class: &str) -> bool {
+        self.imp()
+            .child
+            .upgrade()
+            .is_some_and(|child| child.has_css_class(class))
+    }
+
     /// Set the scale factor and queue a repaint.
     /// Values below 1.0 crop edges inward; only calls `queue_draw()`.
     pub fn set_scale(&self, scale: f64) {
         let imp = self.imp();
+        let scale = scale.clamp(0.0, 1.0);
         if (imp.scale.get() - scale).abs() < f64::EPSILON {
             return;
         }
-        imp.scale.set(scale.clamp(0.0, 1.0));
+        imp.scale.set(scale);
         self.queue_draw();
     }
 


### PR DESCRIPTION
Since we don't use a CSS scale/transform animation when opening or closing a popover, the CSS outline could appear to "jump in" at the end of the animation when the popover reached its final size.

This PR makes `ScaleBox` draw a temporary outline during the animation when outlines are enabled. Once the popover is fully open, we hand off to the normal CSS border and remove the temporary animated outline.