### PR TITLE
fix(ui): use popover opacity for floating overlays

### DIFF
--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 use vibepanel_core::SurfaceStyles;
 
 use crate::services::config_manager::ConfigManager;
-use crate::styles::{icon, notification as notif, surface};
+use crate::styles::{icon, media, notification as notif, osd, surface};
 use crate::widgets::css::{POPOVER_BG_WITH_OPACITY, WIDGET_BG_WITH_OPACITY};
 use crate::widgets::scale_box::ScaleBox;
 
@@ -469,9 +469,10 @@ popover.widget-menu.background * {{
         } else {
             // Layer-shell popovers are GtkBox, not native Popover widgets.
             let is_popover_surface = widget.has_css_class(surface::POPOVER);
-            let is_toast_surface =
-                widget.has_css_class(notif::TOAST) || widget.has_css_class(notif::TOAST_CONTAINER);
-            let bg = if is_popover_surface || is_toast_surface {
+            let is_floating_surface = widget.has_css_class(notif::TOAST)
+                || widget.has_css_class(osd::OSD)
+                || widget.has_css_class(media::CONTENT);
+            let bg = if is_popover_surface || is_floating_surface {
                 POPOVER_BG_WITH_OPACITY
             } else {
                 WIDGET_BG_WITH_OPACITY


### PR DESCRIPTION
Toasts, OSD and media popout used to inherit opacity from widgets to create a uniform look, this is great until your run with:
```toml
[bar]
background_opacity = 0.5

[widgets]
background_opacity = 0.0
```

And your toasts and OSD become practically invisible except for the font... With popovers this has been fixed by making them get the highest opacity between bar and widget as well as a separate setting to control popover opacity.

This PR makes the other surfaces(Toasts, OSD, media popout) use the same opacity as popovers.

I know this is not the best long term solution and a more intuitive control is probably need but that will have to wait for larger config overhaul.