### PR TITLE
tests: add visual regression coverage

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+echo '+cargo test --all'
+cargo test --all
+if command -v xvfb-run >/dev/null 2>&1; then
+    echo '+scripts/run-ui-regression-tests.sh'
+    scripts/run-ui-regression-tests.sh
+else
+    printf '%s\n' 'skipping scripts/run-ui-regression-tests.sh: xvfb-run is not installed'
+fi
+echo '+cargo clippy --all -- -D warnings'
+cargo clippy --all -- -D warnings
+echo '+cargo fmt --all -- --check'
+cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,26 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test --verbose
 
+  ui-regression-tests:
+    runs-on: ubuntu-latest
+    container: rust:trixie
+    name: UI Regression Tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y \
+            libgtk-4-dev \
+            libgtk4-layer-shell-dev \
+            libpulse-dev \
+            libudev-dev \
+            libdbus-1-dev \
+            xvfb
+      - uses: Swatinem/rust-cache@v2
+      - name: Run display-required UI regression tests
+        run: scripts/run-ui-regression-tests.sh
+
   font-check:
     runs-on: ubuntu-latest
     name: Font subset manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
             libdbus-1-dev
           rustup component add clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test --verbose
 
@@ -54,6 +56,8 @@ jobs:
             libdbus-1-dev \
             xvfb
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run display-required UI regression tests
         run: scripts/run-ui-regression-tests.sh
 

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -703,7 +703,6 @@ impl ThemePalette {
     --bar-padding-y: {bar_padding_y}px;
     --bar-padding-y-bottom: {bar_padding_y_bottom}px;
     --widget-height: {widget_height}px;
-    --widget-padding-x: {widget_padding_x}px;
     --widget-padding-y: {widget_padding_y}px;
     --spacing-internal: {internal_spacing}px;
     --spacing-widget-edge: {widget_content_edge}px;
@@ -831,7 +830,6 @@ impl ThemePalette {
                 center_pad
             },
             widget_height = self.sizes.widget_height,
-            widget_padding_x = self.sizes.widget_padding_x,
             widget_padding_y = self.sizes.widget_padding_y,
             internal_spacing = self.sizes.internal_spacing,
             widget_content_edge = self.sizes.widget_content_edge,
@@ -1560,6 +1558,15 @@ impl Default for ThemePalette {
 mod tests {
     use super::*;
 
+    fn css_var_value<'a>(css: &'a str, var_name: &str) -> Option<&'a str> {
+        let needle = format!("{var_name}:");
+        css.lines().find_map(|line| {
+            let trimmed = line.trim();
+            let value = trimmed.strip_prefix(&needle)?;
+            Some(value.trim().trim_end_matches(';').trim())
+        })
+    }
+
     #[test]
     fn test_parse_hex_color_valid() {
         assert_eq!(parse_hex_color("#ff0000"), Some((255, 0, 0)));
@@ -1671,6 +1678,96 @@ mod tests {
         assert!(css.contains("--radius-bar:"));
         assert!(css.contains("--widget-height:"));
         assert!(css.contains("--font-family:"));
+    }
+
+    #[test]
+    fn test_css_vars_block_emits_bar_visual_config_tokens() {
+        let mut config = Config::default();
+        config.bar.size = 40;
+        config.bar.padding = 10;
+        config.bar.background_opacity = 1.0;
+        config.bar.background_color = Some("#445566".to_string());
+        config.bar.border_radius = 50;
+        config.theme.outline = true;
+        config.theme.outline_width = 3;
+        config.bar.outline = Some(true);
+
+        let palette = ThemePalette::from_config(&config, None, None);
+        let css = palette.css_vars_block();
+        let expected_widget_height = format!("{}px", palette.sizes.widget_height);
+        let expected_bar_radius = format!("{}px", palette.bar_border_radius);
+
+        assert_eq!(css_var_value(&css, "--bar-height"), Some("40px"));
+        assert_eq!(
+            css_var_value(&css, "--widget-height"),
+            Some(expected_widget_height.as_str())
+        );
+        assert_eq!(css_var_value(&css, "--bar-padding-y"), Some("10px"));
+        assert_eq!(css_var_value(&css, "--bar-padding-y-bottom"), Some("10px"));
+        assert_eq!(
+            css_var_value(&css, "--color-background-bar"),
+            Some("#445566")
+        );
+        assert_eq!(
+            css_var_value(&css, "--radius-bar"),
+            Some(expected_bar_radius.as_str())
+        );
+        assert_eq!(
+            css_var_value(&css, "--bar-outline-width"),
+            Some("var(--outline-width)")
+        );
+        assert_eq!(css_var_value(&css, "--outline-width"), Some("3px"));
+    }
+
+    #[test]
+    fn test_css_vars_block_emits_transparent_bar_tokens() {
+        let mut config = Config::default();
+        config.bar.padding = 10;
+        config.bar.background_opacity = 0.0;
+
+        let css = ThemePalette::from_config(&config, None, None).css_vars_block();
+
+        assert_eq!(
+            css_var_value(&css, "--color-background-bar"),
+            Some("transparent")
+        );
+        assert_eq!(css_var_value(&css, "--bar-padding-y"), Some("10px"));
+        assert_eq!(css_var_value(&css, "--bar-padding-y-bottom"), Some("0px"));
+    }
+
+    #[test]
+    fn test_css_vars_block_emits_widget_visual_config_tokens() {
+        let mut config = Config::default();
+        config.widgets.background_color = Some("#445566".to_string());
+        config.widgets.background_opacity = 0.35;
+        config.widgets.popover_background_opacity = Some(0.42);
+        config.widgets.border_radius = 50;
+        config.theme.outline = true;
+        config.theme.outline_width = 3;
+        config.widgets.outline = Some(true);
+
+        let palette = ThemePalette::from_config(&config, None, None);
+        let css = palette.css_vars_block();
+
+        assert_eq!(
+            css_var_value(&css, "--widget-background-color"),
+            Some("#445566")
+        );
+        assert_eq!(
+            css_var_value(&css, "--widget-background-opacity"),
+            Some("35%")
+        );
+        assert_eq!(
+            css_var_value(&css, "--popover-background-opacity"),
+            Some("42%")
+        );
+        assert_eq!(css_var_value(&css, "--radius-widget"), Some("9999px"));
+        assert_eq!(
+            css_var_value(&css, "--widget-outline-width"),
+            Some("var(--outline-width)")
+        );
+        assert_eq!(css_var_value(&css, "--outline-width"), Some("3px"));
+        assert_eq!(palette.widget_radius_percent, 50);
     }
 
     #[test]

--- a/crates/vibepanel/Cargo.toml
+++ b/crates/vibepanel/Cargo.toml
@@ -42,10 +42,6 @@ image = { workspace = true }
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = [
-    "precommit-hook",
-    "run-for-all",
-    "run-cargo-test",
-    "run-cargo-clippy",
-    "run-cargo-fmt",
+    "user-hooks",
 ] }
 toml = { workspace = true }

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -26,66 +26,38 @@ use crate::widgets::{
     trigger_ripple_from_gesture,
 };
 
-/// Create and configure the bar window with layer-shell.
+/// Total bar window/content height reserved for the shell.
 ///
-/// The `state` parameter is used to store widget handles, keeping them alive
-/// for the lifetime of the bar. The `output_id` is the monitor connector name
-/// used for per-monitor widget filtering.
-pub fn create_bar_window(
-    app: &Application,
-    config: &Config,
-    monitor: &gtk4::gdk::Monitor,
-    output_id: &str,
-    state: &mut BarState,
-) -> ApplicationWindow {
-    // Window height determines the exclusive zone (via auto_exclusive_zone_enable).
-    // - When bar is visible (opacity > 0): include padding on both sides.
-    // - When bar is transparent (opacity = 0): include only screen-edge padding;
-    //   CSS suppresses the center-side padding in islands mode.
-    let bar_height = if config.bar.background_opacity > 0.0 {
+/// When the bar background is visible, user padding contributes on both sides.
+/// In transparent/islands mode, CSS still applies the screen-edge padding so
+/// widgets are visually offset from the edge, but suppresses center-side
+/// padding to keep the reserved area tighter than visible-bar mode.
+pub(crate) fn rendered_bar_height(config: &Config) -> i32 {
+    if config.bar.background_opacity > 0.0 {
         config.bar.size as i32 + 2 * config.bar.padding as i32
     } else {
         config.bar.size as i32 + config.bar.padding as i32
-    };
+    }
+}
 
-    let window = ApplicationWindow::builder()
-        .application(app)
-        .title("vibepanel")
-        .decorated(false)
-        .resizable(false)
-        .default_height(bar_height)
-        .build();
+/// Production-built bar content shared by the layer-shell window path and
+/// runtime UI regression tests.
+pub(crate) struct BuiltBarContent {
+    pub root: gtk4::Box,
+    pub bar: SectionedBar,
+}
 
-    window.add_css_class(class::BAR_WINDOW);
-
-    // Initialize layer-shell
-    window.init_layer_shell();
-    window.set_namespace(Some("vibepanel"));
-    window.set_layer(Layer::Top);
-
-    // Bind to specific monitor - this should handle width automatically
-    window.set_monitor(Some(monitor));
-    debug!("Bar bound to monitor: {:?}", monitor.connector());
-
-    // Anchor to the configured edge, stretch horizontally
-    let is_bottom = config.bar.is_bottom();
-    window.set_anchor(Edge::Top, !is_bottom);
-    window.set_anchor(Edge::Left, true);
-    window.set_anchor(Edge::Right, true);
-    window.set_anchor(Edge::Bottom, is_bottom);
-
-    // Reserve space (exclusive zone) so other windows don't overlap
-    window.auto_exclusive_zone_enable();
-
-    // Bar doesn't need keyboard input
-    window.set_keyboard_mode(KeyboardMode::None);
-
-    // Set margins from config (legacy behavior)
-    // We keep window margins at 0 for left/right so the bar window
-    // fills the monitor width; screen_margin is applied inside the
-    // bar content instead.
-    let margin = config.bar.screen_margin as i32;
-
+/// Build the real bar widget tree without creating the layer-shell window.
+///
+/// This is intentionally production code: `create_bar_window()` uses this same
+/// builder before adding layer-shell/window-specific behavior, and UI tests
+/// use it to avoid maintaining a parallel bar implementation.
+pub(crate) fn build_bar_content(
+    app: &Application,
+    config: &Config,
+    state: &mut BarState,
+    output_id: Option<&str>,
+) -> BuiltBarContent {
     // Create the bar container using SectionedBar for proper left/center/right layout
     let bar_box = SectionedBar::new(
         config.bar.spacing as i32,
@@ -108,6 +80,7 @@ pub fn create_bar_window(
     // Spacer: empty area between bar content and screen edge.
     // For top bar, spacer goes above (pushes bar down from top edge).
     // For bottom bar, spacer goes below (pushes bar up from bottom edge).
+    let margin = config.bar.screen_margin as i32;
     let spacer = if margin > 0 {
         let s = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
         s.set_size_request(-1, margin);
@@ -117,6 +90,7 @@ pub fn create_bar_window(
         None
     };
 
+    let is_bottom = config.bar.is_bottom();
     if !is_bottom && let Some(ref spacer) = spacer {
         outer_box.append(spacer);
     }
@@ -156,22 +130,77 @@ pub fn create_bar_window(
     );
 
     // Create left section
-    let left_section = create_section("left", config, state, &qs_handle, Some(output_id));
+    let left_section = create_section("left", config, state, &qs_handle, output_id);
     bar_box.set_start_widget(Some(&left_section));
 
     // Create center section only if there are center widgets
     // Without a center widget, the layout manager uses linear allocation
     let has_center_content = !config.widgets.resolved_center().is_empty();
     if has_center_content {
-        let center_section = create_center_section(config, state, &qs_handle, Some(output_id));
+        let center_section = create_center_section(config, state, &qs_handle, output_id);
         bar_box.set_center_widget(Some(&center_section));
     }
 
     // Create right section
-    let right_section = create_section("right", config, state, &qs_handle, Some(output_id));
+    let right_section = create_section("right", config, state, &qs_handle, output_id);
     bar_box.set_end_widget(Some(&right_section));
 
-    window.set_child(Some(&outer_box));
+    BuiltBarContent {
+        root: outer_box,
+        bar: bar_box,
+    }
+}
+
+/// Create and configure the bar window with layer-shell.
+///
+/// The `state` parameter is used to store widget handles, keeping them alive
+/// for the lifetime of the bar. The `output_id` is the monitor connector name
+/// used for per-monitor widget filtering.
+pub fn create_bar_window(
+    app: &Application,
+    config: &Config,
+    monitor: &gtk4::gdk::Monitor,
+    output_id: &str,
+    state: &mut BarState,
+) -> ApplicationWindow {
+    let bar_height = rendered_bar_height(config);
+
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("vibepanel")
+        .decorated(false)
+        .resizable(false)
+        .default_height(bar_height)
+        .build();
+
+    window.add_css_class(class::BAR_WINDOW);
+
+    // Initialize layer-shell
+    window.init_layer_shell();
+    window.set_namespace(Some("vibepanel"));
+    window.set_layer(Layer::Top);
+
+    // Bind to specific monitor - this should handle width automatically
+    window.set_monitor(Some(monitor));
+    debug!("Bar bound to monitor: {:?}", monitor.connector());
+
+    // Anchor to the configured edge, stretch horizontally
+    let is_bottom = config.bar.is_bottom();
+    window.set_anchor(Edge::Top, !is_bottom);
+    window.set_anchor(Edge::Left, true);
+    window.set_anchor(Edge::Right, true);
+    window.set_anchor(Edge::Bottom, is_bottom);
+
+    // Reserve space (exclusive zone) so other windows don't overlap
+    window.auto_exclusive_zone_enable();
+
+    // Bar doesn't need keyboard input
+    window.set_keyboard_mode(KeyboardMode::None);
+
+    let built_content = build_bar_content(app, config, state, Some(output_id));
+    let bar_box = built_content.bar.clone();
+
+    window.set_child(Some(&built_content.root));
 
     // Set window width to the target monitor's width on map.
     // We capture the geometry now rather than using monitor_at_surface() later,
@@ -1094,7 +1123,7 @@ pub(crate) fn replace_user_css() {
 }
 
 /// Generate CSS string from configuration and theme palette.
-fn generate_css(
+pub(crate) fn generate_css(
     config: &Config,
     palette: &ThemePalette,
     popover_palette: Option<&ThemePalette>,
@@ -1123,236 +1152,5 @@ fn generate_css(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::widgets::PopoverKind::{System, Unmergeable};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    struct TestDir(PathBuf);
-
-    impl TestDir {
-        fn new(name: &str) -> Self {
-            let unique = format!(
-                "{}_{}_{}",
-                name,
-                std::process::id(),
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos()
-            );
-            let path = std::env::temp_dir().join(unique);
-            std::fs::create_dir_all(&path).unwrap();
-            Self(path)
-        }
-
-        fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-
-    impl Drop for TestDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
-    #[test]
-    fn merge_runs_empty() {
-        assert_eq!(compute_merge_runs(&[]), vec![]);
-    }
-
-    #[test]
-    fn merge_runs_unmergeable_never_grouped() {
-        let runs = compute_merge_runs(&[
-            MergeKind::Popover(Unmergeable),
-            MergeKind::Popover(Unmergeable),
-            MergeKind::Popover(Unmergeable),
-        ]);
-        assert_eq!(
-            runs,
-            vec![
-                (Unmergeable, 0, 1),
-                (Unmergeable, 1, 2),
-                (Unmergeable, 2, 3),
-            ]
-        );
-    }
-
-    #[test]
-    fn merge_runs_system_grouping() {
-        // Consecutive System entries merge into one run
-        assert_eq!(
-            compute_merge_runs(&[
-                MergeKind::Popover(System),
-                MergeKind::Popover(System),
-                MergeKind::Popover(System),
-            ]),
-            vec![(System, 0, 3)]
-        );
-        // Unmergeable breaks a System run; singleton System stays singleton
-        assert_eq!(
-            compute_merge_runs(&[
-                MergeKind::Popover(System),
-                MergeKind::Popover(System),
-                MergeKind::Popover(Unmergeable),
-                MergeKind::Popover(System),
-            ]),
-            vec![(System, 0, 2), (Unmergeable, 2, 3), (System, 3, 4)],
-        );
-        // Single System is its own run
-        assert_eq!(
-            compute_merge_runs(&[MergeKind::Popover(System)]),
-            vec![(System, 0, 1)]
-        );
-    }
-
-    #[test]
-    fn merge_runs_spacer_absorbed_between_same_kind() {
-        // cpu, spacer, memory → still merges into one System run
-        assert_eq!(
-            compute_merge_runs(&[
-                MergeKind::Popover(System),
-                MergeKind::Spacer,
-                MergeKind::Popover(System),
-            ]),
-            vec![(System, 0, 3)]
-        );
-    }
-
-    #[test]
-    fn merge_runs_spacer_absorbed_into_left_run() {
-        // System, spacer, Unmergeable → spacer attaches to System run
-        assert_eq!(
-            compute_merge_runs(&[
-                MergeKind::Popover(System),
-                MergeKind::Spacer,
-                MergeKind::Popover(Unmergeable),
-            ]),
-            vec![(System, 0, 2), (Unmergeable, 2, 3)]
-        );
-    }
-
-    #[test]
-    fn merge_runs_leading_spacer_absorbed() {
-        // spacer, System, System → leading spacer joins first run
-        assert_eq!(
-            compute_merge_runs(&[
-                MergeKind::Spacer,
-                MergeKind::Popover(System),
-                MergeKind::Popover(System),
-            ]),
-            vec![(System, 0, 3)]
-        );
-    }
-
-    #[test]
-    fn merge_runs_trailing_spacer_absorbed() {
-        // System, spacer → trailing spacer joins the System run
-        assert_eq!(
-            compute_merge_runs(&[MergeKind::Popover(System), MergeKind::Spacer]),
-            vec![(System, 0, 2)]
-        );
-    }
-
-    #[test]
-    fn merge_runs_all_spacers_get_no_runs() {
-        // Spacers only exist to join painted groups; alone they build nothing.
-        assert_eq!(
-            compute_merge_runs(&[MergeKind::Spacer, MergeKind::Spacer]),
-            Vec::new()
-        );
-    }
-
-    #[test]
-    fn user_css_search_paths_config_dir_first() {
-        let dir = std::path::Path::new("/custom/config/dir");
-        let paths = user_css_search_paths_from_env(
-            Some(dir),
-            Some(Path::new("/xdg-home")),
-            Some(Path::new("/home/test")),
-        );
-        assert_eq!(
-            paths,
-            vec![
-                dir.join("style.css"),
-                PathBuf::from("/xdg-home/vibepanel/style.css"),
-                PathBuf::from("/home/test/.config/vibepanel/style.css"),
-                PathBuf::from("style.css"),
-            ]
-        );
-    }
-
-    #[test]
-    fn user_css_search_paths_deduplicates() {
-        let paths = user_css_search_paths_from_env(
-            Some(Path::new("/home/test/.config/vibepanel")),
-            Some(Path::new("/home/test/.config")),
-            Some(Path::new("/home/test")),
-        );
-        assert_eq!(
-            paths,
-            vec![
-                PathBuf::from("/home/test/.config/vibepanel/style.css"),
-                PathBuf::from("style.css"),
-            ]
-        );
-    }
-
-    #[test]
-    fn user_css_search_paths_none_config_dir_still_has_entries() {
-        let paths = user_css_search_paths_from_env(None, None, None);
-        assert_eq!(
-            paths,
-            vec![PathBuf::from("style.css")],
-            "without config/XDG/HOME, only the CWD fallback remains"
-        );
-    }
-
-    #[test]
-    fn user_css_search_paths_xdg_dedup_with_home() {
-        let paths = user_css_search_paths_from_env(
-            None,
-            Some(Path::new("/home/test/.config")),
-            Some(Path::new("/home/test")),
-        );
-        assert_eq!(
-            paths,
-            vec![
-                PathBuf::from("/home/test/.config/vibepanel/style.css"),
-                PathBuf::from("style.css"),
-            ]
-        );
-    }
-
-    #[test]
-    fn find_user_css_returns_none_when_no_file_exists() {
-        // Pass a config_dir that does not contain style.css; without HOME/XDG
-        // overrides the CWD fallback is unlikely to exist either, but we use an
-        // empty tmp dir as config_dir so that slot is definitely absent.
-        let tmp = TestDir::new("vibepanel_test_missing_css");
-        // An empty directory: none of the candidate paths will exist.
-        let result =
-            user_css_search_paths_from_env(Some(tmp.path()), Some(tmp.path()), Some(tmp.path()))
-                .into_iter()
-                .find(|p| p.exists());
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn find_user_css_finds_existing_file() {
-        // Create a real style.css in a temp directory and point config_dir at
-        // it so find_user_css returns the config-adjacent path (highest priority).
-        let tmp = TestDir::new("vibepanel_test_css");
-        let style_path = tmp.path().join("style.css");
-        std::fs::write(&style_path, "/* test */").unwrap();
-
-        // Use the injected-env helper so we don't depend on real HOME/XDG.
-        let found =
-            user_css_search_paths_from_env(Some(tmp.path()), Some(tmp.path()), Some(tmp.path()))
-                .into_iter()
-                .find(|p| p.exists());
-
-        assert_eq!(found, Some(style_path));
-    }
-}
+#[path = "bar_tests.rs"]
+mod tests;

--- a/crates/vibepanel/src/bar_tests.rs
+++ b/crates/vibepanel/src/bar_tests.rs
@@ -1,0 +1,711 @@
+use super::*;
+use crate::popover_registry::{self, DispatchAction};
+use crate::services::compositor::CompositorManager;
+use crate::ui_regression_test_support::{
+    find_descendant_with_class, first_monitor_or_skip, flush_gtk, init_layer_shell_or_skip,
+    registered_test_app, run_ignored_contract_subprocess,
+};
+use crate::widgets::PopoverKind::{System, Unmergeable};
+use crate::widgets::layer_shell_popover::{
+    LayerShellPopover, calculate_bar_exclusive_zone, calculate_popover_bar_margin, popover_bar_edge,
+};
+use std::time::{SystemTime, UNIX_EPOCH};
+use vibepanel_core::config::WidgetPlacement;
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new(name: &str) -> Self {
+        let unique = format!(
+            "{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn layer_shell_test_config() -> Config {
+    let mut config = Config::default();
+    config.theme.mode = "dark".to_string();
+    config.bar.size = 32;
+    config.bar.spacing = 8;
+    config.bar.inset = 8;
+    config.bar.screen_margin = 0;
+    config.theme.animations = false;
+    config.advanced.compositor = "mango".to_string();
+    config.widgets.left = vec![WidgetPlacement::Single("custom-a".to_string())];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+
+    let mut custom_a = vibepanel_core::config::WidgetOptions::default();
+    custom_a
+        .options
+        .insert("label".to_string(), toml::Value::String("A".to_string()));
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-a".to_string(), custom_a);
+
+    config
+}
+
+struct LayerShellContext {
+    app: Application,
+    monitor: gtk4::gdk::Monitor,
+}
+
+fn layer_shell_context_or_skip() -> Option<LayerShellContext> {
+    let display = init_layer_shell_or_skip("layer-shell contract")?;
+    let monitor = first_monitor_or_skip(&display, "layer-shell contract")?;
+
+    Some(LayerShellContext {
+        app: registered_test_app("dev.vibepanel.layer-shell-contract"),
+        monitor,
+    })
+}
+
+fn apply_layer_shell_config(config: &Config, init_compositor: bool) {
+    ConfigManager::init_global(config.clone(), None);
+    if init_compositor {
+        CompositorManager::init_global(&config.advanced);
+    }
+    load_css(config);
+}
+
+struct LayerShellBarFixture {
+    window: ApplicationWindow,
+    _state: BarState,
+}
+
+fn present_layer_shell_bar(
+    context: &LayerShellContext,
+    config: &Config,
+    init_compositor: bool,
+) -> LayerShellBarFixture {
+    apply_layer_shell_config(config, init_compositor);
+    let mut state = BarState::new();
+    let window = create_bar_window(
+        &context.app,
+        config,
+        &context.monitor,
+        "layer-test",
+        &mut state,
+    );
+    window.present();
+    flush_gtk();
+
+    LayerShellBarFixture {
+        window,
+        _state: state,
+    }
+}
+
+fn run_layer_shell_contract_subprocess(contract: &str) {
+    run_ignored_contract_subprocess(
+        "layer_shell_contract_runner",
+        "VIBEPANEL_LAYER_SHELL_CONTRACT",
+        contract,
+        "layer-shell contract",
+    );
+}
+
+fn run_layer_shell_bar_position_contract(position: &str) {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut top_config = layer_shell_test_config();
+    top_config.bar.position = position.to_string();
+    let bar = present_layer_shell_bar(&context, &top_config, false);
+    let top_window = &bar.window;
+
+    let expect_bottom = position == "bottom";
+
+    assert!(top_window.is_layer_window());
+    assert_eq!(
+        top_window.is_anchor(gtk4_layer_shell::Edge::Top),
+        !expect_bottom,
+        "top anchor should track bar.position"
+    );
+    assert!(top_window.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert!(top_window.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert_eq!(
+        top_window.is_anchor(gtk4_layer_shell::Edge::Bottom),
+        expect_bottom,
+        "bottom anchor should track bar.position"
+    );
+    assert_eq!(top_window.layer(), gtk4_layer_shell::Layer::Top);
+    assert_eq!(
+        top_window.keyboard_mode(),
+        gtk4_layer_shell::KeyboardMode::None
+    );
+    assert!(top_window.auto_exclusive_zone_is_enabled());
+    assert_eq!(top_window.namespace().as_deref(), Some("vibepanel"));
+    assert_eq!(top_window.monitor().as_ref(), Some(&context.monitor));
+
+    top_window.close();
+    flush_gtk();
+}
+
+fn run_layer_shell_bar_height_contract(background_opacity: f64) {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.bar.padding = 10;
+    config.bar.background_opacity = background_opacity;
+    let bar = present_layer_shell_bar(&context, &config, false);
+    let window = &bar.window;
+
+    let expected_height = rendered_bar_height(&config);
+    let (_default_width, default_height) = window.default_size();
+
+    assert_eq!(default_height, expected_height);
+    assert!(window.auto_exclusive_zone_is_enabled());
+    assert!(window.height() >= expected_height);
+
+    window.close();
+    flush_gtk();
+}
+
+fn run_layer_shell_popover_position_contract(position: &str) {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.bar.position = position.to_string();
+    config.bar.padding = 10;
+    config.bar.popover_offset = 18;
+    config.bar.background_opacity = 1.0;
+    apply_layer_shell_config(&config, true);
+
+    let popover = LayerShellPopover::new(&context.app, "contract", || {
+        gtk4::Label::new(Some("contract popover")).upcast::<gtk4::Widget>()
+    });
+    popover.show_at(160, Some(context.monitor.clone()));
+    flush_gtk();
+
+    let Some(window) = popover.test_window() else {
+        panic!("popover should create a layer-shell window when shown");
+    };
+    let Some(catcher) = popover.test_click_catcher() else {
+        panic!("popover should create a click-catcher when shown");
+    };
+
+    let expect_bottom = position == "bottom";
+    let bar_edge = popover_bar_edge();
+    let expected_bar_margin = calculate_popover_bar_margin();
+    let expected_catcher_margin = calculate_bar_exclusive_zone();
+
+    assert!(window.is_layer_window());
+    assert_eq!(
+        window.is_anchor(gtk4_layer_shell::Edge::Top),
+        !expect_bottom,
+        "popover top anchor should track bar.position"
+    );
+    assert!(window.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert_eq!(
+        window.is_anchor(gtk4_layer_shell::Edge::Bottom),
+        expect_bottom,
+        "popover bottom anchor should track bar.position"
+    );
+    assert!(!window.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert_eq!(window.layer(), gtk4_layer_shell::Layer::Top);
+    assert_ne!(window.keyboard_mode(), gtk4_layer_shell::KeyboardMode::None);
+    assert_eq!(window.exclusive_zone(), 0);
+    assert_eq!(
+        window.namespace().as_deref(),
+        Some("vibepanel-contract-popover")
+    );
+    assert_eq!(window.monitor().as_ref(), Some(&context.monitor));
+    assert_eq!(window.margin(bar_edge), expected_bar_margin);
+
+    assert!(catcher.is_layer_window());
+    assert!(catcher.is_anchor(gtk4_layer_shell::Edge::Top));
+    assert!(catcher.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert!(catcher.is_anchor(gtk4_layer_shell::Edge::Bottom));
+    assert!(catcher.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert_eq!(catcher.layer(), gtk4_layer_shell::Layer::Top);
+    assert_eq!(
+        catcher.keyboard_mode(),
+        gtk4_layer_shell::KeyboardMode::None
+    );
+    assert_eq!(catcher.exclusive_zone(), -1);
+    assert_eq!(
+        catcher.namespace().as_deref(),
+        Some("vibepanel-click-catcher")
+    );
+    assert_eq!(catcher.monitor().as_ref(), Some(&context.monitor));
+    assert_eq!(catcher.margin(bar_edge), expected_catcher_margin);
+
+    popover.hide();
+    window.close();
+    catcher.close();
+    flush_gtk();
+}
+
+fn run_layer_shell_popover_offset_contract(position: &str, background_opacity: f64) {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.bar.position = position.to_string();
+    config.bar.popover_offset = 23;
+    config.bar.background_opacity = background_opacity;
+    apply_layer_shell_config(&config, true);
+
+    let popover = LayerShellPopover::new(&context.app, "contract", || {
+        gtk4::Label::new(Some("contract popover")).upcast::<gtk4::Widget>()
+    });
+    popover.show_at(160, Some(context.monitor.clone()));
+    flush_gtk();
+
+    let Some(window) = popover.test_window() else {
+        panic!("popover should create a layer-shell window when shown");
+    };
+    let Some(catcher) = popover.test_click_catcher() else {
+        panic!("popover should create a click-catcher when shown");
+    };
+
+    let bar_edge = popover_bar_edge();
+    let expect_bottom = position == "bottom";
+    let expected_bar_margin = calculate_popover_bar_margin();
+    let expected_catcher_margin = calculate_bar_exclusive_zone();
+
+    assert!(window.is_layer_window());
+    assert_eq!(
+        window.is_anchor(gtk4_layer_shell::Edge::Top),
+        !expect_bottom,
+        "popover top anchor should track bar.position"
+    );
+    assert!(window.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert_eq!(
+        window.is_anchor(gtk4_layer_shell::Edge::Bottom),
+        expect_bottom,
+        "popover bottom anchor should track bar.position"
+    );
+    assert!(!window.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert_eq!(window.layer(), gtk4_layer_shell::Layer::Top);
+    assert_eq!(
+        window.namespace().as_deref(),
+        Some("vibepanel-contract-popover")
+    );
+    assert_eq!(window.monitor().as_ref(), Some(&context.monitor));
+    assert_eq!(window.margin(bar_edge), expected_bar_margin);
+    if config.bar.background_opacity > 0.0 {
+        assert_eq!(
+            window.margin(bar_edge),
+            config.bar.popover_offset as i32 - config.bar.padding as i32
+        );
+    } else {
+        assert_eq!(window.margin(bar_edge), config.bar.popover_offset as i32);
+    }
+
+    assert!(catcher.is_layer_window());
+    assert_eq!(catcher.margin(bar_edge), expected_catcher_margin);
+
+    popover.hide();
+    window.close();
+    catcher.close();
+    flush_gtk();
+}
+
+fn run_layer_shell_clock_popover_contract() {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.widgets.left = vec![WidgetPlacement::Single("clock".to_string())];
+    let bar = present_layer_shell_bar(&context, &config, true);
+
+    assert!(
+        popover_registry::dispatch("clock", DispatchAction::Show),
+        "clock widget should register a popover handle"
+    );
+    flush_gtk();
+
+    let Some(popover_window) = popover_registry::test_layer_shell_window("clock") else {
+        panic!("clock registry handle should expose its real layer-shell popover window");
+    };
+    let Some(child) = popover_window.child() else {
+        panic!("clock popover window should have content after being shown");
+    };
+
+    let bar_edge = popover_bar_edge();
+    let expected_bar_margin = calculate_popover_bar_margin();
+
+    assert!(popover_window.is_layer_window());
+    assert!(popover_window.is_anchor(gtk4_layer_shell::Edge::Top));
+    assert!(popover_window.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert!(!popover_window.is_anchor(gtk4_layer_shell::Edge::Bottom));
+    assert!(!popover_window.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert_eq!(popover_window.layer(), gtk4_layer_shell::Layer::Top);
+    assert_eq!(
+        popover_window.namespace().as_deref(),
+        Some("vibepanel-clock-popover")
+    );
+    assert_eq!(popover_window.monitor().as_ref(), Some(&context.monitor));
+    assert_eq!(popover_window.margin(bar_edge), expected_bar_margin);
+    assert!(
+        find_descendant_with_class(&child, crate::styles::calendar::POPOVER).is_some(),
+        "clock popover should contain calendar popover content"
+    );
+
+    popover_registry::dispatch("clock", DispatchAction::Hide);
+    popover_window.close();
+    bar.window.close();
+    flush_gtk();
+}
+
+fn run_layer_shell_system_widget_popover_contract() {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.widgets.left = vec![WidgetPlacement::Single("cpu".to_string())];
+    let bar = present_layer_shell_bar(&context, &config, true);
+
+    assert!(
+        popover_registry::dispatch("cpu", DispatchAction::Show),
+        "cpu widget should register a system popover handle"
+    );
+    flush_gtk();
+
+    let Some(popover_window) = popover_registry::test_layer_shell_window("cpu") else {
+        panic!("cpu registry handle should expose its real layer-shell popover window");
+    };
+    let Some(child) = popover_window.child() else {
+        panic!("cpu popover window should have content after being shown");
+    };
+
+    let bar_edge = popover_bar_edge();
+    let expected_bar_margin = calculate_popover_bar_margin();
+
+    assert!(popover_window.is_layer_window());
+    assert!(popover_window.is_anchor(gtk4_layer_shell::Edge::Top));
+    assert!(popover_window.is_anchor(gtk4_layer_shell::Edge::Right));
+    assert!(!popover_window.is_anchor(gtk4_layer_shell::Edge::Bottom));
+    assert!(!popover_window.is_anchor(gtk4_layer_shell::Edge::Left));
+    assert_eq!(popover_window.layer(), gtk4_layer_shell::Layer::Top);
+    assert_eq!(
+        popover_window.namespace().as_deref(),
+        Some("vibepanel-cpu-popover")
+    );
+    assert_eq!(popover_window.monitor().as_ref(), Some(&context.monitor));
+    assert_eq!(popover_window.margin(bar_edge), expected_bar_margin);
+    assert!(
+        find_descendant_with_class(&child, crate::styles::system_popover::POPOVER).is_some(),
+        "cpu popover should contain shared system popover content"
+    );
+
+    popover_registry::dispatch("cpu", DispatchAction::Hide);
+    popover_window.close();
+    bar.window.close();
+    flush_gtk();
+}
+
+macro_rules! layer_shell_contract_tests {
+    ($(($test_name:ident, $contract:literal, $runner:expr)),+ $(,)?) => {
+        $(
+            #[test]
+            #[ignore = "layer-shell contract: requires a Wayland compositor with layer-shell support"]
+            fn $test_name() {
+                run_layer_shell_contract_subprocess($contract);
+            }
+        )+
+
+        #[test]
+        #[ignore = "internal runner for one layer-shell contract subprocess"]
+        fn layer_shell_contract_runner() {
+            match std::env::var("VIBEPANEL_LAYER_SHELL_CONTRACT").as_deref() {
+                $(Ok($contract) => $runner,)+
+                Ok(other) => panic!("unknown layer-shell contract: {other}"),
+                Err(_) => eprintln!("skipping layer-shell contract runner: no contract selected"),
+            }
+        }
+    };
+}
+
+layer_shell_contract_tests!(
+    (
+        test_layer_shell_bar_position_top,
+        "bar.position.top",
+        run_layer_shell_bar_position_contract("top")
+    ),
+    (
+        test_layer_shell_bar_position_bottom,
+        "bar.position.bottom",
+        run_layer_shell_bar_position_contract("bottom")
+    ),
+    (
+        test_layer_shell_bar_height_visible,
+        "bar.height.visible",
+        run_layer_shell_bar_height_contract(1.0)
+    ),
+    (
+        test_layer_shell_bar_height_transparent,
+        "bar.height.transparent",
+        run_layer_shell_bar_height_contract(0.0)
+    ),
+    (
+        test_layer_shell_popover_position_top,
+        "popover.position.top",
+        run_layer_shell_popover_position_contract("top")
+    ),
+    (
+        test_layer_shell_popover_position_bottom,
+        "popover.position.bottom",
+        run_layer_shell_popover_position_contract("bottom")
+    ),
+    (
+        test_layer_shell_popover_offset_top,
+        "popover.offset.top",
+        run_layer_shell_popover_offset_contract("top", 0.0)
+    ),
+    (
+        test_layer_shell_popover_offset_bottom,
+        "popover.offset.bottom",
+        run_layer_shell_popover_offset_contract("bottom", 0.0)
+    ),
+    (
+        test_layer_shell_popover_offset_visible_top,
+        "popover.offset.visible.top",
+        run_layer_shell_popover_offset_contract("top", 1.0)
+    ),
+    (
+        test_layer_shell_popover_offset_visible_bottom,
+        "popover.offset.visible.bottom",
+        run_layer_shell_popover_offset_contract("bottom", 1.0)
+    ),
+    (
+        test_layer_shell_clock_widget_popover,
+        "widget.clock.popover",
+        run_layer_shell_clock_popover_contract()
+    ),
+    (
+        test_layer_shell_system_widget_popover,
+        "widget.system.popover",
+        run_layer_shell_system_widget_popover_contract()
+    ),
+);
+
+#[test]
+fn merge_runs_empty() {
+    assert_eq!(compute_merge_runs(&[]), vec![]);
+}
+
+#[test]
+fn merge_runs_unmergeable_never_grouped() {
+    let runs = compute_merge_runs(&[
+        MergeKind::Popover(Unmergeable),
+        MergeKind::Popover(Unmergeable),
+        MergeKind::Popover(Unmergeable),
+    ]);
+    assert_eq!(
+        runs,
+        vec![
+            (Unmergeable, 0, 1),
+            (Unmergeable, 1, 2),
+            (Unmergeable, 2, 3),
+        ]
+    );
+}
+
+#[test]
+fn merge_runs_system_grouping() {
+    // Consecutive System entries merge into one run
+    assert_eq!(
+        compute_merge_runs(&[
+            MergeKind::Popover(System),
+            MergeKind::Popover(System),
+            MergeKind::Popover(System),
+        ]),
+        vec![(System, 0, 3)]
+    );
+    // Unmergeable breaks a System run; singleton System stays singleton
+    assert_eq!(
+        compute_merge_runs(&[
+            MergeKind::Popover(System),
+            MergeKind::Popover(System),
+            MergeKind::Popover(Unmergeable),
+            MergeKind::Popover(System),
+        ]),
+        vec![(System, 0, 2), (Unmergeable, 2, 3), (System, 3, 4)],
+    );
+    // Single System is its own run
+    assert_eq!(
+        compute_merge_runs(&[MergeKind::Popover(System)]),
+        vec![(System, 0, 1)]
+    );
+}
+
+#[test]
+fn merge_runs_spacer_absorbed_between_same_kind() {
+    // cpu, spacer, memory → still merges into one System run
+    assert_eq!(
+        compute_merge_runs(&[
+            MergeKind::Popover(System),
+            MergeKind::Spacer,
+            MergeKind::Popover(System),
+        ]),
+        vec![(System, 0, 3)]
+    );
+}
+
+#[test]
+fn merge_runs_spacer_absorbed_into_left_run() {
+    // System, spacer, Unmergeable → spacer attaches to System run
+    assert_eq!(
+        compute_merge_runs(&[
+            MergeKind::Popover(System),
+            MergeKind::Spacer,
+            MergeKind::Popover(Unmergeable),
+        ]),
+        vec![(System, 0, 2), (Unmergeable, 2, 3)]
+    );
+}
+
+#[test]
+fn merge_runs_leading_spacer_absorbed() {
+    // spacer, System, System → leading spacer joins first run
+    assert_eq!(
+        compute_merge_runs(&[
+            MergeKind::Spacer,
+            MergeKind::Popover(System),
+            MergeKind::Popover(System),
+        ]),
+        vec![(System, 0, 3)]
+    );
+}
+
+#[test]
+fn merge_runs_trailing_spacer_absorbed() {
+    // System, spacer → trailing spacer joins the System run
+    assert_eq!(
+        compute_merge_runs(&[MergeKind::Popover(System), MergeKind::Spacer]),
+        vec![(System, 0, 2)]
+    );
+}
+
+#[test]
+fn merge_runs_all_spacers_get_no_runs() {
+    // Spacers only exist to join painted groups; alone they build nothing.
+    assert_eq!(
+        compute_merge_runs(&[MergeKind::Spacer, MergeKind::Spacer]),
+        Vec::new()
+    );
+}
+
+#[test]
+fn user_css_search_paths_config_dir_first() {
+    let dir = std::path::Path::new("/custom/config/dir");
+    let paths = user_css_search_paths_from_env(
+        Some(dir),
+        Some(Path::new("/xdg-home")),
+        Some(Path::new("/home/test")),
+    );
+    assert_eq!(
+        paths,
+        vec![
+            dir.join("style.css"),
+            PathBuf::from("/xdg-home/vibepanel/style.css"),
+            PathBuf::from("/home/test/.config/vibepanel/style.css"),
+            PathBuf::from("style.css"),
+        ]
+    );
+}
+
+#[test]
+fn user_css_search_paths_deduplicates() {
+    let paths = user_css_search_paths_from_env(
+        Some(Path::new("/home/test/.config/vibepanel")),
+        Some(Path::new("/home/test/.config")),
+        Some(Path::new("/home/test")),
+    );
+    assert_eq!(
+        paths,
+        vec![
+            PathBuf::from("/home/test/.config/vibepanel/style.css"),
+            PathBuf::from("style.css"),
+        ]
+    );
+}
+
+#[test]
+fn user_css_search_paths_none_config_dir_still_has_entries() {
+    let paths = user_css_search_paths_from_env(None, None, None);
+    assert_eq!(
+        paths,
+        vec![PathBuf::from("style.css")],
+        "without config/XDG/HOME, only the CWD fallback remains"
+    );
+}
+
+#[test]
+fn user_css_search_paths_xdg_dedup_with_home() {
+    let paths = user_css_search_paths_from_env(
+        None,
+        Some(Path::new("/home/test/.config")),
+        Some(Path::new("/home/test")),
+    );
+    assert_eq!(
+        paths,
+        vec![
+            PathBuf::from("/home/test/.config/vibepanel/style.css"),
+            PathBuf::from("style.css"),
+        ]
+    );
+}
+
+#[test]
+fn find_user_css_returns_none_when_no_file_exists() {
+    // Pass a config_dir that does not contain style.css; without HOME/XDG
+    // overrides the CWD fallback is unlikely to exist either, but we use an
+    // empty tmp dir as config_dir so that slot is definitely absent.
+    let tmp = TestDir::new("vibepanel_test_missing_css");
+    // An empty directory: none of the candidate paths will exist.
+    let result =
+        user_css_search_paths_from_env(Some(tmp.path()), Some(tmp.path()), Some(tmp.path()))
+            .into_iter()
+            .find(|p| p.exists());
+    assert_eq!(result, None);
+}
+
+#[test]
+fn find_user_css_finds_existing_file() {
+    // Create a real style.css in a temp directory and point config_dir at
+    // it so find_user_css returns the config-adjacent path (highest priority).
+    let tmp = TestDir::new("vibepanel_test_css");
+    let style_path = tmp.path().join("style.css");
+    std::fs::write(&style_path, "/* test */").unwrap();
+
+    // Use the injected-env helper so we don't depend on real HOME/XDG.
+    let found =
+        user_css_search_paths_from_env(Some(tmp.path()), Some(tmp.path()), Some(tmp.path()))
+            .into_iter()
+            .find(|p| p.exists());
+
+    assert_eq!(found, Some(style_path));
+}

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -10,6 +10,8 @@ mod sectioned_bar;
 mod services;
 pub mod styles;
 #[cfg(test)]
+mod theme_vars;
+#[cfg(test)]
 mod ui_regression_test_support;
 mod widgets;
 

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -9,6 +9,8 @@ pub mod popover_tracker;
 mod sectioned_bar;
 mod services;
 pub mod styles;
+#[cfg(test)]
+mod ui_regression_test_support;
 mod widgets;
 
 use std::path::{Path, PathBuf};

--- a/crates/vibepanel/src/popover_registry.rs
+++ b/crates/vibepanel/src/popover_registry.rs
@@ -38,6 +38,11 @@ pub trait PopoverToggleable {
     fn monitor_connector(&self) -> Option<String> {
         None
     }
+
+    #[cfg(test)]
+    fn test_layer_shell_window(&self) -> Option<gtk4::ApplicationWindow> {
+        None
+    }
 }
 
 /// Actions that can be dispatched to a registered popover.
@@ -106,6 +111,17 @@ pub fn dispatch(name: &str, action: DispatchAction) -> bool {
         );
         false
     }
+}
+
+#[cfg(test)]
+pub fn test_layer_shell_window(name: &str) -> Option<gtk4::ApplicationWindow> {
+    let normalized = name.replace('-', "_");
+    REGISTRY.with(|r| {
+        r.borrow()
+            .get(&normalized)
+            .and_then(|handles| handles.first())
+            .and_then(|handle| handle.test_layer_shell_window())
+    })
 }
 
 /// Resolve which handle to dispatch to based on the focused monitor.

--- a/crates/vibepanel/src/sectioned_bar.rs
+++ b/crates/vibepanel/src/sectioned_bar.rs
@@ -436,3 +436,7 @@ impl Default for SectionedBar {
         Self::new(8, 12, false, false)
     }
 }
+
+#[cfg(test)]
+#[path = "sectioned_bar_tests.rs"]
+mod tests;

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1,0 +1,1877 @@
+use super::*;
+use crate::theme_vars::{THEME_VAR_EXPECTATIONS, ThemeVarRole, ThemeVarScope};
+use crate::ui_regression_test_support::{
+    CssProviderGuard, Rgba8, assert_pixel_close, center_pixel_of_surface, edge_pixel_of_surface,
+    find_descendant_with_class, flush_gtk, init_gtk_or_skip, maybe_hold_probe_window,
+    painted_surface_fixture_with_classes, run_ignored_contract_subprocess, sample_widget_pixel,
+};
+use crate::widgets::css::{POPOVER_BG_WITH_OPACITY, WIDGET_BG_WITH_OPACITY};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use vibepanel_core::Config;
+
+fn bounds_in_window(
+    widget: &impl IsA<gtk4::Widget>,
+    window: &gtk4::Window,
+) -> (i32, i32, i32, i32) {
+    let bounds = widget
+        .compute_bounds(window.upcast_ref::<gtk4::Widget>())
+        .expect("widget should have bounds after GTK layout");
+
+    (
+        bounds.x().round() as i32,
+        bounds.y().round() as i32,
+        bounds.width().round() as i32,
+        bounds.height().round() as i32,
+    )
+}
+
+fn measured_gap(left: (i32, i32, i32, i32), right: (i32, i32, i32, i32)) -> i32 {
+    right.0 - (left.0 + left.2)
+}
+
+fn count_descendants_with_class(root: &gtk4::Widget, class_name: &str) -> usize {
+    let mut count = usize::from(root.has_css_class(class_name));
+    let mut child = root.first_child();
+    while let Some(widget) = child {
+        count += count_descendants_with_class(&widget, class_name);
+        child = widget.next_sibling();
+    }
+    count
+}
+
+fn collect_descendants_with_class(root: &gtk4::Widget, class_name: &str) -> Vec<gtk4::Widget> {
+    let mut matches = Vec::new();
+    if root.has_css_class(class_name) {
+        matches.push(root.clone());
+    }
+
+    let mut child = root.first_child();
+    while let Some(widget) = child {
+        matches.extend(collect_descendants_with_class(&widget, class_name));
+        child = widget.next_sibling();
+    }
+
+    matches
+}
+
+fn section_widget_class_names(
+    bar: &SectionedBar,
+    section_name: &str,
+    class_names: &[&str],
+) -> Vec<String> {
+    let section = bar
+        .section(section_name)
+        .unwrap_or_else(|| panic!("bar should build a {section_name} section"));
+
+    class_names
+        .iter()
+        .filter(|class_name| find_descendant_with_class(&section, class_name).is_some())
+        .map(|class_name| (*class_name).to_string())
+        .collect()
+}
+
+fn built_bar_fixture(
+    config: &Config,
+) -> (
+    gtk4::Window,
+    SectionedBar,
+    crate::widgets::BarState,
+    PopoverRegistryGuard,
+    CssProviderGuard,
+) {
+    let window_width = 400;
+    let popover_registry_guard = PopoverRegistryGuard::new();
+    let css_provider = widget_css_provider(config);
+    let window = gtk4::Window::builder()
+        .title("vibepanel widgets UI regression test")
+        .default_width(window_width)
+        .default_height(crate::bar::rendered_bar_height(config))
+        .build();
+    let app = gtk4::Application::builder()
+        .application_id("dev.vibepanel.widgets-ui-regression")
+        .build();
+    let mut state = crate::widgets::BarState::new();
+    let built = crate::bar::build_bar_content(&app, config, &mut state, Some("ui-regression-test"));
+    built
+        .root
+        .set_size_request(window_width, crate::bar::rendered_bar_height(config));
+    window.set_child(Some(&built.root));
+    window.present();
+    flush_gtk();
+
+    (
+        window,
+        built.bar,
+        state,
+        popover_registry_guard,
+        css_provider,
+    )
+}
+
+fn widget_options_with_disabled(disabled: bool) -> vibepanel_core::config::WidgetOptions {
+    vibepanel_core::config::WidgetOptions {
+        disabled,
+        ..Default::default()
+    }
+}
+
+fn test_config() -> Config {
+    let mut config = Config::default();
+    config.bar.size = 32;
+    config.bar.spacing = 8;
+    config.bar.screen_margin = 0;
+    config.bar.inset = 8;
+    config.theme.mode = "dark".to_string();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+        vibepanel_core::config::WidgetPlacement::Single("custom-b".to_string()),
+    ];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+
+    let mut custom_a = vibepanel_core::config::WidgetOptions::default();
+    custom_a
+        .options
+        .insert("label".to_string(), toml::Value::String("A".to_string()));
+    let mut custom_b = vibepanel_core::config::WidgetOptions::default();
+    custom_b
+        .options
+        .insert("label".to_string(), toml::Value::String("B".to_string()));
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-a".to_string(), custom_a);
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-b".to_string(), custom_b);
+
+    config
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PaintedBarMetrics {
+    shell_bounds: (i32, i32, i32, i32),
+    bar_bounds: (i32, i32, i32, i32),
+    first_surface_bounds: (i32, i32, i32, i32),
+    painted_surface_gap: i32,
+}
+
+struct PopoverRegistryGuard;
+
+impl PopoverRegistryGuard {
+    fn new() -> Self {
+        crate::popover_registry::clear();
+        Self
+    }
+}
+
+impl Drop for PopoverRegistryGuard {
+    fn drop(&mut self) {
+        crate::popover_registry::clear();
+    }
+}
+
+struct PaintedBarFixture {
+    window: gtk4::Window,
+    _popover_registry_guard: PopoverRegistryGuard,
+    _css_provider: CssProviderGuard,
+    _override_css_provider: Option<CssProviderGuard>,
+    _state: crate::widgets::BarState,
+    root: gtk4::Box,
+    bar: SectionedBar,
+    first_surface: gtk4::Widget,
+    second_surface: gtk4::Widget,
+}
+
+struct UiRegressionTestDir(PathBuf);
+
+impl UiRegressionTestDir {
+    fn new(name: &str) -> Self {
+        let unique = format!(
+            "{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for UiRegressionTestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn set_ui_regression_config(config: &Config) {
+    crate::services::config_manager::ConfigManager::replace_global_for_test(config.clone());
+}
+
+fn set_ui_regression_config_path(config: &Config, config_path: PathBuf) {
+    crate::services::config_manager::ConfigManager::replace_global_with_config_path_for_test(
+        config.clone(),
+        Some(config_path),
+    );
+}
+
+fn widget_css_provider(config: &Config) -> CssProviderGuard {
+    CssProviderGuard::for_config(config, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION)
+}
+
+fn ui_regression_config_css(config: &Config) -> String {
+    let palette = vibepanel_core::ThemePalette::from_config(config, None, None);
+    let popover_palette = vibepanel_core::ThemePalette::popover_palette(config, None, None);
+    crate::bar::generate_css(config, &palette, popover_palette.as_ref())
+}
+
+fn production_bar_declarations(config: &Config) -> String {
+    let css = crate::widgets::css::widget_css(config);
+    let selector = format!(
+        "{}.{class}",
+        crate::styles::class::SECTIONED_BAR,
+        class = crate::styles::class::BAR
+    );
+    let selector_pos = css
+        .find(&selector)
+        .unwrap_or_else(|| panic!("production widget CSS should contain the {selector} selector"));
+    let selector_block = &css[selector_pos..];
+    let block_end = selector_block
+        .find('}')
+        .expect("production bar CSS selector should have a declaration block");
+
+    selector_block[..block_end].to_string()
+}
+fn assert_bar_style_bindings(config: &Config, bar: &SectionedBar) {
+    assert!(
+        bar.has_css_class(crate::styles::class::BAR),
+        "production-built SectionedBar should carry the .bar CSS class"
+    );
+
+    let declarations = production_bar_declarations(config);
+
+    assert!(
+        declarations.contains("background: var(--color-background-bar);"),
+        "production bar CSS should apply --color-background-bar to sectioned-bar.bar"
+    );
+    assert!(
+        declarations.contains("border-radius: var(--radius-bar);"),
+        "production bar CSS should apply --radius-bar to sectioned-bar.bar"
+    );
+    assert!(
+        declarations.contains("border: var(--bar-outline-width) solid"),
+        "production bar CSS should apply --bar-outline-width to sectioned-bar.bar"
+    );
+}
+
+fn production_widget_declarations(config: &Config) -> String {
+    let css = crate::widgets::css::widget_css(config);
+    let selector = ".widget {";
+    let selector_pos = css
+        .find(selector)
+        .expect("production widget CSS should contain the .widget selector");
+    let selector_block = &css[selector_pos..];
+    let block_end = selector_block
+        .find('}')
+        .expect("production .widget selector should have a declaration block");
+
+    selector_block[..block_end].to_string()
+}
+
+fn assert_widget_style_bindings(config: &Config) {
+    let declarations = production_widget_declarations(config);
+
+    assert!(
+        declarations.contains(&format!("background-color: {WIDGET_BG_WITH_OPACITY};")),
+        "production widget CSS should apply --widget-background-color and --widget-background-opacity to .widget"
+    );
+    assert!(
+        declarations.contains("border-radius: var(--radius-widget);"),
+        "production widget CSS should apply --radius-widget to .widget"
+    );
+    assert!(
+        declarations.contains("border: var(--widget-outline-width) solid"),
+        "production widget CSS should apply --widget-outline-width to .widget"
+    );
+}
+
+fn production_popover_declarations(config: &Config) -> String {
+    let css = crate::widgets::css::utility_css(config);
+    let selector = ".vp-surface-popover {";
+    let selector_pos = css
+        .find(selector)
+        .expect("production utility CSS should contain the .vp-surface-popover selector");
+    let selector_block = &css[selector_pos..];
+    let block_end = selector_block
+        .find('}')
+        .expect("production .vp-surface-popover selector should have a declaration block");
+
+    selector_block[..block_end].to_string()
+}
+
+fn assert_popover_style_bindings(config: &Config) {
+    let declarations = production_popover_declarations(config);
+
+    assert!(
+        declarations.contains(&format!("background-color: {POPOVER_BG_WITH_OPACITY};")),
+        "production popover CSS should apply --widget-background-color and --popover-background-opacity to .vp-surface-popover"
+    );
+    assert!(
+        declarations.contains("border: var(--surface-outline-width) solid"),
+        "production popover CSS should apply --surface-outline-width to .vp-surface-popover"
+    );
+}
+
+fn strip_css_comments(css: &str) -> String {
+    let mut stripped = String::with_capacity(css.len());
+    let mut rest = css;
+    while let Some(start) = rest.find("/*") {
+        stripped.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("*/") else {
+            break;
+        };
+        rest = &after_start[end + 2..];
+    }
+    stripped.push_str(rest);
+    stripped
+}
+
+fn declared_css_variables(css: &str) -> BTreeSet<String> {
+    strip_css_comments(css)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_start();
+            if !line.starts_with("--") {
+                return None;
+            }
+            let name = line.split_once(':')?.0.trim();
+            Some(name.to_string())
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CssVarUse {
+    name: String,
+    fallback_vars: Vec<String>,
+    has_fallback: bool,
+    in_hover_selector: bool,
+}
+
+fn matching_paren(input: &str, open_idx: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in input.char_indices().skip_while(|(idx, _)| *idx < open_idx) {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(idx);
+            }
+        }
+    }
+    None
+}
+
+fn split_top_level_once(input: &str, separator: char) -> Option<(&str, &str)> {
+    let mut depth = 0usize;
+    for (idx, ch) in input.char_indices() {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth = depth.saturating_sub(1);
+        } else if ch == separator && depth == 0 {
+            return Some((&input[..idx], &input[idx + ch.len_utf8()..]));
+        }
+    }
+    None
+}
+
+fn css_vars_in_value(value: &str) -> Vec<String> {
+    css_var_uses_in_css(value)
+        .into_iter()
+        .map(|var| var.name)
+        .collect()
+}
+
+fn css_var_uses_in_css(css: &str) -> Vec<CssVarUse> {
+    let css = strip_css_comments(css);
+    let mut uses = Vec::new();
+    let mut offset = 0usize;
+
+    while let Some(relative_start) = css[offset..].find("var(") {
+        let var_start = offset + relative_start;
+        let open_idx = var_start + 3;
+        let Some(close_idx) = matching_paren(&css, open_idx) else {
+            break;
+        };
+        let inner = &css[open_idx + 1..close_idx];
+        let (name_part, fallback_part) = split_top_level_once(inner, ',').unwrap_or((inner, ""));
+        let name = name_part.trim();
+
+        if name.starts_with("--") {
+            let selector_start = css[..var_start].rfind('}').map(|idx| idx + 1).unwrap_or(0);
+            let selector_end = css[selector_start..var_start]
+                .find('{')
+                .map(|idx| selector_start + idx)
+                .unwrap_or(var_start);
+            let selector = &css[selector_start..selector_end];
+            let has_fallback = !fallback_part.trim().is_empty();
+            let fallback_vars = if has_fallback {
+                css_vars_in_value(fallback_part)
+            } else {
+                Vec::new()
+            };
+
+            uses.push(CssVarUse {
+                name: name.to_string(),
+                fallback_vars,
+                has_fallback,
+                in_hover_selector: selector.contains(":hover"),
+            });
+        }
+
+        offset = close_idx + 1;
+    }
+
+    uses
+}
+
+fn rust_composed_theme_var_css() -> &'static str {
+    // Keep this focused on theme vars composed in Rust outside widgets::css::*.
+    // User-facing CSS hooks are documented in the wiki, not mirrored here.
+    concat!(
+        include_str!("services/surfaces.rs"),
+        "\n",
+        include_str!("widgets/osd.rs")
+    )
+}
+
+#[test]
+fn theme_vars_have_valid_internal_consumers() {
+    let config = test_config();
+    let palette = vibepanel_core::ThemePalette::from_config(&config, None, None);
+    let emitted_root_vars = declared_css_variables(&palette.css_vars_block());
+    let production_css = format!(
+        "{}\n{}",
+        crate::widgets::css::utility_css(&config),
+        crate::widgets::css::widget_css(&config)
+    );
+    let var_uses = css_var_uses_in_css(&production_css);
+    let internal_css = format!("{}\n{}", production_css, rust_composed_theme_var_css());
+    let internal_var_uses = css_var_uses_in_css(&internal_css);
+    let consumed = internal_var_uses
+        .iter()
+        .fold(BTreeSet::new(), |mut consumed, var| {
+            consumed.insert(var.name.clone());
+            consumed.extend(var.fallback_vars.iter().cloned());
+            consumed
+        });
+    let expectations_by_name = THEME_VAR_EXPECTATIONS
+        .iter()
+        .map(|var| (var.name, var))
+        .collect::<BTreeMap<_, _>>();
+
+    let missing_builtin_consumers = THEME_VAR_EXPECTATIONS
+        .iter()
+        .filter(|var| var.role == ThemeVarRole::BuiltinCss)
+        .filter(|var| !consumed.contains(var.name))
+        .map(|var| var.name)
+        .collect::<Vec<_>>();
+    assert!(
+        missing_builtin_consumers.is_empty(),
+        "built-in CSS variables must be consumed by production CSS; missing={missing_builtin_consumers:?}"
+    );
+
+    let missing_rust_composed_consumers = THEME_VAR_EXPECTATIONS
+        .iter()
+        .filter(|var| var.role == ThemeVarRole::RustComposedCss)
+        .filter(|var| !consumed.contains(var.name))
+        .map(|var| var.name)
+        .collect::<Vec<_>>();
+    assert!(
+        missing_rust_composed_consumers.is_empty(),
+        "Rust-composed theme vars must be consumed by internal styling paths; missing={missing_rust_composed_consumers:?}"
+    );
+
+    let unknown_consumed = consumed
+        .iter()
+        .filter(|name| {
+            !emitted_root_vars.contains(name.as_str())
+                && !expectations_by_name.contains_key(name.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        unknown_consumed.is_empty(),
+        "production CSS consumes theme vars that are neither emitted nor expected user hooks; unknown={unknown_consumed:?}"
+    );
+
+    let missing_expected_root_vars = THEME_VAR_EXPECTATIONS
+        .iter()
+        .filter(|var| var.scope == ThemeVarScope::Root)
+        .filter(|var| !emitted_root_vars.contains(var.name))
+        .map(|var| var.name)
+        .collect::<Vec<_>>();
+    assert!(
+        missing_expected_root_vars.is_empty(),
+        "theme var expectations reference root vars that are not emitted; missing={missing_expected_root_vars:?}"
+    );
+
+    let optional_builtin_errors = THEME_VAR_EXPECTATIONS
+        .iter()
+        .filter(|var| var.role == ThemeVarRole::OptionalBuiltinCss)
+        .flat_map(|expectation| {
+            let matching_uses = var_uses
+                .iter()
+                .filter(|var_use| var_use.name == expectation.name)
+                .collect::<Vec<_>>();
+            let mut errors = Vec::new();
+            if matching_uses.is_empty() {
+                errors.push(format!("{} is never consumed", expectation.name));
+            }
+            for var_use in matching_uses {
+                if !var_use.has_fallback {
+                    errors.push(format!(
+                        "{} is consumed without a fallback",
+                        expectation.name
+                    ));
+                }
+                for fallback in &var_use.fallback_vars {
+                    let Some(fallback_expectation) = expectations_by_name.get(fallback.as_str())
+                    else {
+                        errors.push(format!(
+                            "{} fallback {} is not in the theme var expectations",
+                            expectation.name, fallback
+                        ));
+                        continue;
+                    };
+                    if fallback_expectation.scope != ThemeVarScope::Root {
+                        errors.push(format!(
+                            "{} fallback {} is not a root variable",
+                            expectation.name, fallback
+                        ));
+                    }
+                    if !emitted_root_vars.contains(fallback.as_str()) {
+                        errors.push(format!(
+                            "{} fallback {} is not emitted by the theme palette",
+                            expectation.name, fallback
+                        ));
+                    }
+                }
+            }
+            errors
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        optional_builtin_errors.is_empty(),
+        "optional built-in CSS variables must be consumed with expected fallbacks; errors={optional_builtin_errors:?}"
+    );
+}
+
+#[test]
+fn theme_vars_cover_hover_bindings() {
+    let config = test_config();
+    let production_css = crate::widgets::css::widget_css(&config);
+    let var_uses = css_var_uses_in_css(&production_css);
+    let hover_vars = THEME_VAR_EXPECTATIONS
+        .iter()
+        .filter(|var| var.hover_binding)
+        .map(|var| var.name)
+        .collect::<Vec<_>>();
+    let missing_hover_bindings = hover_vars
+        .iter()
+        .filter(|name| {
+            !var_uses
+                .iter()
+                .any(|var_use| var_use.name == **name && var_use.in_hover_selector)
+        })
+        .copied()
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing_hover_bindings.is_empty(),
+        "hover CSS variables must be consumed inside :hover selectors; missing={missing_hover_bindings:?}"
+    );
+}
+
+fn outline_color_for_palette(
+    palette: &vibepanel_core::ThemePalette,
+    color: &str,
+    opacity: f64,
+) -> Rgba8 {
+    let resolved = match color {
+        "accent" => palette.accent_primary.as_str(),
+        "foreground" => palette.foreground_primary.as_str(),
+        "subtle" => palette.border_subtle.as_str(),
+        other => other,
+    };
+    let mut rgba = gtk4::gdk::RGBA::parse(resolved)
+        .unwrap_or_else(|_| panic!("resolved outline color should parse: {resolved}"));
+    rgba.set_alpha(rgba.alpha() * opacity as f32);
+    Rgba8::from_gdk(rgba)
+}
+
+fn painted_bar_fixture(config: &Config) -> PaintedBarFixture {
+    painted_bar_fixture_with_override_css(config, None)
+}
+
+fn painted_surface_fixture(
+    config: &Config,
+    class_name: &str,
+) -> crate::ui_regression_test_support::PaintedSurfaceFixture {
+    painted_surface_fixture_with_size(config, class_name, 120, 48)
+}
+
+fn painted_surface_fixture_with_size(
+    config: &Config,
+    class_name: &str,
+    width: i32,
+    height: i32,
+) -> crate::ui_regression_test_support::PaintedSurfaceFixture {
+    painted_surface_fixture_with_classes(config, &[class_name], width, height)
+}
+
+fn painted_bar_fixture_with_override_css(
+    config: &Config,
+    override_css: Option<&str>,
+) -> PaintedBarFixture {
+    set_ui_regression_config(config);
+
+    let window_width = 400;
+    let popover_registry_guard = PopoverRegistryGuard::new();
+    let css_provider = widget_css_provider(config);
+    let override_css_provider = override_css
+        .map(|css| CssProviderGuard::new(css, gtk4::STYLE_PROVIDER_PRIORITY_USER + 100));
+
+    let window = gtk4::Window::builder()
+        .title("vibepanel UI regression config test")
+        .default_width(window_width)
+        .default_height(crate::bar::rendered_bar_height(config))
+        .build();
+
+    let app = gtk4::Application::builder()
+        .application_id("dev.vibepanel.ui-regression")
+        .build();
+    let mut state = crate::widgets::BarState::new();
+    let built = crate::bar::build_bar_content(&app, config, &mut state, Some("ui-regression-test"));
+    built
+        .root
+        .set_size_request(window_width, crate::bar::rendered_bar_height(config));
+    built
+        .bar
+        .set_size_request(window_width, config.bar.size as i32);
+
+    window.set_child(Some(&built.root));
+    window.present();
+    flush_gtk();
+
+    let left_section = built
+        .bar
+        .section("left")
+        .expect("UI regression config should build a left section");
+    assert_bar_style_bindings(config, &built.bar);
+    let first_wrapper = left_section
+        .first_child()
+        .expect("UI regression config should build first widget");
+    let second_wrapper = first_wrapper
+        .next_sibling()
+        .expect("UI regression config should build second widget");
+    let first_surface = find_descendant_with_class(&first_wrapper, crate::styles::class::WIDGET)
+        .expect("first real widget should contain a painted .widget surface");
+    let second_surface = find_descendant_with_class(&second_wrapper, crate::styles::class::WIDGET)
+        .expect("second real widget should contain a painted .widget surface");
+
+    PaintedBarFixture {
+        window,
+        _popover_registry_guard: popover_registry_guard,
+        _css_provider: css_provider,
+        _override_css_provider: override_css_provider,
+        _state: state,
+        root: built.root,
+        bar: built.bar,
+        first_surface,
+        second_surface,
+    }
+}
+
+fn painted_bar_metrics(config: &Config) -> PaintedBarMetrics {
+    let fixture = painted_bar_fixture(config);
+    let shell_bounds = bounds_in_window(&fixture.root, &fixture.window);
+    let bar_bounds = bounds_in_window(&fixture.bar, &fixture.window);
+    let first_surface_bounds = bounds_in_window(&fixture.first_surface, &fixture.window);
+    let second_surface_bounds = bounds_in_window(&fixture.second_surface, &fixture.window);
+    let painted_surface_gap = measured_gap(first_surface_bounds, second_surface_bounds);
+
+    maybe_hold_probe_window();
+
+    fixture.window.close();
+    flush_gtk();
+
+    PaintedBarMetrics {
+        shell_bounds,
+        bar_bounds,
+        first_surface_bounds,
+        painted_surface_gap,
+    }
+}
+
+fn sample_root_pixel(fixture: &PaintedBarFixture, x: i32, y: i32) -> Rgba8 {
+    sample_widget_pixel(&fixture.window, fixture.root.upcast_ref(), x, y)
+}
+
+fn center_pixel_of(fixture: &PaintedBarFixture, widget: &gtk4::Widget) -> Rgba8 {
+    let bounds = bounds_in_window(widget, &fixture.window);
+    sample_root_pixel(fixture, bounds.0 + bounds.2 / 2, bounds.1 + bounds.3 / 2)
+}
+
+fn edge_pixel_of(fixture: &PaintedBarFixture, widget: &gtk4::Widget) -> Rgba8 {
+    let bounds = bounds_in_window(widget, &fixture.window);
+    sample_root_pixel(fixture, bounds.0 + 1, bounds.1 + bounds.3 / 2)
+}
+
+fn assert_luma_delta_at_least(a: Rgba8, b: Rgba8, delta: f64, message: &str) {
+    let observed_delta = (a.luma() - b.luma()).abs();
+    assert!(
+        observed_delta >= delta,
+        "{message}; expected luma delta >= {delta}, observed={observed_delta}, a={a:?}, b={b:?}"
+    );
+}
+
+fn run_ui_regression_config_subprocess(test_case: &str) {
+    run_ignored_contract_subprocess(
+        "ui_regression_config_runner",
+        "VIBEPANEL_UI_REGRESSION_TEST",
+        test_case,
+        "UI regression config test",
+    );
+}
+
+fn run_test_config_bar_size() {
+    let baseline = test_config();
+    let mut changed = baseline.clone();
+    changed.bar.size = 40;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+
+    assert_eq!(
+        changed_metrics.first_surface_bounds.3, changed.bar.size as i32,
+        "bar.size should control the live measured painted widget surface height"
+    );
+    assert_eq!(
+        changed_metrics.bar_bounds.3 - baseline_metrics.bar_bounds.3,
+        (changed.bar.size - baseline.bar.size) as i32,
+        "changing bar.size should grow the live bar allocation by the same delta"
+    );
+    assert_eq!(
+        changed_metrics.painted_surface_gap, baseline_metrics.painted_surface_gap,
+        "changing bar.size should not change bar.spacing's measured painted surface gap"
+    );
+}
+
+fn run_test_config_bar_spacing() {
+    let baseline = test_config();
+    let mut changed = baseline.clone();
+    changed.bar.spacing = 16;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+
+    assert_eq!(
+        changed_metrics.painted_surface_gap, changed.bar.spacing as i32,
+        "bar.spacing should control the live measured gap between painted sibling widget surfaces"
+    );
+    assert_eq!(
+        changed_metrics.bar_bounds.3, baseline_metrics.bar_bounds.3,
+        "changing bar.spacing should not change bar.size's measured bar height"
+    );
+}
+
+fn run_test_config_bar_inset() {
+    let baseline = test_config();
+    let mut changed = baseline.clone();
+    changed.bar.inset = 20;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+
+    assert_eq!(
+        changed_metrics.first_surface_bounds.0, changed.bar.inset as i32,
+        "bar.inset should control the live measured x-position of the first painted widget surface"
+    );
+    assert_eq!(
+        changed_metrics.bar_bounds.3, baseline_metrics.bar_bounds.3,
+        "changing bar.inset should not change bar.size's measured bar height"
+    );
+    assert_eq!(
+        changed_metrics.painted_surface_gap, baseline_metrics.painted_surface_gap,
+        "changing bar.inset should not change bar.spacing's measured painted surface gap"
+    );
+}
+
+fn run_test_config_bar_screen_margin() {
+    let baseline = test_config();
+    let mut changed = baseline.clone();
+    changed.bar.screen_margin = 24;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+
+    let expected_first_x = changed.bar.screen_margin + changed.bar.inset;
+
+    assert_eq!(
+        changed_metrics.first_surface_bounds.0, expected_first_x as i32,
+        "bar.screen_margin should offset the live measured x-position of the first painted widget surface"
+    );
+    assert_eq!(
+        changed_metrics.bar_bounds.3, baseline_metrics.bar_bounds.3,
+        "changing bar.screen_margin should not change bar.size's measured bar height"
+    );
+    assert_eq!(
+        changed_metrics.painted_surface_gap, baseline_metrics.painted_surface_gap,
+        "changing bar.screen_margin should not change bar.spacing's measured painted surface gap"
+    );
+}
+
+fn run_test_config_bar_padding() {
+    let mut baseline = test_config();
+    baseline.bar.background_opacity = 1.0;
+    baseline.bar.padding = 4;
+
+    let mut changed = baseline.clone();
+    changed.bar.padding = 10;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+    let expected_shell_height = crate::bar::rendered_bar_height(&changed);
+
+    assert_eq!(
+        changed_metrics.shell_bounds.3, expected_shell_height,
+        "bar.padding should contribute to live measured rendered shell height when bar background is visible"
+    );
+    assert_eq!(
+        changed_metrics.first_surface_bounds.3, baseline_metrics.first_surface_bounds.3,
+        "changing bar.padding should not change the painted widget surface height"
+    );
+    assert_eq!(
+        changed_metrics.painted_surface_gap, baseline_metrics.painted_surface_gap,
+        "changing bar.padding should not change bar.spacing's measured painted surface gap"
+    );
+}
+
+fn run_test_config_bar_background_opacity() {
+    let mut baseline = test_config();
+    baseline.bar.padding = 10;
+    baseline.bar.background_opacity = 0.0;
+
+    let mut changed = baseline.clone();
+    changed.bar.background_opacity = 1.0;
+
+    let baseline_metrics = painted_bar_metrics(&baseline);
+    let changed_metrics = painted_bar_metrics(&changed);
+
+    assert_eq!(
+        crate::bar::rendered_bar_height(&baseline),
+        baseline.bar.size as i32 + baseline.bar.padding as i32,
+        "transparent bar.background_opacity should include only screen-edge bar.padding in the layer-shell height"
+    );
+    assert_eq!(
+        crate::bar::rendered_bar_height(&changed),
+        changed.bar.size as i32 + 2 * changed.bar.padding as i32,
+        "visible bar.background_opacity should include both sides of bar.padding in the layer-shell height"
+    );
+    assert_eq!(
+        changed_metrics.bar_bounds.3 - baseline_metrics.bar_bounds.3,
+        changed.bar.padding as i32,
+        "changing bar.background_opacity from transparent to visible should expose the center-side bar padding in the live widget tree"
+    );
+    assert_eq!(
+        changed_metrics.painted_surface_gap, baseline_metrics.painted_surface_gap,
+        "changing bar.background_opacity should not change bar.spacing's measured painted surface gap"
+    );
+}
+
+fn run_test_widgets_placement_sections() {
+    let mut config = test_config();
+    config.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Single(
+        "custom-a".to_string(),
+    )];
+    config.widgets.center = vec![vibepanel_core::config::WidgetPlacement::Single(
+        "custom-b".to_string(),
+    )];
+    config.widgets.right = vec![vibepanel_core::config::WidgetPlacement::Single(
+        "clock".to_string(),
+    )];
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+
+    let left_classes = section_widget_class_names(&bar, "left", &["custom-a"]);
+    let center_classes = section_widget_class_names(&bar, "center", &["custom-b"]);
+    let right_classes = section_widget_class_names(&bar, "right", &[crate::styles::widget::CLOCK]);
+
+    assert_eq!(left_classes, vec!["custom-a".to_string()]);
+    assert_eq!(center_classes, vec!["custom-b".to_string()]);
+    assert_eq!(
+        right_classes,
+        vec![crate::styles::widget::CLOCK.to_string()]
+    );
+
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_disabled() {
+    let mut config = test_config();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+        vibepanel_core::config::WidgetPlacement::Single("custom-b".to_string()),
+    ];
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-b".to_string(), widget_options_with_disabled(true));
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let custom_a_count = count_descendants_with_class(&left_section, "custom-a");
+    let custom_b_count = count_descendants_with_class(&left_section, "custom-b");
+
+    assert!(
+        custom_a_count > 0,
+        "enabled sibling should remain present in the real bar tree"
+    );
+    assert_eq!(
+        custom_b_count, 0,
+        "disabled widget should be absent from the real bar tree"
+    );
+
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_grouping_explicit_group() {
+    let mut baseline = test_config();
+    baseline.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+        vibepanel_core::config::WidgetPlacement::Single("custom-b".to_string()),
+    ];
+
+    let mut changed = baseline.clone();
+    changed.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Group {
+        group: vec!["custom-a".to_string(), "custom-b".to_string()],
+    }];
+
+    let (
+        baseline_window,
+        baseline_bar,
+        _baseline_state,
+        _baseline_popover_registry_guard,
+        _baseline_css_provider,
+    ) = built_bar_fixture(&baseline);
+    let (
+        changed_window,
+        changed_bar,
+        _changed_state,
+        _changed_popover_registry_guard,
+        _changed_css_provider,
+    ) = built_bar_fixture(&changed);
+    let baseline_left = baseline_bar
+        .section("left")
+        .expect("baseline bar should build a left section");
+    let changed_left = changed_bar
+        .section("left")
+        .expect("changed bar should build a left section");
+    let baseline_group_count =
+        count_descendants_with_class(&baseline_left, crate::styles::class::WIDGET_GROUP);
+    let changed_group_count =
+        count_descendants_with_class(&changed_left, crate::styles::class::WIDGET_GROUP);
+    let changed_merge_count =
+        count_descendants_with_class(&changed_left, crate::styles::class::WIDGET_MERGE_GROUP);
+    let changed_custom_a_count = count_descendants_with_class(&changed_left, "custom-a");
+    let changed_custom_b_count = count_descendants_with_class(&changed_left, "custom-b");
+
+    assert_eq!(baseline_group_count, 0);
+    assert_eq!(changed_group_count, 1);
+    assert_eq!(changed_merge_count, 0);
+    assert!(changed_custom_a_count > 0);
+    assert!(changed_custom_b_count > 0);
+
+    baseline_window.close();
+    changed_window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_grouping_system_merge() {
+    let mut config = test_config();
+    config.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Group {
+        group: vec!["cpu".to_string(), "memory".to_string()],
+    }];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let group_count =
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_GROUP);
+    let merge_group_count =
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_MERGE_GROUP);
+    let passive_count = count_descendants_with_class(&left_section, crate::styles::class::PASSIVE);
+    let cpu_count = count_descendants_with_class(&left_section, "cpu");
+    let memory_count = count_descendants_with_class(&left_section, "memory");
+
+    assert_eq!(group_count, 1);
+    assert_eq!(merge_group_count, 1);
+    assert_eq!(passive_count, 2);
+    assert!(
+        cpu_count > 0,
+        "cpu should remain visible in the production merge-group subtree"
+    );
+    assert!(
+        memory_count > 0,
+        "memory should remain visible in the production merge-group subtree"
+    );
+
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_grouping_spacing_contract() {
+    let mut config = test_config();
+    config.bar.spacing = 18;
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["custom-b".to_string(), "custom-c".to_string()],
+        },
+    ];
+    let mut custom_c = vibepanel_core::config::WidgetOptions::default();
+    custom_c
+        .options
+        .insert("label".to_string(), toml::Value::String("C".to_string()));
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-c".to_string(), custom_c);
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let group = find_descendant_with_class(&left_section, crate::styles::class::WIDGET_GROUP)
+        .expect("explicit group should render a .widget-group island");
+    let grouped_items = collect_descendants_with_class(&group, crate::styles::class::WIDGET_ITEM);
+    let mut section_surfaces = Vec::new();
+    let mut child = left_section.first_child();
+    while let Some(widget) = child {
+        section_surfaces.push(
+            find_descendant_with_class(&widget, crate::styles::class::WIDGET)
+                .expect("each section child should contain a painted widget surface"),
+        );
+        child = widget.next_sibling();
+    }
+
+    assert_eq!(
+        section_surfaces.len(),
+        2,
+        "left section should have one standalone widget surface and one grouped island surface"
+    );
+    assert_eq!(
+        grouped_items.len(),
+        2,
+        "explicit widget group should keep both custom widgets as grouped items"
+    );
+
+    let standalone_bounds = bounds_in_window(&section_surfaces[0], &window);
+    let group_bounds = bounds_in_window(&section_surfaces[1], &window);
+    let first_grouped_bounds = bounds_in_window(&grouped_items[0], &window);
+    let second_grouped_bounds = bounds_in_window(&grouped_items[1], &window);
+    let external_gap = measured_gap(standalone_bounds, group_bounds);
+    let internal_gap = measured_gap(first_grouped_bounds, second_grouped_bounds);
+
+    assert_eq!(
+        external_gap, config.bar.spacing as i32,
+        "bar.spacing should still separate standalone widgets from explicit groups"
+    );
+    assert_eq!(
+        internal_gap, 0,
+        "explicit group items should not get an extra bar.spacing seam between grouped surfaces"
+    );
+
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_background_color_pixel() {
+    let color = "#445566";
+    let mut config = test_config();
+    config.widgets.background_color = Some(color.to_string());
+    config.widgets.background_opacity = 1.0;
+    if let Some(custom_a) = config.widgets.widget_configs.get_mut("custom-a") {
+        custom_a
+            .options
+            .insert("label".to_string(), toml::Value::String(String::new()));
+    }
+
+    assert_widget_style_bindings(&config);
+
+    let fixture = painted_bar_fixture(&config);
+    let rendered = center_pixel_of(&fixture, &fixture.first_surface);
+    assert_pixel_close(
+        rendered,
+        Rgba8::from_hex(color),
+        "opaque widgets.background_color should paint the sampled widget surface pixel",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_widgets_background_color_precedence_pixel() {
+    let global_color = "#112233";
+    let widget_color = "#445566";
+    let css_color = "#778899";
+
+    let mut config = test_config();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("clock".to_string()),
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+    ];
+    config.widgets.background_color = Some(global_color.to_string());
+    config.widgets.background_opacity = 1.0;
+    config
+        .widgets
+        .widget_configs
+        .entry("clock".to_string())
+        .or_default()
+        .background_color = Some(widget_color.to_string());
+
+    let css = ui_regression_config_css(&config);
+    assert!(
+        css.contains(&format!(
+            ".widget.{clock},",
+            clock = crate::styles::widget::CLOCK
+        )),
+        "per-widget CSS should scope clock overrides to the clock widget class"
+    );
+    assert!(
+        css.contains(&format!("--widget-background-color: {widget_color};")),
+        "clock widget config should emit a per-widget background token override"
+    );
+
+    let widget_fixture = painted_bar_fixture(&config);
+    let widget_rendered = center_pixel_of(&widget_fixture, &widget_fixture.first_surface);
+    assert_pixel_close(
+        widget_rendered,
+        Rgba8::from_hex(widget_color),
+        "clock.background_color should override global widgets.background_color in the rendered widget pixel",
+    );
+    maybe_hold_probe_window();
+    widget_fixture.window.close();
+    flush_gtk();
+
+    let user_css = format!(
+        ".widget.{clock} {{ --widget-background-color: {css_color}; }}",
+        clock = crate::styles::widget::CLOCK
+    );
+    let css_fixture = painted_bar_fixture_with_override_css(&config, Some(&user_css));
+    let css_rendered = center_pixel_of(&css_fixture, &css_fixture.first_surface);
+    assert_pixel_close(
+        css_rendered,
+        Rgba8::from_hex(css_color),
+        "user CSS class override should beat clock.background_color in the rendered widget pixel",
+    );
+    maybe_hold_probe_window();
+    css_fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_bar_background_color_css_override_pixel() {
+    let toml_color = "#112233";
+    let css_color = "#445566";
+
+    let mut config = test_config();
+    config.bar.background_color = Some(toml_color.to_string());
+    config.bar.background_opacity = 1.0;
+
+    let toml_fixture = painted_bar_fixture(&config);
+    let bar_bounds = bounds_in_window(&toml_fixture.bar, &toml_fixture.window);
+    let toml_pixel = sample_root_pixel(
+        &toml_fixture,
+        bar_bounds.0 + 2,
+        bar_bounds.1 + bar_bounds.3 / 2,
+    );
+    assert_pixel_close(
+        toml_pixel,
+        Rgba8::from_hex(toml_color),
+        "bar.background_color should paint the rendered bar background",
+    );
+    maybe_hold_probe_window();
+    toml_fixture.window.close();
+    flush_gtk();
+
+    let user_css = format!(
+        "sectioned-bar.{bar} {{ --color-background-bar: {css_color}; }}",
+        bar = crate::styles::class::BAR
+    );
+    let css_fixture = painted_bar_fixture_with_override_css(&config, Some(&user_css));
+    let css_bar_bounds = bounds_in_window(&css_fixture.bar, &css_fixture.window);
+    let css_pixel = sample_root_pixel(
+        &css_fixture,
+        css_bar_bounds.0 + 2,
+        css_bar_bounds.1 + css_bar_bounds.3 / 2,
+    );
+    assert_pixel_close(
+        css_pixel,
+        Rgba8::from_hex(css_color),
+        "user CSS --color-background-bar override should beat bar.background_color in rendered pixels",
+    );
+    maybe_hold_probe_window();
+    css_fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_user_style_css_production_path_pixel() {
+    let toml_color = "#112233";
+    let css_color = "#445566";
+
+    let mut config = test_config();
+    config.widgets.background_color = Some(toml_color.to_string());
+    config.widgets.background_opacity = 1.0;
+    if let Some(custom_a) = config.widgets.widget_configs.get_mut("custom-a") {
+        custom_a
+            .options
+            .insert("label".to_string(), toml::Value::String(String::new()));
+    }
+
+    let dir = UiRegressionTestDir::new("vibepanel-style-css-ui-regression");
+    let config_path = dir.path().join("config.toml");
+    let style_path = dir.path().join("style.css");
+    std::fs::write(&config_path, "# test config placeholder\n").unwrap();
+    std::fs::write(
+        &style_path,
+        format!(".widget.custom-a {{ --widget-background-color: {css_color}; }}"),
+    )
+    .unwrap();
+
+    set_ui_regression_config_path(&config, config_path);
+    crate::bar::load_css(&config);
+
+    let window_width = 400;
+    let window = gtk4::Window::builder()
+        .title("vibepanel production style.css UI regression test")
+        .default_width(window_width)
+        .default_height(crate::bar::rendered_bar_height(&config))
+        .build();
+    let app = gtk4::Application::builder()
+        .application_id("dev.vibepanel.style-css-ui-regression")
+        .build();
+    let mut state = crate::widgets::BarState::new();
+    let built =
+        crate::bar::build_bar_content(&app, &config, &mut state, Some("ui-regression-test"));
+    built
+        .root
+        .set_size_request(window_width, crate::bar::rendered_bar_height(&config));
+    built
+        .bar
+        .set_size_request(window_width, config.bar.size as i32);
+    window.set_child(Some(&built.root));
+    window.present();
+    flush_gtk();
+
+    let left_section = built
+        .bar
+        .section("left")
+        .expect("UI regression config should build a left section");
+    let first_wrapper = left_section
+        .first_child()
+        .expect("UI regression config should build first widget");
+    let first_surface = find_descendant_with_class(&first_wrapper, crate::styles::class::WIDGET)
+        .expect("first real widget should contain a painted .widget surface");
+    let bounds = bounds_in_window(&first_surface, &window);
+    let rendered = sample_widget_pixel(
+        &window,
+        built.root.upcast_ref(),
+        bounds.0 + bounds.2 / 2,
+        bounds.1 + bounds.3 / 2,
+    );
+
+    assert_pixel_close(
+        rendered,
+        Rgba8::from_hex(css_color),
+        "config-adjacent style.css loaded by production load_css should override rendered widget pixels",
+    );
+
+    std::fs::remove_file(style_path).unwrap();
+    crate::bar::replace_user_css();
+    maybe_hold_probe_window();
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_outline_color_pixels() {
+    for (label, color) in [
+        ("accent", "accent"),
+        ("foreground", "foreground"),
+        ("subtle", "subtle"),
+        ("hex", "#445566"),
+    ] {
+        let mut config = test_config();
+        config.theme.outline = true;
+        config.theme.outline_width = 4;
+        config.theme.outline_color = color.to_string();
+        config.theme.outline_opacity = 1.0;
+        config.widgets.background_color = Some("#101820".to_string());
+        config.widgets.background_opacity = 1.0;
+
+        let palette = vibepanel_core::ThemePalette::from_config(&config, None, None);
+        let expected = outline_color_for_palette(&palette, color, config.theme.outline_opacity)
+            .over(Rgba8::from_hex("#101820"));
+        let fixture = painted_bar_fixture(&config);
+        let rendered = edge_pixel_of(&fixture, &fixture.first_surface);
+
+        assert_pixel_close(
+            rendered,
+            expected,
+            &format!("theme.outline_color={label} should paint the widget border pixel"),
+        );
+
+        maybe_hold_probe_window();
+        fixture.window.close();
+        flush_gtk();
+    }
+}
+
+fn run_test_outline_opacity_and_disabled_pixels() {
+    let mut transparent_config = test_config();
+    transparent_config.theme.outline = true;
+    transparent_config.theme.outline_width = 4;
+    transparent_config.theme.outline_color = "#80a0c0".to_string();
+    transparent_config.theme.outline_opacity = 0.5;
+    transparent_config.widgets.background_color = Some("#101820".to_string());
+    transparent_config.widgets.background_opacity = 1.0;
+
+    let transparent_fixture = painted_bar_fixture(&transparent_config);
+    let transparent_edge = edge_pixel_of(&transparent_fixture, &transparent_fixture.first_surface);
+    assert_pixel_close(
+        transparent_edge,
+        Rgba8::from_hex("#80a0c0")
+            .with_alpha(128)
+            .over(Rgba8::from_hex("#101820")),
+        "theme.outline_opacity should control the rendered border pixel alpha",
+    );
+    maybe_hold_probe_window();
+    transparent_fixture.window.close();
+    flush_gtk();
+
+    let mut disabled_config = transparent_config.clone();
+    disabled_config.widgets.outline = Some(false);
+    disabled_config.theme.outline_opacity = 1.0;
+    let disabled_fixture = painted_bar_fixture(&disabled_config);
+    let disabled_edge = edge_pixel_of(&disabled_fixture, &disabled_fixture.first_surface);
+    assert_pixel_close(
+        disabled_edge,
+        Rgba8::from_hex("#101820"),
+        "widgets.outline=false should remove the rendered widget border",
+    );
+    maybe_hold_probe_window();
+    disabled_fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_per_widget_outline_color_pixel() {
+    let mut config = test_config();
+    config.theme.outline = true;
+    config.theme.outline_width = 4;
+    config.theme.outline_color = "accent".to_string();
+    config.theme.outline_opacity = 1.0;
+    config.theme.accent = Some("#224466".to_string());
+    config.widgets.background_color = Some("#101820".to_string());
+    config.widgets.background_opacity = 1.0;
+    config
+        .widgets
+        .widget_configs
+        .entry("custom-a".to_string())
+        .or_default()
+        .outline_color = Some("foreground".to_string());
+
+    let css = ui_regression_config_css(&config);
+    assert!(
+        css.contains(".widget.custom-a,")
+            && css.contains("--widget-outline-color: var(--color-foreground-primary);"),
+        "per-widget outline_color should emit a scoped widget outline token"
+    );
+
+    let palette = vibepanel_core::ThemePalette::from_config(&config, None, None);
+    let fixture = painted_bar_fixture(&config);
+    let first_edge = edge_pixel_of(&fixture, &fixture.first_surface);
+    let second_edge = edge_pixel_of(&fixture, &fixture.second_surface);
+
+    assert_pixel_close(
+        first_edge,
+        outline_color_for_palette(&palette, "foreground", 1.0),
+        "custom-a.outline_color should override the global outline color on the first widget",
+    );
+    assert_pixel_close(
+        second_edge,
+        outline_color_for_palette(&palette, "accent", 1.0),
+        "sibling widget should keep the global outline color",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_widget_outline_color_css_override_pixel() {
+    let css_color = "#00ff00";
+    let bg_color = "#101820";
+    let mut config = test_config();
+    config.theme.outline = true;
+    config.theme.outline_width = 4;
+    config.theme.outline_color = "accent".to_string();
+    config.theme.outline_opacity = 1.0;
+    config.theme.accent = Some("#224466".to_string());
+    config.widgets.background_color = Some(bg_color.to_string());
+    config.widgets.background_opacity = 1.0;
+
+    let user_css = format!(".widget.custom-a {{ --widget-outline-color: {css_color}; }}");
+    let fixture = painted_bar_fixture_with_override_css(&config, Some(&user_css));
+    let first_edge = edge_pixel_of(&fixture, &fixture.first_surface);
+    let second_edge = edge_pixel_of(&fixture, &fixture.second_surface);
+
+    assert_pixel_close(
+        first_edge,
+        Rgba8::from_hex(css_color),
+        "user CSS --widget-outline-color override should paint the targeted widget outline",
+    );
+    assert_pixel_close(
+        second_edge,
+        outline_color_for_palette(
+            &vibepanel_core::ThemePalette::from_config(&config, None, None),
+            "accent",
+            1.0,
+        ),
+        "sibling widget should keep the TOML/theme outline color",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_surface_outline_css_gsk_parity() {
+    let mut config = test_config();
+    config.theme.outline = true;
+    config.theme.outline_width = 4;
+    config.theme.outline_color = "accent".to_string();
+    config.theme.outline_opacity = 0.8;
+    config.theme.accent = Some("#446688".to_string());
+    config.widgets.background_color = Some("#101820".to_string());
+    config.widgets.popover_background_opacity = Some(1.0);
+
+    set_ui_regression_config(&config);
+    let surface_fixture = painted_surface_fixture(&config, crate::styles::surface::SURFACE_POPOVER);
+    let css_edge = edge_pixel_of_surface(&surface_fixture);
+    let gsk_rgba = crate::services::config_manager::ConfigManager::global()
+        .surface_outline_rgba_for_widget("custom-a", &surface_fixture.surface);
+    let gsk_edge = Rgba8::from_gdk(gsk_rgba).over(Rgba8::from_hex("#101820"));
+
+    assert_pixel_close(
+        css_edge,
+        gsk_edge,
+        "CSS-rendered surface outline and GSK animated outline resolver should agree",
+    );
+
+    maybe_hold_probe_window();
+    surface_fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_theme_mode_dark_light_pixels() {
+    let mut dark = test_config();
+    dark.theme.mode = "dark".to_string();
+    dark.widgets.background_opacity = 1.0;
+
+    let mut light = dark.clone();
+    light.theme.mode = "light".to_string();
+
+    let dark_fixture = painted_bar_fixture(&dark);
+    let dark_pixel = center_pixel_of(&dark_fixture, &dark_fixture.first_surface);
+    maybe_hold_probe_window();
+    dark_fixture.window.close();
+    flush_gtk();
+
+    let light_fixture = painted_bar_fixture(&light);
+    let light_pixel = center_pixel_of(&light_fixture, &light_fixture.first_surface);
+    maybe_hold_probe_window();
+    light_fixture.window.close();
+    flush_gtk();
+
+    assert_luma_delta_at_least(
+        dark_pixel,
+        light_pixel,
+        0.3,
+        "theme.mode dark/light should produce visibly different widget pixels",
+    );
+}
+
+fn run_test_theme_popover_polarity_pixel() {
+    let mut config = test_config();
+    config.theme.mode = "dark".to_string();
+    config.theme.popover = Some("light".to_string());
+    config.bar.background_color = Some("#101820".to_string());
+    config.widgets.background_color = Some("#101820".to_string());
+    config.widgets.background_opacity = 1.0;
+    config.widgets.popover_background_opacity = Some(1.0);
+
+    let css = ui_regression_config_css(&config);
+    assert!(
+        css.contains("/* ===== Popover polarity override ===== */"),
+        "theme.popover should emit scoped popover palette overrides"
+    );
+    assert_popover_style_bindings(&config);
+
+    let bar_fixture = painted_bar_fixture(&config);
+    let bar_pixel = center_pixel_of(&bar_fixture, &bar_fixture.first_surface);
+    maybe_hold_probe_window();
+    bar_fixture.window.close();
+    flush_gtk();
+
+    let popover_fixture = painted_surface_fixture(&config, crate::styles::surface::SURFACE_POPOVER);
+    let popover_pixel = center_pixel_of_surface(&popover_fixture);
+    maybe_hold_probe_window();
+    popover_fixture.window.close();
+    flush_gtk();
+
+    assert_luma_delta_at_least(
+        bar_pixel,
+        popover_pixel,
+        0.25,
+        "theme.popover=light should make a dark bar's popover visibly light",
+    );
+}
+
+fn run_test_theme_states_urgent_pixel() {
+    let urgent_color = "#cc3344";
+    let mut config = test_config();
+    config.theme.states.urgent = urgent_color.to_string();
+    if let Some(custom_a) = config.widgets.widget_configs.get_mut("custom-a") {
+        custom_a
+            .options
+            .insert("label".to_string(), toml::Value::String(String::new()));
+    }
+
+    let fixture = painted_surface_fixture_with_classes(
+        &config,
+        &["workspace-indicator", crate::styles::state::URGENT],
+        120,
+        32,
+    );
+    let urgent_pixel = center_pixel_of_surface(&fixture);
+
+    assert_pixel_close(
+        urgent_pixel,
+        Rgba8::from_hex(urgent_color),
+        "theme.states.urgent should paint urgent workspace/taskbar surfaces",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_workspaces_urgent_production_pixel() {
+    let urgent_color = "#cc3344";
+    let mut config = test_config();
+    config.theme.states.urgent = urgent_color.to_string();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("workspaces".to_string()),
+        vibepanel_core::config::WidgetPlacement::Single("custom-b".to_string()),
+    ];
+    config.widgets.widget_configs.insert(
+        "workspaces".to_string(),
+        vibepanel_core::config::WidgetOptions::default(),
+    );
+
+    let mut snapshot = crate::services::compositor::WorkspaceSnapshot::default();
+    snapshot.active_workspace.insert(1);
+    snapshot.occupied_workspaces.insert(2);
+    snapshot.urgent_workspaces.insert(2);
+    snapshot.window_counts.insert(2, 1);
+    crate::services::compositor::CompositorManager::replace_global_for_test(snapshot.clone());
+    crate::services::workspace::WorkspaceService::replace_state_for_test(
+        vec![
+            crate::services::compositor::WorkspaceMeta {
+                id: 1,
+                idx: 1,
+                name: "1".to_string(),
+                output: None,
+            },
+            crate::services::compositor::WorkspaceMeta {
+                id: 2,
+                idx: 2,
+                name: "2".to_string(),
+                output: None,
+            },
+        ],
+        snapshot,
+    );
+
+    let fixture = painted_bar_fixture(&config);
+    let indicators = collect_descendants_with_class(
+        fixture.bar.upcast_ref::<gtk4::Widget>(),
+        "workspace-indicator",
+    );
+    let indicator = indicators
+        .iter()
+        .find(|indicator| indicator.has_css_class(crate::styles::state::URGENT))
+        .expect("production workspaces widget should render an urgent indicator");
+    assert!(
+        indicator.has_css_class(crate::styles::state::URGENT),
+        "production workspaces widget should apply the urgent state class"
+    );
+    let urgent_pixel = center_pixel_of(&fixture, &indicator);
+
+    assert_pixel_close(
+        urgent_pixel,
+        Rgba8::from_hex(urgent_color),
+        "production workspaces urgent indicator should render theme.states.urgent",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+fn run_test_grouped_seam_pixel() {
+    let mut config = test_config();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-c".to_string()),
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["custom-a".to_string(), "custom-b".to_string()],
+        },
+    ];
+    config.widgets.background_color = Some("#223344".to_string());
+    config.widgets.background_opacity = 1.0;
+    for (name, label) in [("custom-a", "A"), ("custom-b", "B"), ("custom-c", "C")] {
+        config
+            .widgets
+            .widget_configs
+            .entry(name.to_string())
+            .or_default()
+            .options
+            .insert("label".to_string(), toml::Value::String(label.to_string()));
+        config
+            .widgets
+            .widget_configs
+            .entry(name.to_string())
+            .or_default()
+            .options
+            .insert(
+                "on_click".to_string(),
+                toml::Value::String("true".to_string()),
+            );
+    }
+
+    let fixture = painted_bar_fixture(&config);
+    let left_section = fixture
+        .bar
+        .section("left")
+        .expect("bar should build a left section");
+    let group = find_descendant_with_class(&left_section, crate::styles::class::WIDGET_GROUP)
+        .expect("explicit group should render a widget group");
+    let grouped_items = collect_descendants_with_class(&group, crate::styles::class::WIDGET_ITEM);
+    assert_eq!(grouped_items.len(), 2);
+
+    let second_bounds = bounds_in_window(&grouped_items[1], &fixture.window);
+    let seam_pixel = sample_root_pixel(
+        &fixture,
+        second_bounds.0,
+        second_bounds.1 + second_bounds.3 / 2,
+    );
+    assert_pixel_close(
+        seam_pixel,
+        Rgba8::from_hex("#223344"),
+        "grouped widget seam should paint the widget background, not transparent",
+    );
+
+    maybe_hold_probe_window();
+    fixture.window.close();
+    flush_gtk();
+}
+
+macro_rules! ui_regression_config_tests {
+    ($(($test_name:ident, $test_case:literal, $runner:ident)),+ $(,)?) => {
+        $(
+            #[test]
+            #[ignore = "UI regression test: opens GTK windows; run under Xvfb"]
+            fn $test_name() {
+                run_ui_regression_config_subprocess($test_case);
+            }
+        )+
+
+        #[test]
+        #[ignore = "internal runner for one UI regression config subprocess"]
+        fn ui_regression_config_runner() {
+            if !init_gtk_or_skip("UI regression config test", Some("VIBEPANEL_UI_REGRESSION_REQUIRED")) {
+                return;
+            }
+            set_ui_regression_config(&test_config());
+
+            match std::env::var("VIBEPANEL_UI_REGRESSION_TEST").as_deref() {
+                $(Ok($test_case) => $runner(),)+
+                Ok(other) => panic!("unknown UI regression config test: {other}"),
+                Err(_) => eprintln!("skipping UI regression config runner: no contract selected"),
+            }
+        }
+    };
+}
+
+// Contract categories:
+// - UI regression: live GTK layout/rendering measurements or pixel samples.
+// - css binding: app-layer selector/class wiring that consumes core CSS tokens.
+// Pure config-to-token checks live in vibepanel-core unit tests.
+ui_regression_config_tests!(
+    (
+        test_ui_regression_bar_size,
+        "bar.size",
+        run_test_config_bar_size
+    ),
+    (
+        test_ui_regression_bar_spacing,
+        "bar.spacing",
+        run_test_config_bar_spacing
+    ),
+    (
+        test_ui_regression_bar_inset,
+        "bar.inset",
+        run_test_config_bar_inset
+    ),
+    (
+        test_ui_regression_bar_screen_margin,
+        "bar.screen_margin",
+        run_test_config_bar_screen_margin
+    ),
+    (
+        test_ui_regression_bar_padding,
+        "bar.padding",
+        run_test_config_bar_padding
+    ),
+    (
+        test_ui_regression_bar_background_opacity,
+        "bar.background_opacity",
+        run_test_config_bar_background_opacity
+    ),
+    (
+        test_ui_regression_widgets_placement_sections,
+        "widgets.placement.sections",
+        run_test_widgets_placement_sections
+    ),
+    (
+        test_ui_regression_widgets_disabled,
+        "widgets.disabled",
+        run_test_widgets_disabled
+    ),
+    (
+        test_ui_regression_widgets_grouping_explicit_group,
+        "widgets.grouping.explicit-group",
+        run_test_widgets_grouping_explicit_group
+    ),
+    (
+        test_ui_regression_widgets_grouping_system_merge,
+        "widgets.grouping.system-merge",
+        run_test_widgets_grouping_system_merge
+    ),
+    (
+        test_ui_regression_widgets_grouping_spacing,
+        "widgets.grouping.spacing",
+        run_test_widgets_grouping_spacing_contract
+    ),
+    (
+        test_ui_regression_widgets_background_color_pixel,
+        "widgets.background_color_pixel",
+        run_test_widgets_background_color_pixel
+    ),
+    (
+        test_ui_regression_widgets_background_color_precedence_pixel,
+        "widgets.background_color_precedence_pixel",
+        run_test_widgets_background_color_precedence_pixel
+    ),
+    (
+        test_ui_regression_bar_background_color_css_override_pixel,
+        "bar.background_color_css_override_pixel",
+        run_test_bar_background_color_css_override_pixel
+    ),
+    (
+        test_ui_regression_user_style_css_production_path_pixel,
+        "user_style_css.production_path_pixel",
+        run_test_user_style_css_production_path_pixel
+    ),
+    (
+        test_ui_regression_outline_color_pixels,
+        "theme.outline_color_pixel",
+        run_test_outline_color_pixels
+    ),
+    (
+        test_ui_regression_outline_opacity_and_disabled_pixels,
+        "theme.outline_opacity_disabled_pixel",
+        run_test_outline_opacity_and_disabled_pixels
+    ),
+    (
+        test_ui_regression_per_widget_outline_color_pixel,
+        "widgets.outline_color_precedence_pixel",
+        run_test_per_widget_outline_color_pixel
+    ),
+    (
+        test_ui_regression_widget_outline_color_css_override_pixel,
+        "widgets.outline_color_css_override_pixel",
+        run_test_widget_outline_color_css_override_pixel
+    ),
+    (
+        test_ui_regression_surface_outline_css_gsk_parity,
+        "theme.surface_outline_css_gsk_parity",
+        run_test_surface_outline_css_gsk_parity
+    ),
+    (
+        test_ui_regression_theme_mode_dark_light_pixel,
+        "theme.mode_dark_light_pixel",
+        run_test_theme_mode_dark_light_pixels
+    ),
+    (
+        test_ui_regression_theme_popover_polarity_pixel,
+        "theme.popover_polarity_pixel",
+        run_test_theme_popover_polarity_pixel
+    ),
+    (
+        test_ui_regression_theme_states_urgent_pixel,
+        "theme.states_urgent_pixel",
+        run_test_theme_states_urgent_pixel
+    ),
+    (
+        test_ui_regression_workspaces_urgent_production_pixel,
+        "workspaces.urgent_production_pixel",
+        run_test_workspaces_urgent_production_pixel
+    ),
+    (
+        test_ui_regression_widgets_grouped_seam_pixel,
+        "widgets.grouping.seam_pixel",
+        run_test_grouped_seam_pixel
+    ),
+);

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1647,7 +1647,7 @@ fn run_test_workspaces_urgent_production_pixel() {
         indicator.has_css_class(crate::styles::state::URGENT),
         "production workspaces widget should apply the urgent state class"
     );
-    let urgent_pixel = center_pixel_of(&fixture, &indicator);
+    let urgent_pixel = center_pixel_of(&fixture, indicator);
 
     assert_pixel_close(
         urgent_pixel,

--- a/crates/vibepanel/src/services/compositor/manager.rs
+++ b/crates/vibepanel/src/services/compositor/manager.rs
@@ -105,6 +105,24 @@ impl CompositorManager {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_global_for_test(snapshot: WorkspaceSnapshot) {
+        COMPOSITOR_MANAGER.with(|cell| {
+            *cell.borrow_mut() = Some(Rc::new(Self {
+                backend: RefCell::new(None),
+                workspace_callbacks: Callbacks::new(),
+                window_callbacks: Callbacks::new(),
+                keyboard_layout_callbacks: Callbacks::new(),
+                window_list_callbacks: Callbacks::new(),
+                last_workspace_snapshot: RefCell::new(Some(snapshot)),
+                last_window_info: RefCell::new(None),
+                last_keyboard_layout: RefCell::new(None),
+                last_window_list: RefCell::new(None),
+                started: RefCell::new(true),
+            }));
+        });
+    }
+
     /// Register a callback for workspace state changes.
     ///
     /// The callback will be immediately invoked with the current state if available.

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -211,6 +211,21 @@ impl ConfigManager {
         });
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_global_for_test(config: Config) {
+        Self::replace_global_with_config_path_for_test(config, None);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_global_with_config_path_for_test(
+        config: Config,
+        config_path: Option<PathBuf>,
+    ) {
+        CONFIG_MANAGER_INSTANCE.with(|cell| {
+            *cell.borrow_mut() = Some(ConfigManager::new(config, config_path));
+        });
+    }
+
     /// Get the computed theme sizes from the current configuration.
     ///
     /// This returns sizes from the cached palette — no recomputation needed.

--- a/crates/vibepanel/src/services/workspace.rs
+++ b/crates/vibepanel/src/services/workspace.rs
@@ -186,6 +186,19 @@ impl WorkspaceService {
         INSTANCE.with(|s| s.clone())
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_state_for_test(
+        workspaces: Vec<WorkspaceMeta>,
+        snapshot: WorkspaceSnapshot,
+    ) {
+        let service = Self::global();
+        *service.workspaces.borrow_mut() = workspaces;
+        *service.snapshot.borrow_mut() = snapshot;
+        *service.ready.borrow_mut() = true;
+        let service_snapshot = service.build_snapshot();
+        service.callbacks.notify(&service_snapshot);
+    }
+
     /// Register a callback to be invoked when workspace state changes.
     /// The callback is always executed on the GLib main loop.
     pub fn connect<F>(&self, callback: F) -> CallbackId

--- a/crates/vibepanel/src/theme_vars.rs
+++ b/crates/vibepanel/src/theme_vars.rs
@@ -1,0 +1,145 @@
+//! Internal theme variable regression expectations.
+//!
+//! This is not a public CSS API manifest. User-facing CSS hooks are documented
+//! best-effort in the project wiki; this test metadata only tracks variables
+//! that production CSS or Rust-composed styling depends on.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThemeVarScope {
+    Root,
+    UserHook,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThemeVarRole {
+    BuiltinCss,
+    OptionalBuiltinCss,
+    RustComposedCss,
+    Alias,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ThemeVarExpectation {
+    pub(super) name: &'static str,
+    pub(super) scope: ThemeVarScope,
+    pub(super) role: ThemeVarRole,
+    pub(super) hover_binding: bool,
+}
+
+use ThemeVarRole::{Alias, BuiltinCss, OptionalBuiltinCss, RustComposedCss};
+use ThemeVarScope::{Root, UserHook};
+
+pub(super) const THEME_VAR_EXPECTATIONS: &[ThemeVarExpectation] = &[
+    var("--bar-height", Root, BuiltinCss),
+    var("--bar-outline-color", Root, BuiltinCss),
+    var("--bar-outline-opacity", Root, BuiltinCss),
+    var("--bar-outline-width", Root, BuiltinCss),
+    var("--bar-padding-y", Root, BuiltinCss),
+    var("--bar-padding-y-bottom", Root, BuiltinCss),
+    var("--color-accent-hover-bg", Root, BuiltinCss),
+    var("--color-accent-primary", Root, BuiltinCss),
+    var("--color-accent-slider", Root, BuiltinCss),
+    var("--color-accent-text", Root, BuiltinCss),
+    var("--color-background-bar", Root, BuiltinCss),
+    var("--color-card-overlay", Root, BuiltinCss),
+    var("--color-card-overlay-hover", Root, BuiltinCss),
+    var("--color-card-overlay-subtle", Root, Alias),
+    var("--color-click-catcher-overlay", Root, BuiltinCss),
+    var("--color-foreground-disabled", Root, BuiltinCss),
+    var("--color-foreground-faint", Root, BuiltinCss),
+    var("--color-foreground-muted", Root, BuiltinCss),
+    var("--color-foreground-primary", Root, BuiltinCss),
+    var("--color-row-background", Root, Alias),
+    var("--color-row-background-hover", Root, Alias),
+    var("--color-row-critical-background", Root, BuiltinCss),
+    var("--color-slider-track", Root, BuiltinCss),
+    var("--color-state-urgent", Root, BuiltinCss),
+    var("--color-state-warning", Root, BuiltinCss),
+    hover_var("--color-taskbar-button-active-hover-bg", Root, BuiltinCss),
+    hover_var("--color-taskbar-button-hover-bg", Root, BuiltinCss),
+    hover_var("--color-taskbar-button-urgent-hover-bg", Root, BuiltinCss),
+    var("--color-toast-critical-background", Root, BuiltinCss),
+    hover_var("--color-widget-hover-bg", Root, BuiltinCss),
+    hover_var(
+        "--color-workspace-indicator-active-hover-bg",
+        Root,
+        BuiltinCss,
+    ),
+    hover_var(
+        "--color-workspace-indicator-hover-bg",
+        UserHook,
+        OptionalBuiltinCss,
+    ),
+    var(
+        "--color-workspace-indicator-hover-default-bg",
+        Root,
+        BuiltinCss,
+    ),
+    hover_var(
+        "--color-workspace-indicator-urgent-hover-bg",
+        Root,
+        BuiltinCss,
+    ),
+    var("--font-family", Root, BuiltinCss),
+    var("--font-scale", Root, Alias),
+    var("--font-size", Root, BuiltinCss),
+    var("--font-size-base", Root, BuiltinCss),
+    var("--font-size-lg", Root, BuiltinCss),
+    var("--font-size-md", Root, BuiltinCss),
+    var("--font-size-sm", Root, BuiltinCss),
+    var("--font-size-xs", Root, BuiltinCss),
+    var("--icon-size", Root, BuiltinCss),
+    var("--outline-color", Root, Alias),
+    var("--outline-opacity", Root, Alias),
+    var("--outline-width", Root, Alias),
+    var("--popover-background-opacity", Root, BuiltinCss),
+    var("--radius-bar", Root, BuiltinCss),
+    var("--radius-card", Root, BuiltinCss),
+    var("--radius-factor", Root, Alias),
+    var("--radius-pill", Root, BuiltinCss),
+    var("--radius-round", Root, BuiltinCss),
+    var("--radius-surface", Root, BuiltinCss),
+    var("--radius-widget", Root, BuiltinCss),
+    var("--radius-widget-lg", Root, RustComposedCss),
+    var("--shadow-soft", Root, BuiltinCss),
+    var("--slider-height", Root, BuiltinCss),
+    var("--slider-height-thick", Root, BuiltinCss),
+    var("--slider-knob-radius", Root, BuiltinCss),
+    var("--slider-knob-size", Root, BuiltinCss),
+    var("--slider-radius", Root, BuiltinCss),
+    var("--slider-radius-thick", Root, BuiltinCss),
+    var("--spacing-widget-gap", Root, BuiltinCss),
+    var("--surface-outline-color", Root, BuiltinCss),
+    var("--surface-outline-opacity", Root, BuiltinCss),
+    var("--surface-outline-width", Root, BuiltinCss),
+    var("--widget-background-color", Root, BuiltinCss),
+    var("--widget-background-opacity", Root, BuiltinCss),
+    var("--widget-height", Root, BuiltinCss),
+    var("--widget-hover-tint", Root, BuiltinCss),
+    var("--widget-outline-color", Root, BuiltinCss),
+    var("--widget-outline-opacity", Root, BuiltinCss),
+    var("--widget-outline-width", Root, BuiltinCss),
+    var("--widget-padding-y", Root, BuiltinCss),
+];
+
+const fn var(name: &'static str, scope: ThemeVarScope, role: ThemeVarRole) -> ThemeVarExpectation {
+    ThemeVarExpectation {
+        name,
+        scope,
+        role,
+        hover_binding: false,
+    }
+}
+
+const fn hover_var(
+    name: &'static str,
+    scope: ThemeVarScope,
+    role: ThemeVarRole,
+) -> ThemeVarExpectation {
+    ThemeVarExpectation {
+        name,
+        scope,
+        role,
+        hover_binding: true,
+    }
+}

--- a/crates/vibepanel/src/ui_regression_test_support.rs
+++ b/crates/vibepanel/src/ui_regression_test_support.rs
@@ -350,6 +350,8 @@ pub(crate) fn sample_widget_pixel(
     let stride = texture.width() as usize * 4;
     let mut data = vec![0; stride * texture.height() as usize];
     texture.download(&mut data, stride);
+    drop(texture);
+    renderer.unrealize();
 
     let offset = y as usize * stride + x as usize * 4;
     Rgba8 {

--- a/crates/vibepanel/src/ui_regression_test_support.rs
+++ b/crates/vibepanel/src/ui_regression_test_support.rs
@@ -1,0 +1,386 @@
+use gtk4::gdk::prelude::{PaintableExt, TextureExtManual};
+use gtk4::gsk::prelude::GskRendererExt;
+use gtk4::prelude::{
+    ApplicationExt, Cast, DisplayExt, GtkWindowExt, ListModelExt, NativeExt, SnapshotExt,
+    TextureExt, WidgetExt,
+};
+use std::sync::{Mutex, MutexGuard};
+
+use vibepanel_core::Config;
+
+static UI_REGRESSION_SUBPROCESS_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn ui_regression_subprocess_lock() -> MutexGuard<'static, ()> {
+    UI_REGRESSION_SUBPROCESS_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub(crate) fn run_ignored_contract_subprocess(
+    runner_test: &str,
+    env_name: &str,
+    contract: &str,
+    label: &str,
+) {
+    let exe = std::env::current_exe().expect("current test binary path should be available");
+    let output = {
+        let _lock = ui_regression_subprocess_lock();
+        std::process::Command::new(exe)
+            .arg(runner_test)
+            .arg("--ignored")
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .env(env_name, contract)
+            .env("VIBEPANEL_UI_REGRESSION_REQUIRED", "1")
+            .output()
+    }
+    .unwrap_or_else(|_| panic!("{label} subprocess should run"));
+
+    assert!(
+        output.status.success(),
+        "{label} subprocess failed for {contract}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+pub(crate) fn init_gtk_or_skip(context: &str, required_env: Option<&str>) -> bool {
+    let init_ok = gtk4::init().is_ok();
+    let display_available = gtk4::gdk::Display::default().is_some();
+
+    if !init_ok && !display_available {
+        if let Some(env_name) = required_env
+            && env_truthy(env_name)
+        {
+            panic!("{env_name} is set but no GTK display is available");
+        }
+        eprintln!("skipping {context}: GTK display is unavailable");
+        return false;
+    }
+
+    if !display_available {
+        eprintln!("skipping {context}: no default GTK display");
+        return false;
+    }
+
+    true
+}
+
+pub(crate) fn init_layer_shell_or_skip(context: &str) -> Option<gtk4::gdk::Display> {
+    if !init_gtk_or_skip(context, None) {
+        return None;
+    }
+
+    if !gtk4_layer_shell::is_supported() {
+        eprintln!("skipping {context}: compositor does not support layer-shell");
+        return None;
+    }
+
+    gtk4::gdk::Display::default()
+}
+
+pub(crate) fn first_monitor_or_skip(
+    display: &gtk4::gdk::Display,
+    context: &str,
+) -> Option<gtk4::gdk::Monitor> {
+    let monitor = display
+        .monitors()
+        .item(0)?
+        .downcast::<gtk4::gdk::Monitor>()
+        .ok();
+    if monitor.is_none() {
+        eprintln!("skipping {context}: no monitor available");
+    }
+
+    monitor
+}
+
+pub(crate) fn registered_test_app(application_id: &str) -> gtk4::Application {
+    let app = gtk4::Application::builder()
+        .application_id(application_id)
+        .build();
+    app.register(None::<&gtk4::gio::Cancellable>)
+        .expect("test app should register");
+    app
+}
+
+pub(crate) fn maybe_hold_probe_window() {
+    let Ok(ms) = std::env::var("VIBEPANEL_UI_REGRESSION_PROBE_HOLD_MS") else {
+        return;
+    };
+    let Ok(ms) = ms.parse::<u64>() else {
+        return;
+    };
+    if ms == 0 {
+        return;
+    }
+
+    let ctx = gtk4::glib::MainContext::default();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(ms);
+    while std::time::Instant::now() < deadline {
+        ctx.iteration(true);
+    }
+}
+
+pub(crate) struct CssProviderGuard {
+    display: gtk4::gdk::Display,
+    provider: gtk4::CssProvider,
+}
+
+impl CssProviderGuard {
+    pub(crate) fn new(css: &str, priority: u32) -> Self {
+        let provider = gtk4::CssProvider::new();
+        provider.load_from_string(css);
+
+        let display = gtk4::gdk::Display::default().expect("GTK display should exist");
+        gtk4::style_context_add_provider_for_display(&display, &provider, priority);
+
+        Self { display, provider }
+    }
+
+    pub(crate) fn for_config(config: &Config, priority: u32) -> Self {
+        let palette = vibepanel_core::ThemePalette::from_config(config, None, None);
+        let popover_palette = vibepanel_core::ThemePalette::popover_palette(config, None, None);
+        Self::new(
+            &crate::bar::generate_css(config, &palette, popover_palette.as_ref()),
+            priority,
+        )
+    }
+}
+
+impl Drop for CssProviderGuard {
+    fn drop(&mut self) {
+        gtk4::style_context_remove_provider_for_display(&self.display, &self.provider);
+    }
+}
+
+pub(crate) struct PaintedSurfaceFixture {
+    pub(crate) window: gtk4::Window,
+    pub(crate) _css_provider: CssProviderGuard,
+    pub(crate) surface: gtk4::Widget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Rgba8 {
+    pub(crate) r: u8,
+    pub(crate) g: u8,
+    pub(crate) b: u8,
+    pub(crate) a: u8,
+}
+
+impl Rgba8 {
+    pub(crate) fn from_hex(hex: &str) -> Self {
+        let hex = hex
+            .strip_prefix('#')
+            .expect("test color should be a #rrggbb literal");
+        assert_eq!(hex.len(), 6, "test color should be a #rrggbb literal");
+        Self {
+            r: u8::from_str_radix(&hex[0..2], 16).expect("valid red channel"),
+            g: u8::from_str_radix(&hex[2..4], 16).expect("valid green channel"),
+            b: u8::from_str_radix(&hex[4..6], 16).expect("valid blue channel"),
+            a: 255,
+        }
+    }
+
+    pub(crate) fn from_gdk(rgba: gtk4::gdk::RGBA) -> Self {
+        Self {
+            r: (rgba.red().clamp(0.0, 1.0) * 255.0).round() as u8,
+            g: (rgba.green().clamp(0.0, 1.0) * 255.0).round() as u8,
+            b: (rgba.blue().clamp(0.0, 1.0) * 255.0).round() as u8,
+            a: (rgba.alpha().clamp(0.0, 1.0) * 255.0).round() as u8,
+        }
+    }
+
+    pub(crate) fn over(self, background: Self) -> Self {
+        let alpha = f64::from(self.a) / 255.0;
+        let blend = |foreground: u8, background: u8| -> u8 {
+            (f64::from(foreground) * alpha + f64::from(background) * (1.0 - alpha)).round() as u8
+        };
+        Self {
+            r: blend(self.r, background.r),
+            g: blend(self.g, background.g),
+            b: blend(self.b, background.b),
+            a: 255,
+        }
+    }
+
+    pub(crate) fn with_alpha(self, a: u8) -> Self {
+        Self { a, ..self }
+    }
+
+    pub(crate) fn close_to(self, expected: Self, tolerance: u8) -> bool {
+        self.r.abs_diff(expected.r) <= tolerance
+            && self.g.abs_diff(expected.g) <= tolerance
+            && self.b.abs_diff(expected.b) <= tolerance
+            && self.a.abs_diff(expected.a) <= tolerance
+    }
+
+    pub(crate) fn luma(self) -> f64 {
+        fn channel(c: u8) -> f64 {
+            let c = f64::from(c) / 255.0;
+            if c <= 0.03928 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        0.2126 * channel(self.r) + 0.7152 * channel(self.g) + 0.0722 * channel(self.b)
+    }
+}
+
+pub(crate) fn flush_gtk() {
+    let ctx = gtk4::glib::MainContext::default();
+    while ctx.pending() {
+        ctx.iteration(false);
+    }
+}
+
+pub(crate) fn find_descendant_with_class(
+    root: &gtk4::Widget,
+    class_name: &str,
+) -> Option<gtk4::Widget> {
+    if root.has_css_class(class_name) {
+        return Some(root.clone());
+    }
+
+    let mut child = root.first_child();
+    while let Some(widget) = child {
+        if let Some(found) = find_descendant_with_class(&widget, class_name) {
+            return Some(found);
+        }
+        child = widget.next_sibling();
+    }
+
+    None
+}
+
+pub(crate) fn label_with_text(root: &gtk4::Widget, expected: &str) -> bool {
+    if let Ok(label) = root.clone().downcast::<gtk4::Label>()
+        && label.label() == expected
+    {
+        return true;
+    }
+
+    let mut child = root.first_child();
+    while let Some(widget) = child {
+        if label_with_text(&widget, expected) {
+            return true;
+        }
+        child = widget.next_sibling();
+    }
+
+    false
+}
+
+pub(crate) fn painted_surface_fixture_with_classes(
+    config: &Config,
+    class_names: &[&str],
+    width: i32,
+    height: i32,
+) -> PaintedSurfaceFixture {
+    crate::services::config_manager::ConfigManager::replace_global_for_test(config.clone());
+
+    let css_provider =
+        CssProviderGuard::for_config(config, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
+    let window = gtk4::Window::builder()
+        .title("vibepanel UI regression surface test")
+        .default_width(width + 40)
+        .default_height(height + 40)
+        .build();
+
+    let surface = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    for class_name in class_names {
+        surface.add_css_class(class_name);
+    }
+    surface.set_size_request(width, height);
+    window.set_child(Some(&surface));
+    window.present();
+    flush_gtk();
+
+    PaintedSurfaceFixture {
+        window,
+        _css_provider: css_provider,
+        surface: surface.upcast(),
+    }
+}
+
+pub(crate) fn sample_widget_pixel(
+    window: &gtk4::Window,
+    root: &gtk4::Widget,
+    x: i32,
+    y: i32,
+) -> Rgba8 {
+    let width = root.width();
+    let height = root.height();
+    assert!(
+        width > 0 && height > 0,
+        "widget should be allocated before sampling pixels"
+    );
+    assert!(
+        x >= 0 && x < width,
+        "sample x={x} outside rendered widget width={width}"
+    );
+    assert!(
+        y >= 0 && y < height,
+        "sample y={y} outside rendered widget height={height}"
+    );
+
+    let paintable = gtk4::WidgetPaintable::new(Some(root));
+    let snapshot = gtk4::Snapshot::new();
+    paintable.snapshot(&snapshot, f64::from(width), f64::from(height));
+    let node = snapshot
+        .to_node()
+        .expect("widget paintable snapshot should produce a render node");
+    let native = window
+        .native()
+        .expect("painted fixture should have a native surface");
+    let surface = native
+        .surface()
+        .expect("painted fixture native should have a GDK surface");
+    let renderer = gtk4::gsk::Renderer::for_surface(&surface)
+        .expect("painted fixture surface should have a GSK renderer");
+    let viewport = gtk4::graphene::Rect::new(0.0, 0.0, width as f32, height as f32);
+    let texture = renderer.render_texture(&node, Some(&viewport));
+    let stride = texture.width() as usize * 4;
+    let mut data = vec![0; stride * texture.height() as usize];
+    texture.download(&mut data, stride);
+
+    let offset = y as usize * stride + x as usize * 4;
+    Rgba8 {
+        r: data[offset + 2],
+        g: data[offset + 1],
+        b: data[offset],
+        a: data[offset + 3],
+    }
+}
+
+pub(crate) fn center_pixel_of_surface(fixture: &PaintedSurfaceFixture) -> Rgba8 {
+    sample_widget_pixel(
+        &fixture.window,
+        &fixture.surface,
+        fixture.surface.width() / 2,
+        fixture.surface.height() / 2,
+    )
+}
+
+pub(crate) fn edge_pixel_of_surface(fixture: &PaintedSurfaceFixture) -> Rgba8 {
+    sample_widget_pixel(
+        &fixture.window,
+        &fixture.surface,
+        1,
+        fixture.surface.height() / 2,
+    )
+}
+
+pub(crate) fn assert_pixel_close(observed: Rgba8, expected: Rgba8, message: &str) {
+    assert!(
+        observed.close_to(expected, 2),
+        "{message}; expected={expected:?}, observed={observed:?}"
+    );
+}

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -366,6 +366,14 @@ impl crate::popover_registry::PopoverToggleable for MenuHandle {
             .and_then(|m| m.connector())
             .map(|c| c.to_string())
     }
+
+    #[cfg(test)]
+    fn test_layer_shell_window(&self) -> Option<gtk4::ApplicationWindow> {
+        self.popover
+            .borrow()
+            .as_ref()
+            .and_then(|popover| popover.test_window())
+    }
 }
 
 /// Describe a process exit status in human-readable form.

--- a/crates/vibepanel/src/widgets/calendar_popover.rs
+++ b/crates/vibepanel/src/widgets/calendar_popover.rs
@@ -272,3 +272,28 @@ pub fn build_clock_calendar_popover(show_week_numbers: bool) -> (Widget, Rc<dyn 
 
     (container.upcast::<Widget>(), refresh)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui_regression_test_support::{find_descendant_with_class, init_gtk_or_skip};
+
+    #[test]
+    fn clock_calendar_week_number_header_tracks_config() {
+        if !init_gtk_or_skip("clock calendar popover test", None) {
+            return;
+        }
+
+        let (with_week_numbers, _refresh) = build_clock_calendar_popover(true);
+        assert!(
+            find_descendant_with_class(&with_week_numbers, "week-number-header").is_some(),
+            "calendar popover should render the week-number header when week numbers are enabled"
+        );
+
+        let (without_week_numbers, _refresh) = build_clock_calendar_popover(false);
+        assert!(
+            find_descendant_with_class(&without_week_numbers, "week-number-header").is_none(),
+            "calendar popover should omit the week-number header when week numbers are disabled"
+        );
+    }
+}

--- a/crates/vibepanel/src/widgets/css/mod.rs
+++ b/crates/vibepanel/src/widgets/css/mod.rs
@@ -37,8 +37,8 @@ pub const DISMISS_ANIMATION_MS: u64 = 200;
 
 /// Base horizontal padding (px) for `.content` inside widgets.
 ///
-/// Shared between the CSS rule (`padding: var(--widget-padding-y) {CONTENT_PADDING_X}px`)
-/// in `bar.rs` and the runtime padding adjustment in `taskbar.rs`.
+/// Shared between the CSS rule in `bar.rs` and the runtime padding adjustment
+/// in `taskbar.rs`.
 pub const CONTENT_PADDING_X: i32 = 10;
 
 mod bar;

--- a/crates/vibepanel/src/widgets/css/quick_settings.rs
+++ b/crates/vibepanel/src/widgets/css/quick_settings.rs
@@ -400,7 +400,7 @@ window.quick-settings-window {{
     border-radius: var(--radius-widget);
     font-size: calc(var(--font-size) * 1.1);
     background: var(--color-card-overlay);
-    border: 1px solid var(--color-border, rgba(255,255,255,0.1));
+    border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.1));
     margin: 0 2px;
     color: var(--color-foreground-primary);
 }}

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -493,6 +493,16 @@ impl LayerShellPopover {
         self.logically_open.get()
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_window(&self) -> Option<ApplicationWindow> {
+        self.window.borrow().as_ref().cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_click_catcher(&self) -> Option<ApplicationWindow> {
+        self.click_catcher.borrow().as_ref().cloned()
+    }
+
     /// Set a callback to be invoked when the popover is hidden.
     pub fn set_on_close<F: Fn() + 'static>(&self, callback: F) {
         *self.on_close.borrow_mut() = Some(Rc::new(callback));
@@ -1232,5 +1242,20 @@ impl Dismissible for LayerShellPopover {
 
     fn is_visible(&self) -> bool {
         self.is_visible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calculate_bar_exclusive_zone_from_values;
+
+    #[test]
+    fn bar_exclusive_zone_visible_mode_includes_symmetric_padding() {
+        assert_eq!(calculate_bar_exclusive_zone_from_values(32, 10, 1.0, 4), 60);
+    }
+
+    #[test]
+    fn bar_exclusive_zone_island_mode_includes_only_edge_padding() {
+        assert_eq!(calculate_bar_exclusive_zone_from_values(32, 10, 0.0, 4), 50);
     }
 }

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -231,174 +231,8 @@ impl NotificationToast {
         on_dismiss: ToastCallback,
         on_action: ToastActionCallback,
     ) {
-        let outer = GtkBox::new(Orientation::Vertical, 0);
-        outer.add_css_class(notif::TOAST_CONTAINER);
-        outer.add_css_class(notif::TOAST);
-
-        // Apply surface styling
-        SurfaceStyleManager::global().apply_surface_styles(&outer, false);
-
-        // Apply uniform shadow margins so the CSS box-shadow is not clipped at
-        // the layer-shell surface boundary.  Unlike popovers (which are flush
-        // against the bar on one side), the toast floats freely and needs equal
-        // margins on all four sides.
-        let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
-        outer.set_margin_top(sm);
-        outer.set_margin_bottom(sm);
-        outer.set_margin_start(sm);
-        outer.set_margin_end(sm);
-
-        // Add urgency styling
-        if notification.urgency == URGENCY_CRITICAL {
-            outer.add_css_class(notif::TOAST_CRITICAL);
-        } else if notification.urgency == URGENCY_LOW {
-            outer.add_css_class(notif::TOAST_LOW);
-        }
-
-        let has_default_action = notification.actions.iter().any(|(id, _)| id == "default");
-
-        let main_row = GtkBox::new(Orientation::Horizontal, 10);
-
-        // App icon / avatar in a centered column
-        let icon_container = GtkBox::new(Orientation::Vertical, 0);
-        icon_container.set_halign(Align::Center);
-        icon_container.set_valign(Align::Start);
-        icon_container.set_width_request(56);
-
-        let icon = create_notification_image_widget(notification);
-        icon.add_css_class(notif::TOAST_ICON);
-        icon.set_halign(Align::Center);
-        icon_container.append(&icon);
-
-        main_row.append(&icon_container);
-
-        let content = GtkBox::new(Orientation::Vertical, 2);
-        content.set_hexpand(true);
-        content.add_css_class(notif::TOAST_CONTENT);
-
-        let app_label = Label::new(Some(&notification.app_name));
-        app_label.add_css_class(notif::TOAST_APP);
-        app_label.add_css_class(color::MUTED);
-        app_label.set_xalign(0.0);
-        app_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-        app_label.set_margin_bottom(4);
-        content.append(&app_label);
-
-        if !notification.summary.is_empty() {
-            let summary_label = Label::new(Some(&notification.summary));
-            summary_label.add_css_class(notif::TOAST_SUMMARY);
-            summary_label.set_xalign(0.0);
-            summary_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-            summary_label.set_single_line_mode(true);
-            content.append(&summary_label);
-        }
-
-        if !notification.body.is_empty() {
-            let body_markup = sanitize_body_markup(&notification.body);
-            let body_label = Label::new(None);
-            body_label.set_markup(&body_markup);
-            body_label.add_css_class(notif::TOAST_BODY);
-            body_label.add_css_class(color::MUTED);
-            body_label.set_xalign(0.0);
-            body_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-            body_label.set_lines(2);
-            body_label.set_wrap(true);
-            body_label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
-            content.append(&body_label);
-        }
-
-        main_row.append(&content);
-
-        let dismiss_btn = Button::new();
-        dismiss_btn.set_has_frame(false);
-        dismiss_btn.add_css_class(notif::TOAST_DISMISS);
-        dismiss_btn.add_css_class(button::RESET);
-        dismiss_btn.set_valign(Align::Start);
-        dismiss_btn.set_focusable(false);
-
-        let dismiss_icon = Image::from_icon_name("window-close-symbolic");
-        dismiss_icon.set_halign(Align::Center);
-        dismiss_icon.set_valign(Align::Center);
-        dismiss_btn.set_child(Some(&dismiss_icon));
-
-        let notification_id = notification.id;
-        let window = self.window.clone();
-        let on_dismiss_for_btn = on_dismiss.clone();
-        dismiss_btn.connect_clicked(move |_| {
-            on_dismiss_for_btn(notification_id);
-            window.close();
-        });
-
-        main_row.append(&dismiss_btn);
-
-        // Handle default action click
-        if has_default_action {
-            // Make the content area clickable
-            let click_gesture = gtk4::GestureClick::new();
-            click_gesture.set_button(1); // Only respond to left mouse button
-            let on_action_clone = on_action.clone();
-            let on_dismiss_clone = on_dismiss.clone();
-            let notification_id = notification.id;
-            let window_for_action = self.window.clone();
-            // Use connect_pressed instead of connect_released to ensure it's a real click
-            // that started within the widget (released can fire from drags ending on widget)
-            click_gesture.connect_pressed(move |gesture, n_press, _, _| {
-                // Only respond to single clicks (not double-clicks, etc.)
-                if n_press == 1 {
-                    // Stop propagation to prevent accidental triggers
-                    gesture.set_state(gtk4::EventSequenceState::Claimed);
-                    on_action_clone(notification_id, "default");
-                    on_dismiss_clone(notification_id);
-                    window_for_action.close();
-                }
-            });
-            content.add_controller(click_gesture);
-            content.add_css_class(notif::TOAST_CLICKABLE);
-        }
-
-        outer.append(&main_row);
-
-        // Action buttons at the bottom
-        let non_default_actions: Vec<_> = notification
-            .actions
-            .iter()
-            .filter(|(id, _)| id != "default")
-            .collect();
-
-        if !non_default_actions.is_empty() {
-            let actions_box = GtkBox::new(Orientation::Horizontal, 8);
-            actions_box.add_css_class(notif::TOAST_ACTIONS);
-            actions_box.set_halign(Align::End);
-
-            for (action_id, action_label) in non_default_actions {
-                let action_btn = crate::widgets::base::vp_button_with_label(action_label);
-                action_btn.add_css_class(notif::TOAST_ACTION);
-                action_btn.add_css_class(button::GHOST);
-                action_btn.set_focusable(false);
-
-                let on_action_clone = on_action.clone();
-                let on_dismiss_clone = on_dismiss.clone();
-                let notification_id = notification.id;
-                let action_id = action_id.clone();
-                let window_for_action = self.window.clone();
-                action_btn.connect_clicked(move |_| {
-                    on_action_clone(notification_id, &action_id);
-                    on_dismiss_clone(notification_id);
-                    window_for_action.close();
-                });
-
-                actions_box.append(&action_btn);
-            }
-
-            outer.append(&actions_box);
-        }
-
+        let outer = build_toast_content(notification, on_dismiss, on_action, &self.window);
         self.window.set_child(Some(&outer));
-
-        // Apply Pango font attributes to all labels if enabled in config.
-        // This is the central hook for notification toasts - widgets create standard
-        // GTK labels, and we apply Pango attributes here after the tree is built.
-        SurfaceStyleManager::global().apply_pango_attrs_all(&outer);
     }
 
     pub fn present(&self) {
@@ -463,6 +297,184 @@ impl NotificationToast {
         );
         *self.animation_source.borrow_mut() = Some(source_id);
     }
+}
+
+fn build_toast_content(
+    notification: &Notification,
+    on_dismiss: ToastCallback,
+    on_action: ToastActionCallback,
+    close_window: &Window,
+) -> GtkBox {
+    let outer = GtkBox::new(Orientation::Vertical, 0);
+    outer.add_css_class(notif::TOAST_CONTAINER);
+    outer.add_css_class(notif::TOAST);
+
+    // Add urgency styling before applying widget-scoped surface styles, so the
+    // surface provider can preserve urgency-specific border/background rules at
+    // the same CSS priority.
+    if notification.urgency == URGENCY_CRITICAL {
+        outer.add_css_class(notif::TOAST_CRITICAL);
+    } else if notification.urgency == URGENCY_LOW {
+        outer.add_css_class(notif::TOAST_LOW);
+    }
+
+    // Apply surface styling
+    SurfaceStyleManager::global().apply_surface_styles(&outer, false);
+
+    // Apply uniform shadow margins so the CSS box-shadow is not clipped at
+    // the layer-shell surface boundary.  Unlike popovers (which are flush
+    // against the bar on one side), the toast floats freely and needs equal
+    // margins on all four sides.
+    let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
+    outer.set_margin_top(sm);
+    outer.set_margin_bottom(sm);
+    outer.set_margin_start(sm);
+    outer.set_margin_end(sm);
+
+    let has_default_action = notification.actions.iter().any(|(id, _)| id == "default");
+
+    let main_row = GtkBox::new(Orientation::Horizontal, 10);
+
+    // App icon / avatar in a centered column
+    let icon_container = GtkBox::new(Orientation::Vertical, 0);
+    icon_container.set_halign(Align::Center);
+    icon_container.set_valign(Align::Start);
+    icon_container.set_width_request(56);
+
+    let icon = create_notification_image_widget(notification);
+    icon.add_css_class(notif::TOAST_ICON);
+    icon.set_halign(Align::Center);
+    icon_container.append(&icon);
+
+    main_row.append(&icon_container);
+
+    let content = GtkBox::new(Orientation::Vertical, 2);
+    content.set_hexpand(true);
+    content.add_css_class(notif::TOAST_CONTENT);
+
+    let app_label = Label::new(Some(&notification.app_name));
+    app_label.add_css_class(notif::TOAST_APP);
+    app_label.add_css_class(color::MUTED);
+    app_label.set_xalign(0.0);
+    app_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+    app_label.set_margin_bottom(4);
+    content.append(&app_label);
+
+    if !notification.summary.is_empty() {
+        let summary_label = Label::new(Some(&notification.summary));
+        summary_label.add_css_class(notif::TOAST_SUMMARY);
+        summary_label.set_xalign(0.0);
+        summary_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        summary_label.set_single_line_mode(true);
+        content.append(&summary_label);
+    }
+
+    if !notification.body.is_empty() {
+        let body_markup = sanitize_body_markup(&notification.body);
+        let body_label = Label::new(None);
+        body_label.set_markup(&body_markup);
+        body_label.add_css_class(notif::TOAST_BODY);
+        body_label.add_css_class(color::MUTED);
+        body_label.set_xalign(0.0);
+        body_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        body_label.set_lines(2);
+        body_label.set_wrap(true);
+        body_label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
+        content.append(&body_label);
+    }
+
+    main_row.append(&content);
+
+    let dismiss_btn = Button::new();
+    dismiss_btn.set_has_frame(false);
+    dismiss_btn.add_css_class(notif::TOAST_DISMISS);
+    dismiss_btn.add_css_class(button::RESET);
+    dismiss_btn.set_valign(Align::Start);
+    dismiss_btn.set_focusable(false);
+
+    let dismiss_icon = Image::from_icon_name("window-close-symbolic");
+    dismiss_icon.set_halign(Align::Center);
+    dismiss_icon.set_valign(Align::Center);
+    dismiss_btn.set_child(Some(&dismiss_icon));
+
+    let notification_id = notification.id;
+    let window = close_window.clone();
+    let on_dismiss_for_btn = on_dismiss.clone();
+    dismiss_btn.connect_clicked(move |_| {
+        on_dismiss_for_btn(notification_id);
+        window.close();
+    });
+
+    main_row.append(&dismiss_btn);
+
+    // Handle default action click
+    if has_default_action {
+        // Make the content area clickable
+        let click_gesture = gtk4::GestureClick::new();
+        click_gesture.set_button(1); // Only respond to left mouse button
+        let on_action_clone = on_action.clone();
+        let on_dismiss_clone = on_dismiss.clone();
+        let notification_id = notification.id;
+        let window_for_action = close_window.clone();
+        // Use connect_pressed instead of connect_released to ensure it's a real click
+        // that started within the widget (released can fire from drags ending on widget)
+        click_gesture.connect_pressed(move |gesture, n_press, _, _| {
+            // Only respond to single clicks (not double-clicks, etc.)
+            if n_press == 1 {
+                // Stop propagation to prevent accidental triggers
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
+                on_action_clone(notification_id, "default");
+                on_dismiss_clone(notification_id);
+                window_for_action.close();
+            }
+        });
+        content.add_controller(click_gesture);
+        content.add_css_class(notif::TOAST_CLICKABLE);
+    }
+
+    outer.append(&main_row);
+
+    // Action buttons at the bottom
+    let non_default_actions: Vec<_> = notification
+        .actions
+        .iter()
+        .filter(|(id, _)| id != "default")
+        .collect();
+
+    if !non_default_actions.is_empty() {
+        let actions_box = GtkBox::new(Orientation::Horizontal, 8);
+        actions_box.add_css_class(notif::TOAST_ACTIONS);
+        actions_box.set_halign(Align::End);
+
+        for (action_id, action_label) in non_default_actions {
+            let action_btn = crate::widgets::base::vp_button_with_label(action_label);
+            action_btn.add_css_class(notif::TOAST_ACTION);
+            action_btn.add_css_class(button::GHOST);
+            action_btn.set_focusable(false);
+
+            let on_action_clone = on_action.clone();
+            let on_dismiss_clone = on_dismiss.clone();
+            let notification_id = notification.id;
+            let action_id = action_id.clone();
+            let window_for_action = close_window.clone();
+            action_btn.connect_clicked(move |_| {
+                on_action_clone(notification_id, &action_id);
+                on_dismiss_clone(notification_id);
+                window_for_action.close();
+            });
+
+            actions_box.append(&action_btn);
+        }
+
+        outer.append(&actions_box);
+    }
+
+    // Apply Pango font attributes to all labels if enabled in config.
+    // This is the central hook for notification toasts - widgets create standard
+    // GTK labels, and we apply Pango attributes here after the tree is built.
+    SurfaceStyleManager::global().apply_pango_attrs_all(&outer);
+
+    outer
 }
 
 impl Drop for NotificationToast {
@@ -619,3 +631,7 @@ impl NotificationToastManager {
         self.toasts.borrow().keys().cloned().collect()
     }
 }
+
+#[cfg(test)]
+#[path = "notifications_toast_tests.rs"]
+mod tests;

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -1,0 +1,228 @@
+use super::*;
+use crate::services::config_manager::ConfigManager;
+use crate::ui_regression_test_support::{
+    CssProviderGuard, find_descendant_with_class, flush_gtk, init_gtk_or_skip,
+    init_layer_shell_or_skip, label_with_text, registered_test_app,
+    run_ignored_contract_subprocess,
+};
+use std::rc::Rc;
+use vibepanel_core::Config;
+
+fn test_app() -> Application {
+    registered_test_app("dev.vibepanel.toast-ui-regression")
+}
+
+fn test_notification(urgency: u8) -> Notification {
+    Notification {
+        id: u32::from(urgency) + 1,
+        app_name: "UI Regression Test".to_string(),
+        app_icon: String::new(),
+        summary: "Toast summary".to_string(),
+        body: "Toast body".to_string(),
+        actions: Vec::new(),
+        urgency,
+        timestamp: 0.0,
+        expire_timeout: 0,
+        desktop_entry: None,
+        image_path: None,
+        image_data: None,
+        transient: true,
+    }
+}
+
+fn run_toast_ui_regression_subprocess(test_case: &str) {
+    run_ignored_contract_subprocess(
+        "notification_toast_ui_regression_runner",
+        "VIBEPANEL_NOTIFICATION_TOAST_UI_REGRESSION_TEST",
+        test_case,
+        "notification toast UI regression test",
+    );
+}
+
+#[test]
+fn test_notification_toast_critical_class_consumes_critical_tokens() {
+    let css = crate::widgets::css::widget_css(&Config::default());
+
+    assert!(
+        css.contains(
+            ".notification-row.notification-critical,\n.notification-toast-critical {\n    border-left: 3px solid var(--color-state-warning);"
+        ),
+        "critical toast selector should consume the shared warning border token"
+    );
+    assert!(
+        css.contains(
+            ".notification-toast-critical {\n    background-color: var(--color-toast-critical-background);"
+        ),
+        "critical toast selector should consume the toast critical background token"
+    );
+}
+
+fn run_test_notification_toast_structure() {
+    if !init_gtk_or_skip(
+        "notification toast UI regression test",
+        Some("VIBEPANEL_UI_REGRESSION_REQUIRED"),
+    ) {
+        return;
+    }
+
+    let mut config = Config::default();
+    config.theme.mode = "dark".to_string();
+    ConfigManager::replace_global_for_test(config.clone());
+    let _css_provider =
+        CssProviderGuard::for_config(&config, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
+    let palette = ConfigManager::global().palette();
+    SurfaceStyleManager::global().reconfigure(
+        palette.surface_styles(),
+        config.advanced.pango_font_rendering,
+    );
+
+    let window = gtk4::Window::builder()
+        .title("vibepanel toast structure UI regression test")
+        .default_width(220)
+        .default_height(120)
+        .build();
+    let notification = test_notification(URGENCY_CRITICAL);
+    let noop_dismiss: ToastCallback = Rc::new(|_| {});
+    let noop_action: ToastActionCallback = Rc::new(|_, _| {});
+    let surface = build_toast_content(&notification, noop_dismiss, noop_action, &window);
+    surface.set_size_request(180, 80);
+    window.set_child(Some(&surface));
+    window.present();
+    flush_gtk();
+
+    let child = window
+        .child()
+        .expect("toast test window should contain production toast content");
+    let container = find_descendant_with_class(&child, notif::TOAST_CONTAINER)
+        .expect("toast should render a styled notification container");
+
+    assert!(container.has_css_class(notif::TOAST));
+    assert!(container.has_css_class(notif::TOAST_CRITICAL));
+    assert!(!container.has_css_class(notif::TOAST_LOW));
+    assert!(
+        label_with_text(&child, "UI Regression Test"),
+        "toast should render the notification app name"
+    );
+    assert!(
+        label_with_text(&child, "Toast summary"),
+        "toast should render the notification summary"
+    );
+    assert!(
+        label_with_text(&child, "Toast body"),
+        "toast should render the notification body"
+    );
+
+    window.close();
+    flush_gtk();
+}
+
+#[test]
+#[ignore = "notification toast structure contract: requires a Wayland compositor with layer-shell support"]
+fn test_notification_toast_structure_contract() {
+    if init_layer_shell_or_skip("notification toast UI regression test").is_none() {
+        return;
+    }
+
+    let app = test_app();
+    for position in ["top", "bottom"] {
+        let mut config = Config::default();
+        config.theme.mode = "dark".to_string();
+        config.bar.position = position.to_string();
+        config.advanced.compositor = "mango".to_string();
+        ConfigManager::replace_global_for_test(config.clone());
+        let _css_provider =
+            CssProviderGuard::for_config(&config, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
+        let palette = ConfigManager::global().palette();
+        SurfaceStyleManager::global().reconfigure(
+            palette.surface_styles(),
+            config.advanced.pango_font_rendering,
+        );
+
+        let notification = test_notification(URGENCY_CRITICAL);
+        let noop_dismiss: ToastCallback = Rc::new(|_| {});
+        let noop_action: ToastActionCallback = Rc::new(|_, _| {});
+        let noop_timeout: ToastCallback = Rc::new(|_| {});
+        let noop_height: ToastCallback = Rc::new(|_| {});
+        let toast = NotificationToast::new(
+            &app,
+            &notification,
+            noop_dismiss,
+            noop_action,
+            noop_timeout,
+            noop_height,
+            TOAST_BAR_MARGIN,
+        );
+        toast.present();
+        flush_gtk();
+
+        let child = toast
+            .window
+            .child()
+            .expect("toast window should contain a styled surface");
+        let container = find_descendant_with_class(&child, notif::TOAST_CONTAINER)
+            .expect("toast should render a styled notification container");
+        let bar_edge = if position == "bottom" {
+            Edge::Bottom
+        } else {
+            Edge::Top
+        };
+        let opposite_edge = if position == "bottom" {
+            Edge::Top
+        } else {
+            Edge::Bottom
+        };
+        let right_margin = (TOAST_MARGIN_RIGHT
+            - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
+        .max(0);
+
+        assert!(toast.window.is_layer_window());
+        assert_eq!(toast.window.namespace().as_deref(), Some("vibepanel-toast"));
+        assert_eq!(toast.window.layer(), Layer::Overlay);
+        assert_eq!(toast.window.keyboard_mode(), KeyboardMode::None);
+        assert_eq!(toast.window.exclusive_zone(), 0);
+        assert!(toast.window.is_anchor(bar_edge));
+        assert!(toast.window.is_anchor(Edge::Right));
+        assert!(!toast.window.is_anchor(Edge::Left));
+        assert!(!toast.window.is_anchor(opposite_edge));
+        assert_eq!(toast.window.margin(bar_edge), TOAST_BAR_MARGIN);
+        assert_eq!(toast.window.margin(Edge::Right), right_margin);
+
+        assert!(toast.window.has_css_class(notif::TOAST_WRAPPER));
+        assert!(container.has_css_class(notif::TOAST));
+        assert!(container.has_css_class(notif::TOAST_CRITICAL));
+        assert!(!container.has_css_class(notif::TOAST_LOW));
+        assert!(
+            label_with_text(&child, "UI Regression Test"),
+            "toast should render the notification app name"
+        );
+        assert!(
+            label_with_text(&child, "Toast summary"),
+            "toast should render the notification summary"
+        );
+        assert!(
+            label_with_text(&child, "Toast body"),
+            "toast should render the notification body"
+        );
+
+        toast.window.close();
+        flush_gtk();
+    }
+}
+
+#[test]
+#[ignore = "UI regression test: opens GTK windows; run under Xvfb"]
+fn test_ui_regression_notification_toast_structure() {
+    run_toast_ui_regression_subprocess("toast.structure");
+}
+
+#[test]
+#[ignore = "internal runner for one notification toast UI regression subprocess"]
+fn notification_toast_ui_regression_runner() {
+    match std::env::var("VIBEPANEL_NOTIFICATION_TOAST_UI_REGRESSION_TEST").as_deref() {
+        Ok("toast.structure") => run_test_notification_toast_structure(),
+        Ok(other) => panic!("unknown notification toast UI regression test: {other}"),
+        Err(_) => {
+            eprintln!("skipping notification toast UI regression test: no test case selected")
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ Documentation has moved to the [wiki](https://github.com/prankstr/vibepanel/wiki
 - [Widgets](https://github.com/prankstr/vibepanel/wiki/Widgets)
 - [Theming](https://github.com/prankstr/vibepanel/wiki/Theming)
 - [CSS Variables](https://github.com/prankstr/vibepanel/wiki/CSS-Variables)
+- [UI Regression Tests](ui-regression-tests.md)

--- a/docs/ui-regression-tests.md
+++ b/docs/ui-regression-tests.md
@@ -1,0 +1,118 @@
+# UI Regression Tests
+
+Vibepanel has production-backed UI regression tests for the bar and widget tree.
+They are intentionally small and focus on regressions that unit tests do not
+catch well: spacing, inherited style tokens, grouping seams, and rendered
+colors.
+
+## Running
+
+The regular test suite does not present GTK UI windows:
+
+```sh
+cargo test
+```
+
+Run window-presenting GTK UI regression tests explicitly under Xvfb. The command
+unsets `WAYLAND_DISPLAY` and forces GTK onto Xvfb's X11 display so no windows
+appear on your real desktop session:
+
+```sh
+scripts/run-ui-regression-tests.sh
+```
+
+The local pre-commit hook runs this script when `xvfb-run` is installed. If Xvfb
+is unavailable locally, the hook skips the window-presenting UI regression suite
+and still runs `cargo test --all`, clippy, and rustfmt checks. CI runs the UI
+regression script with Xvfb installed.
+
+Layer-shell contracts require a Wayland compositor with layer-shell support, so
+they stay ignored in the default suite:
+
+```sh
+cargo test -p vibepanel layer_shell -- --ignored --test-threads=1
+```
+
+The CI UI regression job does not run these layer-shell/compositor-dependent
+contracts. CI uses Xvfb, which provides an X11 display, not a Wayland
+compositor. Run layer-shell contracts locally under a real Wayland session with
+layer-shell support when changing compositor protocol behavior.
+
+To pause probe windows while debugging locally:
+
+```sh
+VIBEPANEL_UI_REGRESSION_PROBE_HOLD_MS=2000 cargo test -p vibepanel sectioned_bar -- --test-threads=1
+```
+
+## Structure
+
+The bar UI regression tests use subprocess wrappers. GTK, display-level CSS
+providers, and global config state are process-scoped, so each wrapper launches
+one isolated contract via an internal ignored runner.
+
+Keep window-presenting GTK UI regression tests ignored in the default suite,
+name their runnable wrappers with the `test_ui_regression_` prefix, and run them
+through the Xvfb script above. Keep internal runners, manual probes, and
+compositor-dependent layer-shell contracts ignored as well.
+
+## Pixel Sampling
+
+Prefer sampling stable painted regions over exact visual edges. For background
+checks, clear or minimize labels so center samples do not hit glyph pixels. Avoid
+sampling borders, rounded corners, shadows, or antialiased edges unless that is
+the behavior under test. When exact coordinates are fragile, scan a small region
+for the expected color instead of asserting a single pixel.
+
+## Test Tiers
+
+The suite follows four tiers that map to the theming model:
+
+| Tier | Purpose | Examples |
+| --- | --- | --- |
+| Core unit | Validate config parsing, theme derivation, and emitted CSS tokens without GTK. | `ThemePalette::css_vars_block`, outline/color/polarity tokens |
+| CSS binding | Validate production selectors consume the expected CSS variables/classes. | `.widget`, `.vp-surface-popover`, notification rows |
+| GTK UI regression | Validate Xvfb-compatible rendered layout and pixels. | bar spacing, widget pixels, grouping seams |
+| Layer-shell | Validate compositor protocol state. Ignored by default and not run in CI's Xvfb job. | anchors, namespace, margins, exclusive zone |
+
+CSS variable coverage should start with cheap regression tests: theme variables
+consumed by production CSS should be emitted by the theme palette or explicitly
+marked as optional hooks with safe fallbacks. Use GTK UI regression tests only
+when a string-level assertion cannot prove the user-visible result.
+
+Good UI regression candidates validate non-trivial propagation or rendering
+paths: CSS variables composed with opacity/color-mix, scoped precedence such as
+TOML versus user CSS, conditional values such as enabled/disabled outlines,
+GTK/GSK-sensitive properties such as border alpha/radius, and historically
+brittle areas like group seams. Do not add rendered tests mechanically for every
+typography, icon, shadow, foreground, accent, or outgoing variable.
+
+Layer-shell contracts should assert layer-shell behavior. If a test only checks
+structure, CSS classes, or rendered colors, prefer a normal GTK UI regression
+test so it can run in CI without a compositor.
+
+## Theming Coverage
+
+Use the theming docs as the coverage checklist. Prefer one high-signal contract
+per behavior over mechanically testing every token in every tier.
+
+| Theming area | Core unit | CSS contract | GTK UI regression | Layer-shell | Intentionally not covered / next gap |
+| --- | --- | --- | --- | --- | --- |
+| `theme.mode` dark/light | palette polarity tokens | shared surface selectors | dark/light widget pixel delta | n/a | `theme.mode = auto` / wallpaper-derived polarity |
+| `theme.popover` polarity | popover token block | `.vp-surface-popover` vars | popover-vs-bar pixel delta | popover anchors/margins separately | n/a |
+| `theme.states.urgent` | state tokens | urgent selectors | urgent workspace/taskbar pixels | n/a | Add `success` only if a real state-surface regression appears |
+| `theme.states.warning` / critical notifications | critical background tokens | notification row selectors | n/a | toast window protocol separately | Revisit floating-toast critical styling in a follow-up PR |
+| Hover state | hover tokens | hover vars consumed inside `:hover` selectors | intentionally not covered | n/a | `StateFlags::PRELIGHT` did not reliably activate GTK `:hover` under Xvfb; add rendered hover only when a stable trigger exists |
+| Outline color/opacity | outline tokens and per-widget overrides | bar/widget/surface border vars | outline border pixels and CSS/GSK parity | n/a | n/a |
+| `[bar]` size/spacing/inset/padding | token derivation | bar selector bindings | live bar measurements | bar anchor/exclusive-zone contracts | n/a |
+| `[widgets]` background/radius/opacity | token derivation | `.widget`/popover bindings | widget/background pixels and grouping seams | n/a | radius/opacity pixels only if regressions recur |
+| `[widgets.<name>]` overrides | per-widget CSS generation | scoped widget/popover selectors | override precedence pixels | n/a | Extend with a matrix only before adding more bespoke precedence pixels |
+| User CSS overrides | n/a | selector reachability | override precedence pixels and runtime `style.css` load path | n/a | n/a |
+| Surface families | surface token derivation | shared surface classes | popover pixels | popover/toast protocol separately | OSD, tray/menu, quick settings, toast pixels |
+
+Known follow-ups:
+
+- Add targeted coverage for `theme.mode = auto` / wallpaper-derived polarity.
+- Add pango-font-rendering assertions by inspecting GTK label attributes rather
+  than pixels.
+- Add more surface-specific tests for OSD, tray/menu surfaces, and quick
+  settings once shared UI regression helpers are reused outside `sectioned_bar.rs`.

--- a/scripts/run-ui-regression-tests.sh
+++ b/scripts/run-ui-regression-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v xvfb-run >/dev/null 2>&1; then
+    printf '%s\n' "error: xvfb-run is required for GTK UI regression tests"
+    printf '%s\n' "install Xvfb so UI regression tests can run without presenting desktop windows"
+    exit 1
+fi
+
+# Run only the ignored GTK UI regression wrappers. Internal runners are invoked
+# by those wrappers and layer-shell contracts still need a real Wayland compositor.
+echo '+xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 VIBEPANEL_UI_REGRESSION_REQUIRED=1 cargo test -p vibepanel test_ui_regression_ -- --ignored --test-threads=1'
+xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 VIBEPANEL_UI_REGRESSION_REQUIRED=1 cargo test -p vibepanel test_ui_regression_ -- --ignored --test-threads=1


### PR DESCRIPTION
This PR adds UI tests on top of the existing unit tests.

Most regressions have been visual stuff in the bar widgets that I miss because it's hard to remember to test every single option. Bar/widget spacing, grouping seams, inherited colors, CSS variable bindings, outline behavior etc etc.

It adds a small GTK/Xvfb-based regression harness, rendered bar/widget contracts, CSS variable contract tests etc. The tests reuse production widget building where possible so they validate the real UI instead.