### PR TITLE
feat(widgets): add control panel and quieter display options

### DIFF
--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -269,6 +269,9 @@ pub mod qs {
     /// Wi-Fi toggle card (`.qs-wifi`).
     pub const WIFI: &str = "qs-wifi";
 
+    /// Volume bar icon (`.qs-volume`).
+    pub const VOLUME: &str = "qs-volume";
+
     /// Bluetooth toggle card (`.qs-bluetooth`).
     pub const BLUETOOTH: &str = "qs-bluetooth";
 

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -15,6 +15,7 @@ use crate::styles::widget as wgt;
 use crate::widgets::WidgetConfig;
 use crate::widgets::base::BaseWidget;
 use crate::widgets::calendar_popover::build_clock_calendar_popover;
+use crate::widgets::control_panel::build_clock_control_panel;
 use crate::widgets::warn_unknown_options;
 
 /// Default format string for the clock display.
@@ -28,11 +29,26 @@ pub struct ClockConfig {
     pub format: String,
     /// Whether to show week numbers in the calendar popover.
     pub show_week_numbers: bool,
+    /// Whether the clock opens the combined control panel instead of the
+    /// calendar-only popover.
+    pub control_panel: bool,
+    /// Optional custom widget name whose exec output is shown in the control
+    /// panel weather card.
+    pub control_panel_weather_widget: Option<String>,
 }
 
 impl WidgetConfig for ClockConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("clock", entry, &["format", "show_week_numbers"]);
+        warn_unknown_options(
+            "clock",
+            entry,
+            &[
+                "format",
+                "show_week_numbers",
+                "control_panel",
+                "control_panel_weather_widget",
+            ],
+        );
 
         let format = entry
             .options
@@ -47,9 +63,24 @@ impl WidgetConfig for ClockConfig {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
+        let control_panel = entry
+            .options
+            .get("control_panel")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let control_panel_weather_widget = entry
+            .options
+            .get("control_panel_weather_widget")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
         Self {
             format,
             show_week_numbers,
+            control_panel,
+            control_panel_weather_widget,
         }
     }
 }
@@ -59,6 +90,8 @@ impl Default for ClockConfig {
         Self {
             format: DEFAULT_FORMAT.to_string(),
             show_week_numbers: true,
+            control_panel: false,
+            control_panel_weather_widget: None,
         }
     }
 }
@@ -85,6 +118,8 @@ impl ClockWidget {
         let label = base.add_label(Some("--:--"), &[wgt::CLOCK_LABEL]);
 
         let show_week_numbers = config.show_week_numbers;
+        let control_panel = config.control_panel;
+        let control_panel_weather_widget = config.control_panel_weather_widget.clone();
 
         // Shared slot for the calendar refresh callback. Populated by the
         // builder on first open, invoked by on_show on every subsequent open.
@@ -93,14 +128,17 @@ impl ClockWidget {
 
         let refresh_for_builder = refresh_slot.clone();
         let menu_handle = base.create_menu(move || {
-            let (widget, refresh) = build_clock_calendar_popover(show_week_numbers);
+            let (widget, refresh) = if control_panel {
+                build_clock_control_panel(show_week_numbers, control_panel_weather_widget.clone())
+            } else {
+                build_clock_calendar_popover(show_week_numbers)
+            };
             *refresh_for_builder.borrow_mut() = Some(refresh);
             widget
         });
 
-        // Reuse the calendar widget across open/close cycles to avoid
-        // unbounded memory growth from GTK4.
-        menu_handle.set_reuse_content(true);
+        // Rebuild the combined panel on open so notification history is fresh.
+        menu_handle.set_reuse_content(!control_panel);
         menu_handle.set_on_show(move || {
             if let Some(ref cb) = *refresh_slot.borrow() {
                 cb();

--- a/crates/vibepanel/src/widgets/control_panel.rs
+++ b/crates/vibepanel/src/widgets/control_panel.rs
@@ -1,0 +1,164 @@
+//! Combined clock control panel.
+//!
+//! This reuses the existing notification, media, and calendar popover
+//! components so the clock can open a GNOME-like overview panel.
+
+use std::cell::Cell;
+use std::process::{Command, Stdio};
+use std::rc::Rc;
+
+use chrono::Local;
+use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, Label, Orientation, Widget};
+use gtk4::{gio, glib};
+
+use crate::services::config_manager::ConfigManager;
+use crate::services::media::MediaService;
+use crate::styles::surface;
+use crate::widgets::calendar_popover::build_clock_calendar_popover;
+use crate::widgets::media_popover::build_media_popover_with_controller;
+use crate::widgets::notifications_popover::build_popover_content as build_notifications_content;
+
+/// Build the clock control panel content and return a refresh callback.
+pub fn build_clock_control_panel(
+    show_week_numbers: bool,
+    weather_widget_name: Option<String>,
+) -> (Widget, Rc<dyn Fn()>) {
+    let root = GtkBox::new(Orientation::Horizontal, 12);
+    root.add_css_class("control-panel");
+
+    let left_col = GtkBox::new(Orientation::Vertical, 10);
+    left_col.add_css_class("control-panel-left");
+    left_col.set_size_request(380, -1);
+    left_col.set_vexpand(true);
+
+    let suppress_rebuild = Rc::new(Cell::new(false));
+    let notifications = build_notifications_content(None, suppress_rebuild);
+    notifications.add_css_class("control-panel-notifications");
+    left_col.append(&notifications);
+
+    let right_col = GtkBox::new(Orientation::Vertical, 10);
+    right_col.add_css_class("control-panel-right");
+    right_col.set_size_request(360, -1);
+    right_col.set_vexpand(true);
+
+    let time_card = build_time_weather_card(weather_widget_name);
+    right_col.append(&time_card.container);
+
+    let (media_widget, media_controller) = build_media_popover_with_controller(|| {});
+    media_widget.add_css_class("control-panel-media");
+    right_col.append(&media_widget);
+
+    let (calendar_widget, calendar_refresh) = build_clock_calendar_popover(show_week_numbers);
+    calendar_widget.add_css_class("control-panel-calendar");
+    right_col.append(&calendar_widget);
+
+    root.append(&left_col);
+    root.append(&right_col);
+
+    let refresh = {
+        let time_label = time_card.time_label.clone();
+        let date_label = time_card.date_label.clone();
+        let weather_label = time_card.weather_label.clone();
+        Rc::new(move || {
+            refresh_time_labels(&time_label, &date_label);
+            refresh_weather_label(&weather_label);
+            media_controller.update_from_snapshot(&MediaService::global().snapshot());
+            calendar_refresh();
+        }) as Rc<dyn Fn()>
+    };
+
+    refresh();
+    (root.upcast(), refresh)
+}
+
+struct TimeWeatherCard {
+    container: GtkBox,
+    time_label: Label,
+    date_label: Label,
+    weather_label: Option<(Label, String)>,
+}
+
+fn build_time_weather_card(weather_widget_name: Option<String>) -> TimeWeatherCard {
+    let container = GtkBox::new(Orientation::Vertical, 2);
+    container.add_css_class("control-panel-card");
+    container.add_css_class("control-panel-time-weather");
+
+    let time_label = Label::new(None);
+    time_label.add_css_class("control-panel-time");
+    time_label.set_xalign(0.0);
+    time_label.set_halign(Align::Fill);
+
+    let date_label = Label::new(None);
+    date_label.add_css_class(surface::POPOVER_TITLE);
+    date_label.add_css_class("control-panel-date");
+    date_label.set_xalign(0.0);
+    date_label.set_halign(Align::Fill);
+
+    let weather_label = weather_widget_name.map(|widget_name| {
+        let label = Label::new(None);
+        label.add_css_class("control-panel-weather");
+        label.set_xalign(0.0);
+        label.set_halign(Align::Fill);
+        (label, widget_name)
+    });
+
+    container.append(&time_label);
+    container.append(&date_label);
+    if let Some((ref label, _)) = weather_label {
+        container.append(label);
+    }
+
+    TimeWeatherCard {
+        container,
+        time_label,
+        date_label,
+        weather_label,
+    }
+}
+
+fn refresh_time_labels(time_label: &Label, date_label: &Label) {
+    let now = Local::now();
+    time_label.set_label(&now.format("%H:%M").to_string());
+    date_label.set_label(&now.format("%A, %B %-d").to_string());
+}
+
+fn refresh_weather_label(label: &Option<(Label, String)>) {
+    let Some((label, widget_name)) = label else {
+        return;
+    };
+
+    let cmd = ConfigManager::global()
+        .get_widget_option(widget_name, "exec")
+        .and_then(|v| v.as_str().map(str::to_string));
+
+    let Some(cmd) = cmd else {
+        return;
+    };
+
+    let label = label.clone();
+    glib::spawn_future_local(async move {
+        let result = gio::spawn_blocking(move || {
+            Command::new("sh")
+                .args(["-c", &cmd])
+                .stdin(Stdio::null())
+                .stderr(Stdio::null())
+                .output()
+                .ok()
+                .and_then(|output| {
+                    if output.status.success() {
+                        String::from_utf8(output.stdout).ok()
+                    } else {
+                        None
+                    }
+                })
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .await;
+
+        if let Ok(Some(text)) = result {
+            label.set_label(&text);
+        }
+    });
+}

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -205,6 +205,10 @@ window.notification-toast-wrapper,
     min-width: 300px;
 }}
 
+.notification-toast {{
+    background-color: color-mix(in srgb, var(--color-background-popover) 58%, transparent);
+}}
+
 .notification-toast-actions {{
     margin-top: 10px;
     padding-top: 8px;

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -28,6 +28,8 @@ const DEFAULT_SHOW_ICON: bool = true;
 /// Memory display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum MemoryFormat {
+    /// Show no text on the bar; details remain available in tooltip/popover.
+    None,
     /// Show percentage only: "76%"
     #[default]
     Percentage,
@@ -41,6 +43,7 @@ impl MemoryFormat {
     /// Parse from a string value.
     fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
+            "none" | "hidden" | "icon" => Self::None,
             "absolute" => Self::Absolute,
             "both" => Self::Both,
             _ => Self::Percentage,
@@ -168,6 +171,7 @@ impl Drop for MemoryWidget {
 /// Format memory usage according to the selected format.
 fn format_memory(snapshot: &SystemSnapshot, format: &MemoryFormat) -> String {
     match format {
+        MemoryFormat::None => String::new(),
         MemoryFormat::Percentage => format!("{:.0}%", snapshot.memory_percent),
         MemoryFormat::Absolute => format_bytes(snapshot.memory_used),
         MemoryFormat::Both => format!(
@@ -191,8 +195,12 @@ fn update_memory_widget(
         if show_icon {
             icon_handle.widget().set_visible(true);
         }
-        memory_label.set_label("?");
-        memory_label.set_visible(true);
+        if *format == MemoryFormat::None {
+            memory_label.set_visible(false);
+        } else {
+            memory_label.set_label("?");
+            memory_label.set_visible(true);
+        }
 
         let tooltip_manager = TooltipManager::global();
         tooltip_manager.set_styled_tooltip(container, "Memory: Service unavailable");
@@ -215,7 +223,7 @@ fn update_memory_widget(
 
     let text = format_memory(snapshot, format);
     memory_label.set_label(&text);
-    memory_label.set_visible(true);
+    memory_label.set_visible(!text.is_empty());
 
     let tooltip = format!(
         "Memory: {:.1}%\n{} / {}",
@@ -274,6 +282,8 @@ mod tests {
         assert_eq!(MemoryFormat::from_str("ABSOLUTE"), MemoryFormat::Absolute);
         assert_eq!(MemoryFormat::from_str("both"), MemoryFormat::Both);
         assert_eq!(MemoryFormat::from_str("Both"), MemoryFormat::Both);
+        assert_eq!(MemoryFormat::from_str("none"), MemoryFormat::None);
+        assert_eq!(MemoryFormat::from_str("icon"), MemoryFormat::None);
         assert_eq!(MemoryFormat::from_str("unknown"), MemoryFormat::Percentage);
     }
 }

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -18,6 +18,7 @@ mod battery;
 mod battery_popover;
 mod calendar_popover;
 mod clock;
+mod control_panel;
 mod cpu;
 mod custom;
 mod gpu;

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -4,7 +4,7 @@
 //! - Bell icon with unread notification badge
 //! - CSS states: has-notifications, has-critical, backend-unavailable
 //! - Popover with scrollable notification list and dismiss controls
-//! - Toast overlay windows for new notifications (top-right stacked)
+//! - Toast overlay windows for new notifications
 //!
 //! This module is split into several files for maintainability:
 //! - `notifications.rs` (this file): Widget implementation and badge logic
@@ -23,6 +23,7 @@ use tracing::debug;
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
+use crate::services::config_manager::ConfigManager;
 use crate::services::icons::IconHandle;
 use crate::services::notification::{NotificationService, URGENCY_CRITICAL};
 use crate::services::tooltip::TooltipManager;
@@ -30,16 +31,34 @@ use crate::styles::widget;
 use crate::widgets::base::MenuHandle;
 use crate::widgets::{BaseWidget, WidgetConfig};
 
+use super::control_panel::build_clock_control_panel;
 use super::notifications_popover::{ClosePopoverCallback, build_popover_content};
 use super::notifications_toast::NotificationToastManager;
 
 /// Configuration for the notification widget.
 #[derive(Debug, Clone, Default)]
-pub struct NotificationsConfig {}
+pub struct NotificationsConfig {
+    /// Hide the bell until there is notification history.
+    hide_empty: bool,
+    /// Open the combined clock control panel instead of the notification-only
+    /// popover.
+    control_panel: bool,
+}
 
 impl WidgetConfig for NotificationsConfig {
-    fn from_entry(_entry: &WidgetEntry) -> Self {
-        Self {}
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        Self {
+            hide_empty: entry
+                .options
+                .get("hide_empty")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            control_panel: entry
+                .options
+                .get("control_panel")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        }
     }
 }
 
@@ -65,6 +84,7 @@ struct NotificationsWidgetInner {
     /// When set, the popover dismiss handler already removed the row in-place,
     /// so `on_service_update` should skip `refresh_if_visible`.
     suppress_rebuild: Rc<Cell<bool>>,
+    hide_empty: bool,
 }
 
 impl NotificationsWidgetInner {
@@ -77,6 +97,11 @@ impl NotificationsWidgetInner {
 
         // Show toasts for new notifications
         self.show_new_toasts(service);
+
+        if self.hide_empty {
+            self.container
+                .set_visible(service.backend_available() && count > 0);
+        }
 
         // Update badge: unread since last popover open
         // Badge is shown as a simple dot (no text), count is only in tooltip
@@ -314,7 +339,7 @@ pub struct NotificationsWidget {
 
 impl NotificationsWidget {
     /// Create a new notification widget.
-    pub fn new(_config: NotificationsConfig) -> Self {
+    pub fn new(config: NotificationsConfig) -> Self {
         let base = BaseWidget::new(&[widget::NOTIFICATIONS]);
 
         // Create an overlay for badge on top of icon
@@ -343,6 +368,9 @@ impl NotificationsWidget {
         base.content().append(&overlay);
 
         base.set_tooltip("Notifications");
+        if config.hide_empty {
+            base.widget().set_visible(false);
+        }
 
         let inner = Rc::new(NotificationsWidgetInner {
             icon_handle,
@@ -355,19 +383,36 @@ impl NotificationsWidget {
             menu_handle: RefCell::new(None),
             last_notif_ids: RefCell::new(Vec::new()),
             suppress_rebuild: Rc::new(Cell::new(false)),
+            hide_empty: config.hide_empty,
         });
 
         // Build menu before constructing Self so we can move base/inner cleanly.
         let suppress_rebuild = Rc::clone(&inner.suppress_rebuild);
         let inner_for_menu = Rc::clone(&inner);
+        let control_panel = config.control_panel;
         let menu_handle = base.create_menu(|| GtkBox::new(Orientation::Vertical, 0).into());
         let handle_weak = Rc::downgrade(&menu_handle);
         menu_handle.set_builder(move || {
             inner_for_menu.mark_as_seen();
-            let on_close: Option<ClosePopoverCallback> = handle_weak
-                .upgrade()
-                .map(|handle| Rc::new(move || handle.hide()) as ClosePopoverCallback);
-            build_popover_content(on_close, Rc::clone(&suppress_rebuild))
+            if control_panel {
+                suppress_rebuild.set(false);
+
+                let show_week_numbers = ConfigManager::global()
+                    .get_widget_option("clock", "show_week_numbers")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                let weather_widget_name = ConfigManager::global()
+                    .get_widget_option("clock", "control_panel_weather_widget")
+                    .and_then(|v| v.as_str().map(str::to_string));
+                let (widget, _refresh) =
+                    build_clock_control_panel(show_week_numbers, weather_widget_name);
+                widget
+            } else {
+                let on_close: Option<ClosePopoverCallback> = handle_weak
+                    .upgrade()
+                    .map(|handle| Rc::new(move || handle.hide()) as ClosePopoverCallback);
+                build_popover_content(on_close, Rc::clone(&suppress_rebuild))
+            }
         });
         *inner.menu_handle.borrow_mut() = Some(menu_handle);
 

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -19,8 +19,6 @@ pub const TOAST_TIMEOUT_CRITICAL_MS: u32 = 0;
 /// Estimated height per toast (including padding/margins) for stack positioning
 pub const TOAST_ESTIMATED_HEIGHT: i32 = 85;
 pub const TOAST_GAP: i32 = 4;
-pub const TOAST_BAR_MARGIN: i32 = 10;
-pub const TOAST_MARGIN_RIGHT: i32 = 10;
 
 /// Popover dimensions
 pub const POPOVER_WIDTH: i32 = 400;

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -106,7 +106,7 @@ fn compute_max_scroll_height() -> i32 {
 ///   single notification does NOT close the popover.
 /// * `suppress_rebuild` - Flag set by dismiss handlers to prevent the service
 ///   update listener from rebuilding the popover (since the row was already removed).
-pub(super) fn build_popover_content(
+pub(crate) fn build_popover_content(
     on_close: Option<ClosePopoverCallback>,
     suppress_rebuild: Rc<Cell<bool>>,
 ) -> gtk4::Widget {

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -1,8 +1,7 @@
 //! Notification toast windows for displaying new notifications.
 //!
 //! This module handles floating toast windows that appear when new notifications
-//! arrive. Toasts stack vertically on the bar-adjacent edge (top-right when bar
-//! is at top, bottom-right when bar is at bottom) and auto-dismiss after a
+//! arrive. Toasts appear at top-center and auto-dismiss after a
 //! timeout (except for critical notifications).
 
 use gtk4::glib::{self, SourceId};
@@ -28,9 +27,9 @@ use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{button, color, notification as notif};
 
 use super::notifications_common::{
-    POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_BAR_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
-    TOAST_MARGIN_RIGHT, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
-    create_notification_image_widget, sanitize_body_markup,
+    POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
+    TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS, create_notification_image_widget,
+    sanitize_body_markup,
 };
 
 /// Floating toast window for displaying a single notification.
@@ -69,9 +68,7 @@ impl NotificationToast {
 
         window.add_css_class(notif::TOAST_WRAPPER);
 
-        // Determine bar position for toast anchoring
-        let is_bottom = ConfigManager::global().bar_is_bottom();
-        let bar_edge = if is_bottom { Edge::Bottom } else { Edge::Top };
+        let bar_edge = Edge::Top;
 
         // Initialize layer shell
         window.init_layer_shell();
@@ -80,19 +77,14 @@ impl NotificationToast {
         window.set_exclusive_zone(0);
         window.set_keyboard_mode(KeyboardMode::None);
 
-        // Anchor to bar-edge + right
-        window.set_anchor(bar_edge, true);
-        window.set_anchor(Edge::Right, true);
+        // Anchor to top only: layer-shell centers the unanchored horizontal axis.
+        window.set_anchor(Edge::Top, true);
+        window.set_anchor(Edge::Bottom, false);
+        window.set_anchor(Edge::Right, false);
         window.set_anchor(Edge::Left, false);
-        // Ensure opposite edge is unanchored
-        let opposite_edge = if is_bottom { Edge::Top } else { Edge::Bottom };
-        window.set_anchor(opposite_edge, false);
 
-        window.set_margin(bar_edge, initial_margin);
-        let right_margin = (TOAST_MARGIN_RIGHT
-            - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
-        .max(0);
-        window.set_margin(Edge::Right, right_margin);
+        window.set_margin(bar_edge, initial_margin.max(12));
+        window.set_margin(Edge::Right, 0);
 
         let notification_id = notification.id;
         let toast = Rc::new(Self {
@@ -558,7 +550,7 @@ impl NotificationToastManager {
         let initial_margin = {
             let order = self.toast_order.borrow();
             let toasts = self.toasts.borrow();
-            let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
+            let mut y_offset = 0;
             for &id in order.iter() {
                 if let Some(toast) = toasts.get(&id) {
                     y_offset += (toast.height() - 2 * sm).max(0) + TOAST_GAP;
@@ -606,7 +598,7 @@ impl NotificationToastManager {
         let order = self.toast_order.borrow();
         let toasts = self.toasts.borrow();
         let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
-        let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
+        let mut y_offset = 0;
         for &id in order.iter() {
             if let Some(toast) = toasts.get(&id) {
                 toast.update_bar_margin(y_offset, ConfigManager::global().animations_enabled());

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -195,6 +195,7 @@ impl QuickSettingsWidget {
             let audio_icon_name_initial =
                 volume_icon_name(audio_snapshot.volume, audio_snapshot.muted);
             let audio_icon = base.add_icon(audio_icon_name_initial, &[icon::ICON, icon::TEXT]);
+            audio_icon.widget().add_css_class(qs::VOLUME);
 
             // Subscribe to AudioService updates
             let audio_icon_handle = audio_icon.clone();
@@ -251,6 +252,7 @@ impl QuickSettingsWidget {
             if bt_connected_devices > 0 {
                 bt_icon.widget().add_css_class(state::ICON_ACTIVE);
             }
+            bt_icon.widget().set_visible(bt_powered);
             if !bt_powered {
                 bt_icon.widget().add_css_class(qs::BT_DISABLED_ICON);
             }
@@ -262,6 +264,7 @@ impl QuickSettingsWidget {
                     let widget = bt_icon_handle.widget();
 
                     if !snapshot.has_adapter && snapshot.is_ready {
+                        widget.set_visible(false);
                         widget.add_css_class(state::SERVICE_UNAVAILABLE);
                         widget.remove_css_class(state::ICON_ACTIVE);
                         bt_icon_handle.set_icon("bluetooth-disabled-symbolic");
@@ -274,6 +277,7 @@ impl QuickSettingsWidget {
 
                     let powered = snapshot.powered;
                     let connected_devices = snapshot.connected_devices;
+                    widget.set_visible(powered);
 
                     let icon_name = bt_icon_name(powered, connected_devices);
                     bt_icon_handle.set_icon(icon_name);
@@ -323,6 +327,7 @@ impl QuickSettingsWidget {
 
             let ctx = NetworkIconContext::for_bar(&snapshot);
             let wifi_icon = base.add_icon(network_icon_name(&ctx), &[icon::ICON, icon::TEXT]);
+            wifi_icon.widget().add_css_class(qs::WIFI);
 
             if !wifi_enabled && !wired_connected {
                 wifi_icon.widget().add_css_class(qs::WIFI_DISABLED_ICON);
@@ -482,9 +487,10 @@ impl QuickSettingsWidget {
             let vpn_icon_name_initial = vpn_icon_name();
             let vpn_icon = base.add_icon(vpn_icon_name_initial, &[icon::ICON, icon::TEXT]);
 
-            if !vpn_snapshot.available {
-                vpn_icon.widget().set_visible(false);
-            } else if vpn_any_active {
+            vpn_icon
+                .widget()
+                .set_visible(vpn_snapshot.available && vpn_any_active);
+            if vpn_snapshot.available && vpn_any_active {
                 vpn_icon.widget().add_css_class(state::ICON_ACTIVE);
             }
 
@@ -493,8 +499,9 @@ impl QuickSettingsWidget {
             vpn_callback_id = Some(VpnService::global().connect(move |snapshot: &VpnSnapshot| {
                 let widget = vpn_icon_handle.widget();
 
-                if !snapshot.available {
+                if !snapshot.available || !snapshot.any_active {
                     widget.set_visible(false);
+                    widget.remove_css_class(state::ICON_ACTIVE);
                     return;
                 }
                 widget.set_visible(true);


### PR DESCRIPTION
Summary:
- Add an optional clock notification control panel.
- Add quieter memory, bluetooth, and VPN bar display options.

Testing:
- cargo test --workspace --all-targets
- Manually tested by me.

Disclosure: This code was generated using Codex GPT-5.5.