### PR TITLE
feat(audio): add overdrive setting to raise volume limits

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -96,6 +96,10 @@ enabled = true
 position = "bottom" # "bottom", "top", "left", "right"
 show_value = false  # Show current value after the bar
 
+[audio]
+# Allow output and microphone volume over 100% (over-amplification), capped at PulseAudio's recommended UI max.
+allow_overdrive = false
+
 [advanced]
 # compositor = "auto"  # "auto", "hyprland", "niri", "mango"
 

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -109,6 +109,9 @@ pub struct Config {
     /// On-screen display configuration.
     pub osd: OsdConfig,
 
+    /// Audio configuration.
+    pub audio: AudioConfig,
+
     /// Advanced configuration options.
     pub advanced: AdvancedConfig,
 }
@@ -568,6 +571,9 @@ impl Config {
             "  enabled: {}, position: {}, timeout: {}ms, show_value: {}",
             self.osd.enabled, self.osd.position, self.osd.timeout_ms, self.osd.show_value
         ));
+
+        lines.push("\nAudio:".to_string());
+        lines.push(format!("  allow_overdrive: {}", self.audio.allow_overdrive));
 
         lines.join("\n")
     }
@@ -1375,6 +1381,14 @@ impl Default for OsdConfig {
     }
 }
 
+/// Audio configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AudioConfig {
+    /// Allow output and microphone volume above 100%, capped at PulseAudio's recommended UI maximum.
+    pub allow_overdrive: bool,
+}
+
 /// Advanced configuration options.
 ///
 /// These settings are for power users and workarounds for specific
@@ -1422,6 +1436,7 @@ mod tests {
         assert_eq!(config.bar.screen_margin, 0);
         assert_eq!(config.bar.background_opacity, 0.0);
         assert_eq!(config.widgets.background_opacity, 1.0);
+        assert!(!config.audio.allow_overdrive);
         assert_eq!(config.advanced.compositor, "auto");
         assert_eq!(config.theme.mode, "auto");
         assert!(config.theme.accent.is_none());
@@ -1497,6 +1512,7 @@ mod tests {
 
         // Default values from embedded config should be inherited
         assert_eq!(config.bar.screen_margin, 0);
+        assert!(!config.audio.allow_overdrive);
 
         // Widgets should come from embedded defaults, not be empty
         assert!(
@@ -1559,6 +1575,17 @@ mod tests {
         assert_eq!(config.theme.icons.theme, "material");
         // bar.background_opacity comes from bar section defaults
         assert_eq!(config.bar.background_opacity, 0.0);
+    }
+
+    #[test]
+    fn test_load_with_defaults_audio_overdrive() {
+        let user_toml = r#"
+            [audio]
+            allow_overdrive = true
+        "#;
+
+        let config = Config::load_with_defaults(user_toml).unwrap();
+        assert!(config.audio.allow_overdrive);
     }
 
     #[test]

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -117,6 +117,49 @@ pub struct Config {
 }
 
 impl Config {
+    /// Best-effort loader for the standalone volume CLI's overdrive policy.
+    ///
+    /// Volume keybinds should stay reliable even when the full bar config is
+    /// invalid, so this reads only `[audio].allow_overdrive` and falls back to
+    /// `false` on any missing, unreadable, malformed, or wrongly typed value.
+    pub fn read_audio_allow_overdrive(explicit_path: Option<&Path>) -> bool {
+        fn read_policy(path: &Path) -> Option<bool> {
+            let contents = std::fs::read_to_string(path).ok()?;
+            let table = contents.parse::<Table>().ok()?;
+            table
+                .get("audio")
+                .and_then(|audio| audio.as_table())
+                .and_then(|audio| audio.get("allow_overdrive"))
+                .and_then(|value| value.as_bool())
+        }
+
+        if let Some(path) = explicit_path {
+            let policy = read_policy(path);
+            if policy.is_none() {
+                tracing::debug!(
+                    path = %path.display(),
+                    "using safe default audio policy for volume command"
+                );
+            }
+            return policy.unwrap_or(false);
+        }
+
+        for path in Self::config_search_paths() {
+            if path.exists() {
+                let policy = read_policy(&path);
+                if policy.is_none() {
+                    tracing::debug!(
+                        path = %path.display(),
+                        "using safe default audio policy for volume command"
+                    );
+                }
+                return policy.unwrap_or(false);
+            }
+        }
+
+        false
+    }
+
     /// Load configuration from an embedded default TOML string.
     pub fn from_default_toml() -> Result<Self> {
         let config: Config = toml::from_str(DEFAULT_CONFIG_TOML)?;

--- a/crates/vibepanel-core/tests/config_integration.rs
+++ b/crates/vibepanel-core/tests/config_integration.rs
@@ -309,3 +309,75 @@ fn test_validation_collects_multiple_errors() {
         "Should report osd.timeout_ms error"
     );
 }
+
+#[test]
+fn test_audio_overdrive_policy_explicit_true() {
+    let temp_dir = std::env::temp_dir().join("vibepanel_test_audio_policy_true");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let config_path = temp_dir.join("config.toml");
+    std::fs::write(&config_path, "[audio]\nallow_overdrive = true\n").unwrap();
+
+    assert!(Config::read_audio_allow_overdrive(Some(&config_path)));
+
+    std::fs::remove_dir_all(&temp_dir).unwrap();
+}
+
+#[test]
+fn test_audio_overdrive_policy_explicit_false() {
+    let temp_dir = std::env::temp_dir().join("vibepanel_test_audio_policy_false");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let config_path = temp_dir.join("config.toml");
+    std::fs::write(&config_path, "[audio]\nallow_overdrive = false\n").unwrap();
+
+    assert!(!Config::read_audio_allow_overdrive(Some(&config_path)));
+
+    std::fs::remove_dir_all(&temp_dir).unwrap();
+}
+
+#[test]
+fn test_audio_overdrive_policy_missing_or_invalid_falls_back() {
+    let temp_dir = std::env::temp_dir().join("vibepanel_test_audio_policy_invalid");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let missing_path = temp_dir.join("missing.toml");
+    assert!(!Config::read_audio_allow_overdrive(Some(&missing_path)));
+
+    let malformed_path = temp_dir.join("malformed.toml");
+    std::fs::write(&malformed_path, "this is not valid toml {{{{\n").unwrap();
+    assert!(!Config::read_audio_allow_overdrive(Some(&malformed_path)));
+
+    let missing_audio_path = temp_dir.join("missing-audio.toml");
+    std::fs::write(&missing_audio_path, "[bar]\nsize = 40\n").unwrap();
+    assert!(!Config::read_audio_allow_overdrive(Some(
+        &missing_audio_path
+    )));
+
+    let wrong_type_path = temp_dir.join("wrong-type.toml");
+    std::fs::write(&wrong_type_path, "[audio]\nallow_overdrive = \"yes\"\n").unwrap();
+    assert!(!Config::read_audio_allow_overdrive(Some(&wrong_type_path)));
+
+    std::fs::remove_dir_all(&temp_dir).unwrap();
+}
+
+#[test]
+fn test_audio_overdrive_policy_ignores_unrelated_validation_errors() {
+    let temp_dir = std::env::temp_dir().join("vibepanel_test_audio_policy_lenient");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let config_path = temp_dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[audio]\nallow_overdrive = true\n\n[theme]\nmode = \"invalid\"\n",
+    )
+    .unwrap();
+
+    assert!(Config::read_audio_allow_overdrive(Some(&config_path)));
+
+    std::fs::remove_dir_all(&temp_dir).unwrap();
+}

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -11,7 +11,7 @@ mod services;
 pub mod styles;
 mod widgets;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
@@ -19,6 +19,7 @@ use gtk4::Application;
 use gtk4::prelude::*;
 use tracing::{debug, error, info, warn};
 
+use services::audio::AudioService;
 use services::bar_manager;
 use vibepanel_core::{Config, logging};
 
@@ -112,10 +113,9 @@ enum BrightnessAction {
 enum VolumeAction {
     /// Get current volume percentage
     Get,
-    /// Set volume to a specific percentage (0-150)
+    /// Set volume to a specific percentage
     Set {
-        /// Volume percentage (0-150, values above 100 are overdrive)
-        #[arg(value_parser = clap::value_parser!(u32).range(0..=150))]
+        /// Volume percentage, clamped to the configured user-facing range
         percent: u32,
     },
     /// Increase volume by a percentage (default: 5)
@@ -188,14 +188,15 @@ enum PopoverAction {
 }
 
 fn main() -> ExitCode {
-    let args = Args::parse();
+    let mut args = Args::parse();
 
     // Initialize logging
     logging::init(args.verbose);
 
-    // Handle subcommands (these don't need config or GTK)
-    if let Some(command) = args.command {
-        return handle_command(command);
+    // CLI subcommands don't need GTK. Volume only needs the audio policy and can
+    // fall back safely if unrelated config is broken.
+    if let Some(command) = args.command.take() {
+        return handle_command(command, args.config.as_deref());
     }
 
     // Load configuration using XDG lookup chain
@@ -254,15 +255,34 @@ fn main() -> ExitCode {
 }
 
 /// Handle CLI subcommands (brightness, volume, etc.)
-fn handle_command(command: Command) -> ExitCode {
+fn handle_command(command: Command, config_path: Option<&Path>) -> ExitCode {
     match command {
         Command::Brightness { action } => handle_brightness_command(action),
-        Command::Volume { action } => handle_volume_command(action),
+        Command::Volume { action } => {
+            handle_volume_command(action, load_volume_allow_overdrive(config_path))
+        }
         Command::Inhibit { action } => handle_inhibit_command(action),
         Command::Media { action } => handle_media_command(action),
         Command::Bar { action } => handle_bar_command(action),
         Command::Popover { action } => handle_popover_command(action),
     }
+}
+
+fn load_volume_allow_overdrive(config_path: Option<&Path>) -> bool {
+    let load_result = match Config::find_and_load(config_path) {
+        Ok(result) => result,
+        Err(e) => {
+            warn!("using default audio policy for volume command: {}", e);
+            return false;
+        }
+    };
+
+    if let Err(e) = load_result.config.validate() {
+        warn!("using default audio policy for volume command: {}", e);
+        return false;
+    }
+
+    load_result.config.audio.allow_overdrive
 }
 
 /// Handle brightness subcommands using direct sysfs/logind access.
@@ -318,8 +338,8 @@ fn handle_brightness_command(action: BrightnessAction) -> ExitCode {
 }
 
 /// Handle volume subcommands using PulseAudio.
-fn handle_volume_command(action: VolumeAction) -> ExitCode {
-    use crate::services::audio::AudioCli;
+fn handle_volume_command(action: VolumeAction, allow_overdrive: bool) -> ExitCode {
+    use crate::services::audio::{AudioCli, volume_user_max_percent};
     use crate::services::ipc::{notify_volume, notify_volume_unavailable};
 
     /// Check if an error indicates the audio sink is unavailable for control.
@@ -328,7 +348,8 @@ fn handle_volume_command(action: VolumeAction) -> ExitCode {
         error.contains("not ready") || error.contains("no channels")
     }
 
-    let mut cli = match AudioCli::new() {
+    let user_max_percent = volume_user_max_percent(allow_overdrive);
+    let mut cli = match AudioCli::new(user_max_percent) {
         Some(c) => c,
         None => {
             eprintln!(
@@ -346,7 +367,7 @@ fn handle_volume_command(action: VolumeAction) -> ExitCode {
         VolumeAction::Set { percent } => {
             match cli.set_volume(percent) {
                 Ok(()) => {
-                    notify_volume(percent, cli.is_muted());
+                    notify_volume(cli.get_volume(), cli.is_muted());
                     ExitCode::SUCCESS
                 }
                 Err(e) if is_sink_unavailable_error(&e) => {
@@ -362,12 +383,12 @@ fn handle_volume_command(action: VolumeAction) -> ExitCode {
             }
         }
         VolumeAction::Inc { amount } => {
-            let current = cli.get_volume();
-            let new_value = (current + amount).min(150);
-            match cli.set_volume(new_value) {
+            let delta = amount.min(i32::MAX as u32) as i32;
+            match cli.set_volume_relative(delta) {
                 Ok(()) => {
-                    notify_volume(new_value, cli.is_muted());
-                    println!("{}", new_value);
+                    let actual = cli.get_volume();
+                    notify_volume(actual, cli.is_muted());
+                    println!("{}", actual);
                     ExitCode::SUCCESS
                 }
                 Err(e) if is_sink_unavailable_error(&e) => {
@@ -382,12 +403,12 @@ fn handle_volume_command(action: VolumeAction) -> ExitCode {
             }
         }
         VolumeAction::Dec { amount } => {
-            let current = cli.get_volume();
-            let new_value = current.saturating_sub(amount);
-            match cli.set_volume(new_value) {
+            let delta = -(amount.min(i32::MAX as u32) as i32);
+            match cli.set_volume_relative(delta) {
                 Ok(()) => {
-                    notify_volume(new_value, cli.is_muted());
-                    println!("{}", new_value);
+                    let actual = cli.get_volume();
+                    notify_volume(actual, cli.is_muted());
+                    println!("{}", actual);
                     ExitCode::SUCCESS
                 }
                 Err(e) if is_sink_unavailable_error(&e) => {
@@ -565,21 +586,23 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
         info!("Running with default configuration (no file found)");
     }
 
-    // Initialize the config manager singleton (before GTK, so it's ready for hot-reload)
-    ConfigManager::init_global(config.clone(), config_source.clone());
-
-    // Initialize the compositor manager singleton with advanced config
-    // This must happen after ConfigManager but before GTK widgets are created
-    CompositorManager::init_global(&config.advanced);
-
     // Default to Wayland backend
-    // SAFETY: This is called before GTK initialization, and we're setting a
-    // well-known environment variable. No other threads are accessing env vars yet.
+    // SAFETY: This is called before GTK initialization and before any service
+    // initialization that may spawn worker threads (for example AudioService).
+    // No other threads are accessing env vars yet.
     if std::env::var("GDK_BACKEND").is_err() {
         unsafe {
             std::env::set_var("GDK_BACKEND", "wayland");
         }
     }
+
+    // Initialize the config manager singleton (before GTK, so it's ready for hot-reload)
+    ConfigManager::init_global(config.clone(), config_source.clone());
+    AudioService::global().set_allow_overdrive(config.audio.allow_overdrive);
+
+    // Initialize the compositor manager singleton with advanced config
+    // This must happen after ConfigManager but before GTK widgets are created
+    CompositorManager::init_global(&config.advanced);
 
     let app = Application::builder()
         .application_id("io.github.vibepanel")

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -115,7 +115,7 @@ enum VolumeAction {
     Get,
     /// Set volume to a specific percentage
     Set {
-        /// Volume percentage, clamped to the configured user-facing range
+        /// Volume percentage, clamped to 100% unless audio overdrive is enabled in readable config
         percent: u32,
     },
     /// Increase volume by a percentage (default: 5)
@@ -259,30 +259,13 @@ fn handle_command(command: Command, config_path: Option<&Path>) -> ExitCode {
     match command {
         Command::Brightness { action } => handle_brightness_command(action),
         Command::Volume { action } => {
-            handle_volume_command(action, load_volume_allow_overdrive(config_path))
+            handle_volume_command(action, Config::read_audio_allow_overdrive(config_path))
         }
         Command::Inhibit { action } => handle_inhibit_command(action),
         Command::Media { action } => handle_media_command(action),
         Command::Bar { action } => handle_bar_command(action),
         Command::Popover { action } => handle_popover_command(action),
     }
-}
-
-fn load_volume_allow_overdrive(config_path: Option<&Path>) -> bool {
-    let load_result = match Config::find_and_load(config_path) {
-        Ok(result) => result,
-        Err(e) => {
-            warn!("using default audio policy for volume command: {}", e);
-            return false;
-        }
-    };
-
-    if let Err(e) = load_result.config.validate() {
-        warn!("using default audio policy for volume command: {}", e);
-        return false;
-    }
-
-    load_result.config.audio.allow_overdrive
 }
 
 /// Handle brightness subcommands using direct sysfs/logind access.
@@ -338,6 +321,9 @@ fn handle_brightness_command(action: BrightnessAction) -> ExitCode {
 }
 
 /// Handle volume subcommands using PulseAudio.
+///
+/// Volume commands are standalone media-key friendly operations: config errors
+/// must not fail the command, so unreadable policy safely caps controls at 100%.
 fn handle_volume_command(action: VolumeAction, allow_overdrive: bool) -> ExitCode {
     use crate::services::audio::{AudioCli, volume_user_max_percent};
     use crate::services::ipc::{notify_volume, notify_volume_unavailable};

--- a/crates/vibepanel/src/services/audio.rs
+++ b/crates/vibepanel/src/services/audio.rs
@@ -46,7 +46,7 @@ use pulse::proplist::Proplist;
 use pulse::volume::Volume;
 
 /// Information about an audio sink (output device).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkInfoSnapshot {
     /// Internal PulseAudio name (used for set-default-sink).
     pub name: String,
@@ -62,7 +62,7 @@ pub struct SinkInfoSnapshot {
 }
 
 /// Information about an audio source (input device).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceInfoSnapshot {
     /// Internal PulseAudio name (used for set-default-source).
     pub name: String,
@@ -78,7 +78,7 @@ pub struct SourceInfoSnapshot {
 }
 
 /// Snapshot of audio service state for callbacks.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AudioSnapshot {
     /// Current volume as a percentage, where values above 100 are overdrive.
     pub volume: u32,
@@ -526,46 +526,8 @@ impl AudioService {
             mic_control_available: update.mic_control_available,
         };
 
-        // Check if anything actually changed.
-        {
-            let current = self.current.borrow();
-            if current.volume == new_snapshot.volume
-                && current.muted == new_snapshot.muted
-                && current.mic_muted == new_snapshot.mic_muted
-                && current.mic_volume == new_snapshot.mic_volume
-                && current.default_sink_name == new_snapshot.default_sink_name
-                && current.default_source_name == new_snapshot.default_source_name
-                && current.available == new_snapshot.available
-                && current.control_available == new_snapshot.control_available
-                && current.mic_control_available == new_snapshot.mic_control_available
-                && current.sinks.len() == new_snapshot.sinks.len()
-                && current.sources.len() == new_snapshot.sources.len()
-            {
-                // Sinks list length is the same; check if contents differ.
-                let sinks_equal =
-                    current
-                        .sinks
-                        .iter()
-                        .zip(new_snapshot.sinks.iter())
-                        .all(|(a, b)| {
-                            a.name == b.name
-                                && a.is_default == b.is_default
-                                && a.port_available == b.port_available
-                        });
-                let sources_equal =
-                    current
-                        .sources
-                        .iter()
-                        .zip(new_snapshot.sources.iter())
-                        .all(|(a, b)| {
-                            a.name == b.name
-                                && a.is_default == b.is_default
-                                && a.port_available == b.port_available
-                        });
-                if sinks_equal && sources_equal {
-                    return;
-                }
-            }
+        if *self.current.borrow() == new_snapshot {
+            return;
         }
 
         // Update state and mark as ready.

--- a/crates/vibepanel/src/services/audio.rs
+++ b/crates/vibepanel/src/services/audio.rs
@@ -80,13 +80,13 @@ pub struct SourceInfoSnapshot {
 /// Snapshot of audio service state for callbacks.
 #[derive(Debug, Clone)]
 pub struct AudioSnapshot {
-    /// Current volume as a percentage (0–150, allowing overdrive).
+    /// Current volume as a percentage, where values above 100 are overdrive.
     pub volume: u32,
     /// Whether the default sink is muted.
     pub muted: bool,
     /// Whether the default source (mic) is muted, if available.
     pub mic_muted: Option<bool>,
-    /// Current mic volume as a percentage (0–150), if available.
+    /// Current mic volume as a percentage, if available.
     pub mic_volume: Option<u32>,
     /// List of available sinks.
     pub sinks: Vec<SinkInfoSnapshot>,
@@ -147,22 +147,22 @@ impl AudioSnapshot {
 /// Commands sent from the main thread to the Pulse worker thread.
 ///
 /// These commands are processed asynchronously by the PulseAudio worker thread.
-/// Volume operations are clamped to [0, 150] before being sent.
+/// User-facing volume operations are clamped before being sent.
 #[derive(Debug)]
 enum AudioCommand {
-    /// Set volume to an absolute percentage (0–150).
+    /// Set volume to an absolute percentage.
     ///
-    /// Values are clamped to [0, 150] before sending. Values above 100 represent
-    /// overdrive/amplification. The command is silently ignored if no default
-    /// sink is available or if the sink's control is unavailable (e.g., 0 channels).
+    /// Values are clamped to the configured user-facing range before sending. The command is
+    /// silently ignored if no default sink is available or if the sink's control is unavailable
+    /// (e.g., 0 channels).
     SetVolume(u32),
 
-    /// Adjust volume relative to the current level.
+    /// Adjust output volume relative to the worker's latest known state.
     ///
-    /// The delta is added to the current volume percentage. The result is clamped
-    /// to [0, 150]. Positive values increase volume, negative values decrease it.
-    /// Example: `SetVolumeRelative(-5)` decreases volume by 5 percentage points.
-    SetVolumeRelative(i32),
+    /// Used by UI scroll controls so queued deltas compose deterministically while staying inside
+    /// the UI volume range. If the current volume is above `max_percent`, negative deltas snap back
+    /// to `max_percent` before applying further decreases.
+    SetVolumeRelative { delta: i32, max_percent: u32 },
 
     /// Set the mute state for the default audio output sink.
     ///
@@ -176,9 +176,9 @@ enum AudioCommand {
     /// The UI is notified immediately for responsiveness.
     ToggleMute,
 
-    /// Set microphone volume to an absolute percentage (0–150).
+    /// Set microphone volume to an absolute percentage.
     ///
-    /// Values are clamped to [0, 150] before sending. Silently ignored if
+    /// Values are clamped to the configured user-facing range before sending. Silently ignored if
     /// no default source is available or if mic control is unavailable.
     SetMicVolume(u32),
 
@@ -230,6 +230,59 @@ enum AudioCommand {
     Shutdown,
 }
 
+fn volume_to_percent(volume: Volume) -> u32 {
+    ((volume.0 as f64 / Volume::NORMAL.0 as f64) * 100.0).round() as u32
+}
+
+pub(crate) fn volume_ui_max_percent() -> u32 {
+    // Keep the UI usable if a backend reports a UI max below normal volume.
+    volume_to_percent(Volume::ui_max()).max(100)
+}
+
+pub(crate) fn volume_user_max_percent(allow_overdrive: bool) -> u32 {
+    if allow_overdrive {
+        volume_ui_max_percent()
+    } else {
+        100
+    }
+}
+
+fn percent_to_valid_volume(percent: u32) -> Volume {
+    let raw = (Volume::NORMAL.0 as f64 * percent as f64 / 100.0).round() as u32;
+    Volume(raw.min(Volume::MAX.0))
+}
+
+pub(crate) fn valid_volume_percent(percent: u32) -> u32 {
+    volume_to_percent(percent_to_valid_volume(percent))
+}
+
+pub(crate) fn user_volume_percent(percent: u32, max_percent: u32) -> u32 {
+    valid_volume_percent(percent).min(max_percent)
+}
+
+/// Apply a relative volume change within the user-facing cap.
+///
+/// If the backend volume is already above the cap, upward changes are ignored
+/// and the first downward change snaps back to the cap instead of also applying
+/// the decrement.
+fn bounded_relative_volume_target(current: u32, delta: i32, max_percent: u32) -> Option<u32> {
+    if delta > 0 {
+        if current >= max_percent {
+            None
+        } else {
+            Some(current.saturating_add(delta as u32).min(max_percent))
+        }
+    } else if delta < 0 {
+        if current > max_percent {
+            Some(max_percent)
+        } else {
+            Some(current.saturating_sub(delta.unsigned_abs()))
+        }
+    } else {
+        None
+    }
+}
+
 /// Internal state update sent from the Pulse thread to the main thread.
 #[derive(Debug, Clone)]
 struct AudioStateUpdate {
@@ -258,6 +311,8 @@ pub struct AudioService {
     ready_at: Cell<Option<Instant>>,
     /// Sender for commands to the Pulse worker thread.
     command_tx: Sender<AudioCommand>,
+    /// Maximum percentage Vibepanel is allowed to request from user-facing controls.
+    user_max_percent: Cell<u32>,
 }
 
 impl AudioService {
@@ -271,6 +326,7 @@ impl AudioService {
             ready: Cell::new(false),
             ready_at: Cell::new(None),
             command_tx,
+            user_max_percent: Cell::new(100),
         });
 
         // State updates come back via glib::idle_add_once() - no polling needed.
@@ -351,18 +407,35 @@ impl AudioService {
         self.current.borrow().available
     }
 
-    /// Set volume as a percentage (0–150).
+    /// Configure the user-facing volume cap from audio settings.
+    pub fn set_allow_overdrive(&self, allow_overdrive: bool) {
+        let max_percent = volume_user_max_percent(allow_overdrive);
+        if self.user_max_percent.replace(max_percent) != max_percent {
+            let snapshot = self.current.borrow().clone();
+            self.callbacks.notify(&snapshot);
+        }
+    }
+
+    /// Current user-facing volume cap.
+    pub fn user_max_percent(&self) -> u32 {
+        self.user_max_percent.get()
+    }
+
+    /// Set volume as a percentage.
     ///
-    /// Values are clamped to [0, 150]. This method is efficient for rapid
-    /// calls (e.g., holding volume keys).
+    /// Clamps user-originated volume requests to the configured user-facing range.
+    /// This method is efficient for rapid calls (e.g., holding volume keys).
     pub fn set_volume(&self, percent: u32) {
-        let percent = percent.clamp(0, 150);
+        let percent = user_volume_percent(percent, self.user_max_percent());
         let _ = self.command_tx.send(AudioCommand::SetVolume(percent));
     }
 
-    /// Adjust volume by a relative amount (e.g., +5 or -5 percentage points).
+    /// Adjust output volume relative to the worker's latest known state.
     pub fn set_volume_relative(&self, delta: i32) {
-        let _ = self.command_tx.send(AudioCommand::SetVolumeRelative(delta));
+        let max_percent = self.user_max_percent();
+        let _ = self
+            .command_tx
+            .send(AudioCommand::SetVolumeRelative { delta, max_percent });
     }
 
     /// Set the mute state for the default sink.
@@ -395,12 +468,12 @@ impl AudioService {
             .send(AudioCommand::SetDefaultSink(name.to_string()));
     }
 
-    /// Set mic volume as a percentage (0–150).
+    /// Set mic volume as a percentage.
     ///
-    /// Values are clamped to [0, 150]. This method is efficient for rapid
+    /// Values are clamped to the configured user-facing range. This method is efficient for rapid
     /// calls (e.g., dragging slider).
     pub fn set_mic_volume(&self, percent: u32) {
-        let percent = percent.clamp(0, 150);
+        let percent = user_volume_percent(percent, self.user_max_percent());
         let _ = self.command_tx.send(AudioCommand::SetMicVolume(percent));
     }
 
@@ -533,7 +606,7 @@ impl Drop for AudioService {
 #[derive(Default)]
 struct PulseWorkerState {
     // ===== Sink (Output Device) State =====
-    /// Current volume of the default sink as a percentage (0–150).
+    /// Current volume of the default sink as a percentage.
     ///
     /// Values above 100 represent overdrive/amplification. Updated whenever
     /// we receive sink info from PulseAudio. Not updated if the sink reports
@@ -589,7 +662,7 @@ struct PulseWorkerState {
     /// Once set, remains `Some` for the session lifetime.
     mic_muted: Option<bool>,
 
-    /// Current volume of the default source (microphone) as a percentage (0–150).
+    /// Current volume of the default source (microphone) as a percentage.
     ///
     /// `None` if we haven't yet received source info. Values above 100
     /// represent gain/amplification.
@@ -868,15 +941,16 @@ fn handle_command(
                 percent,
             );
         }
-        AudioCommand::SetVolumeRelative(delta) => {
+        AudioCommand::SetVolumeRelative { delta, max_percent } => {
             let current = state.lock().volume;
-            let new_volume = (current as i32 + delta).clamp(0, 150) as u32;
-            set_sink_volume(
-                Arc::clone(&mainloop),
-                Arc::clone(&context),
-                Arc::clone(&state),
-                new_volume,
-            );
+            if let Some(target) = bounded_relative_volume_target(current, delta, max_percent) {
+                set_sink_volume(
+                    Arc::clone(&mainloop),
+                    Arc::clone(&context),
+                    Arc::clone(&state),
+                    target,
+                );
+            }
         }
         AudioCommand::SetMuted(muted) => {
             set_sink_mute(
@@ -1348,7 +1422,7 @@ fn update_source_state(
     // Calculate volume as percentage (only if volume structure is valid)
     let volume_percent = if volume_valid && channel_count > 0 {
         let avg_volume = info.volume.avg();
-        ((avg_volume.0 as f64 / Volume::NORMAL.0 as f64) * 100.0).round() as u32
+        volume_to_percent(avg_volume)
     } else {
         st.mic_volume.unwrap_or(0) // Keep previous value if invalid
     };
@@ -1432,7 +1506,7 @@ fn update_sink_state(state: &Arc<Mutex<PulseWorkerState>>, info: &SinkInfo) {
     // Calculate volume as percentage (only if volume structure is valid)
     let volume_percent = if volume_valid && channel_count > 0 {
         let avg_volume = info.volume.avg();
-        ((avg_volume.0 as f64 / Volume::NORMAL.0 as f64) * 100.0).round() as u32
+        volume_to_percent(avg_volume)
     } else {
         st.volume // Keep previous value if invalid
     };
@@ -1554,8 +1628,8 @@ fn set_sink_volume(
     let ctx = context.lock();
     let mut introspect = ctx.introspect();
 
-    // Calculate the volume value.
-    let volume_value = Volume((Volume::NORMAL.0 as f64 * percent as f64 / 100.0) as u32);
+    let volume_value = percent_to_valid_volume(percent);
+    let percent = volume_to_percent(volume_value);
 
     // Use the actual channel count from the sink
     let mut cv = pulse::volume::ChannelVolumes::default();
@@ -1685,8 +1759,8 @@ fn set_source_volume(
     let ctx = context.lock();
     let mut introspect = ctx.introspect();
 
-    // Calculate the volume value.
-    let volume_value = Volume((Volume::NORMAL.0 as f64 * percent as f64 / 100.0) as u32);
+    let volume_value = percent_to_valid_volume(percent);
+    let percent = volume_to_percent(volume_value);
 
     // Use the actual channel count from the source
     let mut cv = pulse::volume::ChannelVolumes::default();
@@ -1773,13 +1847,15 @@ pub struct AudioCli {
     channel_count: u8,
     /// Whether volume control is currently available (sink not suspended).
     control_available: bool,
+    /// Maximum percentage Vibepanel CLI commands are allowed to request.
+    user_max_percent: u32,
 }
 
 impl AudioCli {
     /// Create a new CLI audio controller.
     ///
     /// Returns `None` if PulseAudio connection fails.
-    pub fn new() -> Option<Self> {
+    pub fn new(user_max_percent: u32) -> Option<Self> {
         let mut mainloop = StandardMainloop::new()?;
 
         let mut proplist = Proplist::new()?;
@@ -1830,6 +1906,7 @@ impl AudioCli {
             sink_index: None,
             channel_count: 2,         // Default to stereo, updated by refresh_state
             control_available: false, // Conservative default, updated by refresh_state
+            user_max_percent,
         };
 
         // Fetch initial state.
@@ -1848,7 +1925,7 @@ impl AudioCli {
         self.muted
     }
 
-    /// Set volume to a specific percentage (0-150).
+    /// Set volume to a specific percentage.
     pub fn set_volume(&mut self, percent: u32) -> Result<(), String> {
         let sink_index = self.sink_index.ok_or_else(|| {
             "no default sink found (is PulseAudio/pipewire-pulse running?)".to_string()
@@ -1866,12 +1943,11 @@ impl AudioCli {
             return Err("audio device not ready (try playing audio first)".to_string());
         }
 
-        let percent = percent.clamp(0, 150);
+        let percent = user_volume_percent(percent, self.user_max_percent);
 
         let mut introspect = self.context.introspect();
 
-        // Calculate the volume value.
-        let volume_value = Volume((Volume::NORMAL.0 as f64 * percent as f64 / 100.0) as u32);
+        let volume_value = percent_to_valid_volume(percent);
 
         // Use the actual channel count from the sink
         let mut cv = pulse::volume::ChannelVolumes::default();
@@ -1885,6 +1961,16 @@ impl AudioCli {
         // Update cached state.
         self.volume = percent;
 
+        Ok(())
+    }
+
+    /// Adjust volume relative to the current cached CLI state.
+    pub fn set_volume_relative(&mut self, delta: i32) -> Result<(), String> {
+        if let Some(target) =
+            bounded_relative_volume_target(self.volume, delta, self.user_max_percent)
+        {
+            self.set_volume(target)?;
+        }
         Ok(())
     }
 
@@ -1994,8 +2080,7 @@ impl AudioCli {
         introspect.get_sink_info_by_name(name, move |list_result| {
             if let ListResult::Item(info) = list_result {
                 let avg_volume = info.volume.avg();
-                let volume_percent =
-                    ((avg_volume.0 as f64 / Volume::NORMAL.0 as f64) * 100.0).round() as u32;
+                let volume_percent = volume_to_percent(avg_volume);
 
                 // Compute control_available using same logic as AudioService.
                 // We do NOT check sink state - suspended sinks still accept volume control.
@@ -2053,5 +2138,64 @@ impl AudioCli {
 impl Drop for AudioCli {
     fn drop(&mut self) {
         self.context.disconnect();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_to_valid_volume_maps_100_to_normal() {
+        assert_eq!(percent_to_valid_volume(100), Volume::NORMAL);
+    }
+
+    #[test]
+    fn percent_to_valid_volume_clamps_to_pulse_max() {
+        assert_eq!(percent_to_valid_volume(u32::MAX), Volume::MAX);
+    }
+
+    #[test]
+    fn volume_ui_max_percent_stays_within_valid_volume_range() {
+        let ui_max = volume_ui_max_percent();
+        assert!(ui_max >= 100);
+        assert!(ui_max <= valid_volume_percent(u32::MAX));
+    }
+
+    #[test]
+    fn volume_user_max_percent_respects_overdrive_flag() {
+        assert_eq!(volume_user_max_percent(false), 100);
+        assert_eq!(volume_user_max_percent(true), volume_ui_max_percent());
+    }
+
+    #[test]
+    fn valid_volume_percent_is_idempotent() {
+        for percent in [50, 100, 150, u32::MAX] {
+            let normalized = valid_volume_percent(percent);
+            assert_eq!(valid_volume_percent(normalized), normalized);
+        }
+    }
+
+    #[test]
+    fn user_volume_percent_caps_to_ui_max() {
+        let ui_max = volume_ui_max_percent();
+        assert_eq!(user_volume_percent(100, ui_max), 100);
+        assert_eq!(user_volume_percent(ui_max, ui_max), ui_max);
+        assert_eq!(
+            user_volume_percent(ui_max.saturating_add(1), ui_max),
+            ui_max
+        );
+        assert_eq!(user_volume_percent(u32::MAX, ui_max), ui_max);
+        assert_eq!(user_volume_percent(ui_max, 100), 100);
+    }
+
+    #[test]
+    fn bounded_relative_volume_target_respects_ui_cap() {
+        assert_eq!(bounded_relative_volume_target(50, 5, 153), Some(55));
+        assert_eq!(bounded_relative_volume_target(153, 5, 153), None);
+        assert_eq!(bounded_relative_volume_target(200, 5, 153), None);
+        assert_eq!(bounded_relative_volume_target(200, -5, 153), Some(153));
+        assert_eq!(bounded_relative_volume_target(50, -5, 153), Some(45));
+        assert_eq!(bounded_relative_volume_target(50, 0, 153), None);
     }
 }

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -45,6 +45,7 @@ const FILE_CHANGE_DEBOUNCE_MS: u64 = 300;
 const WALLPAPER_POLL_INTERVAL_SECS: u32 = 2;
 
 use crate::bar;
+use crate::services::audio::AudioService;
 use crate::services::bar_manager::BarManager;
 use crate::services::icons::IconsService;
 use crate::services::network::NetworkService;
@@ -750,6 +751,7 @@ impl ConfigManager {
     pub(crate) fn handle_config_message(self: &Rc<Self>, msg: ConfigMessage) {
         match msg {
             ConfigMessage::Reloaded(new_config) => {
+                AudioService::global().set_allow_overdrive(new_config.audio.allow_overdrive);
                 self.apply_config(*new_config);
             }
             ConfigMessage::Error(err) => {

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use tracing::trace;
 
-use crate::services::audio::AudioService;
+use crate::services::audio::{AudioService, valid_volume_percent};
 use crate::services::brightness::BrightnessService;
 use crate::services::callbacks::CallbackId;
 use crate::styles::{color, osd};
@@ -153,10 +153,13 @@ impl OsdWidget {
         &self.root
     }
 
-    pub fn set_value(&self, value: u32) {
-        let v = value.clamp(0, 100) as f64;
-        self.scale.set_value(v);
-        self.value_label.set_text(&(v as u32).to_string());
+    pub fn set_value(&self, value: u32, max_value: u32) {
+        let max_value = max_value.max(1);
+        // `max_value` is the recommended UI scale maximum. The actual audio
+        // value may exceed it; GTK saturates the bar while the label stays exact.
+        self.scale.set_range(0.0, max_value as f64);
+        self.scale.set_value(value as f64);
+        self.value_label.set_text(&value.to_string());
         // Show normal content, hide unavailable
         self.normal_content.set_visible(true);
         self.unavailable_content.set_visible(false);
@@ -294,9 +297,9 @@ impl OsdOverlay {
     }
 
     /// Show the overlay with a specific icon + value.
-    pub fn show_value(self: &Rc<Self>, icon_name: &str, value: u32) {
+    pub fn show_value(self: &Rc<Self>, icon_name: &str, value: u32, max_value: u32) {
         self.osd_widget.set_icon(icon_name);
-        self.osd_widget.set_value(value);
+        self.osd_widget.set_value(value, max_value);
 
         self.window.set_visible(true);
         self.reset_hide_timer();
@@ -313,11 +316,11 @@ impl OsdOverlay {
         } else {
             "display-brightness-high-symbolic"
         };
-        self.show_value(icon, value);
+        self.show_value(icon, value, 100);
     }
 
     /// Volume-specific helper: compute icon from volume/mute state and show.
-    pub fn show_volume(self: &Rc<Self>, volume: u32, muted: bool) {
+    pub fn show_volume(self: &Rc<Self>, volume: u32, muted: bool, max_volume: u32) {
         let icon = if muted || volume == 0 {
             "audio-volume-muted-symbolic"
         } else if volume < 33 {
@@ -327,8 +330,7 @@ impl OsdOverlay {
         } else {
             "audio-volume-high-symbolic"
         };
-        // Clamp to 100 for display, even though we allow overdrive internally.
-        self.show_value(icon, volume.min(100));
+        self.show_value(icon, volume, max_volume);
     }
 
     /// Show OSD indicating volume control is unavailable (device not ready).
@@ -523,7 +525,7 @@ impl OsdOverlay {
             return;
         }
 
-        self.show_volume(volume, muted);
+        self.show_volume(volume, muted, AudioService::global().user_max_percent());
     }
 
     // Public: IPC message handling (called by the panel-level IPC listener)
@@ -537,10 +539,11 @@ impl OsdOverlay {
         match msg {
             IpcMessage::Volume { percent, muted } => {
                 debug!("OSD: received volume {}% muted={}", percent, muted);
+                let percent = valid_volume_percent(*percent);
                 // Notify AudioService of the external volume request so
                 // behavioral detection can track whether the backend responded.
                 let audio = AudioService::global();
-                audio.note_external_volume_request(*percent);
+                audio.note_external_volume_request(percent);
 
                 // Check if control is available before showing normal volume OSD
                 let snapshot = audio.current();
@@ -548,7 +551,7 @@ impl OsdOverlay {
                     // Backend is up but not accepting volume changes
                     self.show_volume_unavailable();
                 } else {
-                    self.show_volume(*percent, *muted);
+                    self.show_volume(percent, *muted, AudioService::global().user_max_percent());
                 }
             }
             IpcMessage::VolumeUnavailable => {

--- a/crates/vibepanel/src/widgets/quick_settings/audio_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/audio_card.rs
@@ -111,7 +111,10 @@ pub fn build_audio_row() -> AudioRowWidgets {
     let result = SliderRow::builder()
         .icon("audio-volume-high-symbolic")
         .interactive_icon(true) // Mute button is clickable
-        .range(0.0, 100.0)
+        // The slider is an interactive control, so keep its range capped to
+        // what Vibepanel is allowed to request. Programmatic updates are
+        // guarded to avoid writing external over-cap values back to Pulse.
+        .range(0.0, AudioService::global().user_max_percent() as f64)
         .step(1.0)
         .with_expander(true) // Sink list expander
         .build();
@@ -124,6 +127,19 @@ pub fn build_audio_row() -> AudioRowWidgets {
         expander_button: result.expander_button.expect("expander requested"),
         arrow_handle: result.expander_icon.expect("expander requested"),
     }
+}
+
+/// Update the slider from the backend state without causing write-back.
+///
+/// External volume can exceed Vibepanel's configured cap, but this is an
+/// interactive control: keep the range capped to the values Vibepanel may
+/// request. GTK will visually saturate over-cap values at the maximum, while
+/// the tooltip preserves the true backend volume.
+pub fn set_volume_slider_display(slider: &Scale, volume: u32) {
+    let max_percent = AudioService::global().user_max_percent().max(1);
+    slider.set_range(0.0, max_percent as f64);
+    slider.set_value(volume as f64);
+    slider.set_tooltip_text(Some(&format!("{volume}%")));
 }
 
 /// Container for audio details (sink list) widgets.
@@ -318,7 +334,7 @@ pub fn on_audio_changed(state: &AudioCardState, snapshot: &AudioSnapshot) {
     // Update volume slider (with flag to prevent feedback loop)
     if let Some(slider) = state.slider.borrow().as_ref() {
         state.updating.set(true);
-        slider.set_value(snapshot.volume as f64);
+        set_volume_slider_display(slider, snapshot.volume);
         slider.set_sensitive(control_ok);
         state.updating.set(false);
     }
@@ -404,6 +420,7 @@ pub fn attach_volume_scroll_controller(widget: &impl IsA<gtk4::Widget>, step: i3
     scroll.connect_scroll(move |_controller, _dx, dy| {
         let snapshot = AudioService::global().current();
         if !snapshot.available || !snapshot.control_available {
+            accumulated.set(0.0);
             return gtk4::glib::Propagation::Proceed;
         }
 
@@ -417,9 +434,12 @@ pub fn attach_volume_scroll_controller(widget: &impl IsA<gtk4::Widget>, step: i3
 
         acc += dy;
 
+        let audio = AudioService::global();
+        let step = step.abs();
+
         while acc.abs() >= 1.0 {
             let direction = if acc < 0.0 { 1 } else { -1 };
-            AudioService::global().set_volume_relative(direction * step);
+            audio.set_volume_relative(direction * step);
             acc -= acc.signum();
         }
 

--- a/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
@@ -108,7 +108,10 @@ pub fn build_mic_row() -> MicRowWidgets {
     let result = SliderRow::builder()
         .icon("microphone-sensitivity-high-symbolic")
         .interactive_icon(true) // Mute button is clickable
-        .range(0.0, 100.0)
+        // The slider is an interactive control, so keep its range capped to
+        // what Vibepanel is allowed to request. Programmatic updates are
+        // guarded to avoid writing external over-cap values back to Pulse.
+        .range(0.0, AudioService::global().user_max_percent() as f64)
         .step(1.0)
         .with_expander(true) // Source list expander
         .build();
@@ -121,6 +124,19 @@ pub fn build_mic_row() -> MicRowWidgets {
         expander_button: result.expander_button.expect("expander requested"),
         arrow_handle: result.expander_icon.expect("expander requested"),
     }
+}
+
+/// Update the slider from the backend state without causing write-back.
+///
+/// External mic volume can exceed Vibepanel's configured cap, but this is an
+/// interactive control: keep the range capped to the values Vibepanel may
+/// request. GTK will visually saturate over-cap values at the maximum, while
+/// the tooltip preserves the true backend volume.
+pub fn set_mic_slider_display(slider: &Scale, volume: u32) {
+    let max_percent = AudioService::global().user_max_percent().max(1);
+    slider.set_range(0.0, max_percent as f64);
+    slider.set_value(volume as f64);
+    slider.set_tooltip_text(Some(&format!("{volume}%")));
 }
 
 /// Container for mic details (source list) widgets.
@@ -311,7 +327,7 @@ pub fn on_mic_changed(state: &MicCardState, snapshot: &AudioSnapshot) {
     // Update volume slider (with flag to prevent feedback loop)
     if let Some(slider) = state.slider.borrow().as_ref() {
         state.updating.set(true);
-        slider.set_value(mic_volume as f64);
+        set_mic_slider_display(slider, mic_volume);
         slider.set_sensitive(control_ok);
         state.updating.set(false);
     }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -988,7 +988,7 @@ impl QuickSettingsWindow {
         let audio_service = AudioService::global();
         let audio_snapshot = audio_service.current();
 
-        audio_widgets.slider.set_value(audio_snapshot.volume as f64);
+        audio_card::set_volume_slider_display(&audio_widgets.slider, audio_snapshot.volume);
 
         let vol_icon = audio_card::volume_icon_name(audio_snapshot.volume, audio_snapshot.muted);
         audio_widgets.icon_handle.set_icon(vol_icon);
@@ -1084,7 +1084,7 @@ impl QuickSettingsWindow {
         let mic_volume = audio_snapshot.mic_volume.unwrap_or(0);
         let mic_muted = audio_snapshot.mic_muted.unwrap_or(false);
 
-        mic_widgets.slider.set_value(mic_volume as f64);
+        mic_card::set_mic_slider_display(&mic_widgets.slider, mic_volume);
 
         let mic_icon = mic_card::mic_icon_name(mic_volume, mic_muted);
         mic_widgets.icon_handle.set_icon(mic_icon);


### PR DESCRIPTION
This PR adds an `audio.allow_overdrive` option. When enabled, volume can go up to PulseAudio's recommened [UI max](https://docs.rs/libpulse-binding/latest/libpulse_binding/volume/struct.Volume.html#method.ui_max). 

When disabled, sliders and vibepanel volume set/inc/dec stay capped at 100%, while tooltips, OSD labels and `volume get` still show the true current volume.

Config:
```toml
[audio]
allow_overdrive = false # default
```