### PR TITLE
feat(config): add custom JSON output and icon theme options

### DIFF
--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -1100,6 +1100,11 @@ pub struct WidgetOptions {
     #[serde(default)]
     pub outline_color: Option<String>,
 
+    /// Shell command to execute on left-click. Runs via `sh -c`.
+    /// If set, it takes precedence over the widget's native left-click popover.
+    #[serde(default)]
+    pub on_click: Option<String>,
+
     /// Shell command to execute on right-click. Runs via `sh -c`.
     #[serde(default)]
     pub on_click_right: Option<String>,
@@ -1205,8 +1210,8 @@ fn format_widget_section(items: &[WidgetPlacement]) -> Vec<String> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ThemeIconsConfig {
-    /// Icon backend: "material" for bundled Material Symbols, or "gtk" for
-    /// the system GTK icon theme.
+    /// Icon set: "material" for bundled Material Symbols, "gtk" for the
+    /// system GTK icon theme, or a named GTK icon theme such as "Adwaita".
     pub theme: String,
 
     /// Icon stroke weight for Material Symbols (100-700). Lower = thinner strokes.
@@ -2250,12 +2255,14 @@ mod tests {
     #[test]
     fn test_widget_options_click_handlers_parsed() {
         let toml_str = r#"
+            on_click = "notify-send primary"
             on_click_right = "notify-send hello"
             on_click_middle = "xdg-open https://example.com"
             format = "%H:%M"
         "#;
         let opts: WidgetOptions = toml::from_str(toml_str).unwrap();
 
+        assert_eq!(opts.on_click, Some("notify-send primary".to_string()));
         assert_eq!(opts.on_click_right, Some("notify-send hello".to_string()));
         assert_eq!(
             opts.on_click_middle,
@@ -2271,12 +2278,14 @@ mod tests {
     #[test]
     fn test_widget_options_click_handlers_not_in_options_map() {
         let toml_str = r#"
+            on_click = "notify-send primary"
             on_click_right = "notify-send hello"
             on_click_middle = "xdg-open https://example.com"
         "#;
         let opts: WidgetOptions = toml::from_str(toml_str).unwrap();
 
         // Click handler fields should NOT leak into the options HashMap
+        assert!(!opts.options.contains_key("on_click"));
         assert!(!opts.options.contains_key("on_click_right"));
         assert!(!opts.options.contains_key("on_click_middle"));
     }
@@ -2290,18 +2299,21 @@ mod tests {
 
         assert!(opts.on_click_right.is_none());
         assert!(opts.on_click_middle.is_none());
+        assert!(opts.on_click.is_none());
     }
 
     #[test]
     fn test_widget_options_click_handlers_not_in_widget_entry() {
         // Verify click handlers don't leak into WidgetEntry.options
         let opts = WidgetOptions {
+            on_click: Some("notify-send primary".to_string()),
             on_click_right: Some("notify-send hello".to_string()),
             on_click_middle: Some("xdg-open https://example.com".to_string()),
             ..Default::default()
         };
 
         let entry = WidgetEntry::with_options("clock", &opts);
+        assert!(!entry.options.contains_key("on_click"));
         assert!(!entry.options.contains_key("on_click_right"));
         assert!(!entry.options.contains_key("on_click_middle"));
     }

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -487,8 +487,9 @@ fn build_widget_or_group(
                     if e.name == "spacer" {
                         MergeKind::Spacer
                     } else {
-                        let (right, middle) = ConfigManager::global().get_click_handlers(&e.name);
-                        if right.is_some() || middle.is_some() {
+                        let (left, right, middle) =
+                            ConfigManager::global().get_click_handlers(&e.name);
+                        if left.is_some() || right.is_some() || middle.is_some() {
                             MergeKind::Popover(PopoverKind::Unmergeable)
                         } else {
                             MergeKind::Popover(popover_kind_for(&e.name))

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -476,14 +476,23 @@ impl ConfigManager {
 
     /// Get click handler commands for a widget.
     ///
-    /// Returns `(on_click_right, on_click_middle)` from `[widgets.<name>]`.
-    pub fn get_click_handlers(&self, widget_name: &str) -> (Option<String>, Option<String>) {
+    /// Returns `(on_click, on_click_right, on_click_middle)` from `[widgets.<name>]`.
+    pub fn get_click_handlers(
+        &self,
+        widget_name: &str,
+    ) -> (Option<String>, Option<String>, Option<String>) {
         let config = self.config.borrow();
         config
             .widgets
             .get_options(widget_name)
-            .map(|opts| (opts.on_click_right.clone(), opts.on_click_middle.clone()))
-            .unwrap_or((None, None))
+            .map(|opts| {
+                (
+                    opts.on_click.clone(),
+                    opts.on_click_right.clone(),
+                    opts.on_click_middle.clone(),
+                )
+            })
+            .unwrap_or((None, None, None))
     }
 
     /// Get `show_if` command and interval for a widget.

--- a/crates/vibepanel/src/services/icons.rs
+++ b/crates/vibepanel/src/services/icons.rs
@@ -1699,17 +1699,36 @@ impl IconsService {
     /// icon theme's `changed` signal so that icons are rebuilt live when the
     /// system icon theme changes.
     fn setup_backends(service: &Rc<Self>, theme: &str) {
-        // Get the display's icon theme for lookups. We don't call set_theme_name()
-        // on this because it's a singleton and GTK warns about modifying it.
-        // Instead, we just use it for icon lookups with the system's configured theme.
+        Self::configure_gtk_icon_theme(service, theme);
+
+        // Started unconditionally — supports live theme switching via reconfigure().
+        Self::start_font_dir_watcher();
+
+        // Initialize Material if configured
+        if is_material_theme(theme) {
+            service.ensure_material_css();
+        }
+    }
+
+    fn configure_gtk_icon_theme(service: &Rc<Self>, theme: &str) {
         if let Some(display) = gtk4::gdk::Display::default() {
-            let gtk_theme = IconTheme::for_display(&display);
+            let gtk_theme = if is_material_theme(theme) || theme.eq_ignore_ascii_case("gtk") {
+                // Use the process/display default icon theme.
+                IconTheme::for_display(&display)
+            } else {
+                // Use an explicitly named GTK icon theme such as "Adwaita".
+                // This gives config a real icon-set selector without changing
+                // the user's global GTK settings.
+                let gtk_theme = IconTheme::new();
+                gtk_theme.set_theme_name(Some(theme));
+                gtk_theme
+            };
 
             // Rebuild icons whenever the system icon theme changes.
             let weak = Rc::downgrade(service);
             gtk_theme.connect_changed(move |_| {
                 if let Some(service) = weak.upgrade() {
-                    // Only relevant when using the GTK backend (non-Material)
+                    // Only relevant when using a GTK icon backend.
                     if !service.uses_material() {
                         service.reapply_all_icons();
                     }
@@ -1720,14 +1739,6 @@ impl IconsService {
         } else {
             debug!("No display available; GTK icon backend will use fallback");
             *service.icon_theme.borrow_mut() = None;
-        }
-
-        // Started unconditionally — supports live theme switching via reconfigure().
-        Self::start_font_dir_watcher();
-
-        // Initialize Material if configured
-        if is_material_theme(theme) {
-            service.ensure_material_css();
         }
     }
 
@@ -1767,10 +1778,11 @@ impl IconsService {
     ///
     /// # Arguments
     ///
-    /// * `new_theme` - The new theme name ("material" for Material Symbols,
-    ///   or a GTK theme name like "Adwaita", "Breeze", etc.)
+    /// * `new_theme` - The new theme name: "material" for Material Symbols,
+    ///   "gtk" for the system GTK icon theme, or a GTK icon theme name like
+    ///   "Adwaita", "Breeze", etc.
     /// * `new_weight` - The font weight for Material Symbols (100-700)
-    pub fn reconfigure(&self, new_theme: &str, new_weight: u16) {
+    pub fn reconfigure(self: &Rc<Self>, new_theme: &str, new_weight: u16) {
         let old_theme = self.theme.borrow().clone();
         let old_weight = *self.weight.borrow();
         let theme_changed = old_theme != new_theme;
@@ -1797,6 +1809,10 @@ impl IconsService {
         // Update theme name and weight
         *self.theme.borrow_mut() = new_theme.to_string();
         *self.weight.borrow_mut() = new_weight;
+
+        if theme_changed {
+            Self::configure_gtk_icon_theme(self, new_theme);
+        }
 
         // Reload Material CSS if switching to Material or if weight changed while using Material
         let switching_to_material = is_material_theme(new_theme) && !is_material_theme(&old_theme);
@@ -2536,7 +2552,7 @@ mod tests {
     #[test]
     fn test_reconfigure_changes_theme_and_backend_kind() {
         // Test that reconfigure() updates theme and backend kind
-        let service = IconsService {
+        let service = Rc::new(IconsService {
             theme: RefCell::new("material".to_string()),
             weight: RefCell::new(400),
             material_ready: RefCell::new(true),
@@ -2545,7 +2561,7 @@ mod tests {
             handles: RefCell::new(Vec::new()),
             material_css_provider: RefCell::new(None),
             font_path: RefCell::new(None),
-        };
+        });
 
         assert_eq!(service.theme(), "material");
         assert!(service.uses_material());
@@ -2563,7 +2579,7 @@ mod tests {
     #[test]
     fn test_reconfigure_same_theme_is_noop() {
         // Reconfiguring to the same theme and weight should be a no-op
-        let service = IconsService {
+        let service = Rc::new(IconsService {
             theme: RefCell::new("material".to_string()),
             weight: RefCell::new(400),
             material_ready: RefCell::new(true),
@@ -2572,7 +2588,7 @@ mod tests {
             handles: RefCell::new(Vec::new()),
             material_css_provider: RefCell::new(None),
             font_path: RefCell::new(None),
-        };
+        });
 
         // This should not change anything
         service.reconfigure("material", 400);

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -585,10 +585,14 @@ impl BaseWidget {
 
         let menu: Rc<RefCell<Option<Rc<MenuHandle>>>> = Rc::new(RefCell::new(None));
 
-        let (on_click_right, on_click_middle) =
+        let (mut on_click, on_click_right, on_click_middle) =
             ConfigManager::global().get_click_handlers(&widget_name);
+        if widget_name.starts_with(widget::CUSTOM_PREFIX) {
+            on_click = None;
+        }
 
-        let has_click_handler = on_click_right.is_some() || on_click_middle.is_some();
+        let has_click_handler =
+            on_click.is_some() || on_click_right.is_some() || on_click_middle.is_some();
         if has_click_handler {
             container.add_css_class(state::CLICKABLE);
         }
@@ -600,15 +604,26 @@ impl BaseWidget {
             let menu_for_cb = menu.clone();
             let container_for_ripple = container.clone();
             let ripple_for_press = ripple_handle.clone();
+            let widget_name_for_cb = widget_name.clone();
             gesture_click.connect_pressed(move |gesture, _n_press, x, y| {
                 let button = gesture.current_button();
 
                 if button == gdk::BUTTON_PRIMARY {
-                    // Skip if target is an interactive child (e.g., a Button)
+                    // Let embedded controls (for example media play/pause)
+                    // handle their own primary clicks before widget-level
+                    // click commands or popovers run.
                     if click_target_matches(gesture, x, y, |w| {
                         w.downcast_ref::<gtk4::Button>().is_some()
                     }) {
                         debug!("BaseWidget press: target is a Button, skipping");
+                        return;
+                    }
+
+                    if let Some(ref cmd) = on_click {
+                        debug!("BaseWidget left-click: sh -c {}", cmd);
+                        TooltipManager::global().cancel_and_hide();
+                        PopoverTracker::global().dismiss_active();
+                        spawn_click_command(&widget_name_for_cb, cmd);
                         return;
                     }
 

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -40,11 +40,13 @@ use gtk4::gio;
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, GestureClick, Image, Label, Orientation, gdk};
+use serde::Deserialize;
 use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::config_manager::ConfigManager;
 use crate::services::icons::{IconHandle, has_material_mapping};
+use crate::services::tooltip::TooltipManager;
 use crate::styles::{icon, state, widget as wgt};
 use crate::widgets::base::{BaseWidget, describe_exit_status};
 use crate::widgets::{WidgetConfig, warn_unknown_options};
@@ -64,6 +66,64 @@ const KNOWN_OPTIONS: &[&str] = &[
 
 /// Default exec timeout in seconds.
 const EXEC_TIMEOUT_SECS: u64 = 10;
+
+/// Normalized output from a custom widget exec command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CustomExecOutput {
+    text: String,
+    tooltip: Option<String>,
+}
+
+/// JSON shape emitted by Waybar-style custom scripts.
+#[derive(Debug, Deserialize, PartialEq)]
+struct CustomExecJsonOutput {
+    /// Primary display text used by Waybar custom modules.
+    #[serde(default)]
+    text: String,
+    /// Alternate label key accepted for compatibility with simple scripts.
+    #[serde(default)]
+    label: String,
+    /// Optional tooltip text.
+    #[serde(default)]
+    tooltip: Option<String>,
+    /// Optional numeric percentage. Used as tooltip fallback when tooltip is
+    /// absent.
+    #[serde(default)]
+    percentage: Option<CustomExecPercentage>,
+}
+
+impl CustomExecJsonOutput {
+    fn into_output(self) -> CustomExecOutput {
+        let text = if self.text.is_empty() {
+            self.label
+        } else {
+            self.text
+        };
+
+        let tooltip = self
+            .tooltip
+            .filter(|s| !s.is_empty())
+            .or_else(|| self.percentage.map(|percentage| percentage.to_tooltip()));
+
+        CustomExecOutput { text, tooltip }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum CustomExecPercentage {
+    Integer(i64),
+    Float(f64),
+}
+
+impl CustomExecPercentage {
+    fn to_tooltip(&self) -> String {
+        match self {
+            Self::Integer(n) => format!("{n}%"),
+            Self::Float(n) => format!("{n:.0}%"),
+        }
+    }
+}
 
 /// Configuration for a custom widget instance.
 #[derive(Debug, Clone, Default)]
@@ -237,6 +297,11 @@ impl CustomWidget {
         // Retrieve show_if config from WidgetOptions (not CustomConfig — these
         // are cross-cutting fields parsed at the WidgetOptions level).
         let (show_if_cmd, show_if_interval) = ConfigManager::global().get_show_if(&css_class_name);
+        let custom_on_click = config.on_click.clone().or_else(|| {
+            ConfigManager::global()
+                .get_click_handlers(&css_class_name)
+                .0
+        });
 
         // When exec + interval is active, show_if piggybacks on the exec cycle
         // instead of running a separate timer. Cancel BaseWidget's show_if timer.
@@ -255,7 +320,7 @@ impl CustomWidget {
 
         // Enables hover styling for left-click action.
         // BaseWidget handles CLICKABLE for on_click_right / on_click_middle.
-        if config.on_click.is_some() {
+        if custom_on_click.is_some() {
             base.widget().add_css_class(state::CLICKABLE);
         }
 
@@ -394,7 +459,7 @@ impl CustomWidget {
             None
         };
 
-        if let Some(on_click) = config.on_click {
+        if let Some(on_click) = custom_on_click {
             // Custom widget's own left-click handler. Runs the command, then
             // re-runs exec to refresh the label immediately.
             // Right-click and middle-click are handled by BaseWidget via
@@ -624,8 +689,8 @@ fn run_exec(
         match result {
             Ok(Ok(output)) => {
                 // Trim whitespace (including the trailing newline from read_line)
-                let text = output.trim();
-                if text.is_empty() {
+                let output = parse_exec_output(output.trim());
+                if output.text.is_empty() {
                     label.set_label(&fallback_text);
                     // Auto-hide when exec returns empty and no fallback is configured
                     if fallback_text.is_empty() {
@@ -633,11 +698,14 @@ fn run_exec(
                     }
                 } else {
                     let display = if let Some(ref tmpl) = template {
-                        tmpl.replace("{output}", text)
+                        tmpl.replace("{output}", &output.text)
                     } else {
-                        text.to_string()
+                        output.text
                     };
                     label.set_label(&display);
+                    if let Some(tooltip) = output.tooltip {
+                        TooltipManager::global().set_styled_tooltip(&widget, &tooltip);
+                    }
                     widget.set_visible(true);
                 }
             }
@@ -651,6 +719,25 @@ fn run_exec(
             }
         }
     });
+}
+
+fn parse_exec_output(text: &str) -> CustomExecOutput {
+    let trimmed = text.trim();
+    if !trimmed.starts_with('{') {
+        return CustomExecOutput {
+            text: trimmed.to_string(),
+            tooltip: None,
+        };
+    }
+
+    let Ok(output) = serde_json::from_str::<CustomExecJsonOutput>(trimmed) else {
+        return CustomExecOutput {
+            text: trimmed.to_string(),
+            tooltip: None,
+        };
+    };
+
+    output.into_output()
 }
 
 #[cfg(test)]
@@ -714,6 +801,39 @@ mod tests {
         assert_eq!(config.on_click, Some("wlogout".to_string()));
         assert_eq!(config.tooltip, Some("Power menu".to_string()));
         assert_eq!(config.max_chars, Some(30));
+    }
+
+    #[test]
+    fn test_parse_exec_output_plain_text() {
+        assert_eq!(
+            parse_exec_output("hello"),
+            CustomExecOutput {
+                text: "hello".to_string(),
+                tooltip: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_exec_output_waybar_json() {
+        assert_eq!(
+            parse_exec_output(r#"{"text":"󰋎 ","percentage":72}"#),
+            CustomExecOutput {
+                text: "󰋎 ".to_string(),
+                tooltip: Some("72%".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_exec_output_tooltip_json() {
+        assert_eq!(
+            parse_exec_output(r#"{"text":"󰋎 ","tooltip":"Headset 72%"}"#),
+            CustomExecOutput {
+                text: "󰋎 ".to_string(),
+                tooltip: Some("Headset 72%".to_string()),
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Add primary click handlers and named GTK icon themes.
- Parse Waybar-style custom widget JSON output.

Testing:
- cargo test --workspace --all-targets
- Manually tested by me.

Disclosure: This code was generated using Codex GPT-5.5.