### PR TITLE
refactor(theme): move surface styling to generated CSS

### DIFF
--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -50,9 +50,6 @@ const FOREGROUND_MUTED_OPACITY: f64 = 0.6;
 const FOREGROUND_DISABLED_OPACITY: f64 = 0.4;
 const FOREGROUND_FAINT_OPACITY: f64 = 0.3;
 
-// Toast critical background blend weight
-const TOAST_CRITICAL_URGENT_WEIGHT: f64 = 0.35;
-
 /// Perceptual dark/light boundary in WCAG linear relative luminance.
 ///
 /// CIELAB L*=50 (perceptual midpoint) ⇒ Y = ((50+16)/116)³ ≈ 0.184187.
@@ -305,11 +302,6 @@ pub struct SurfaceStyles {
     pub text_color: String,
     pub font_family: String,
     pub font_size: u32,
-    pub border_radius: u32,
-    pub border_color: String,
-    pub opacity: f64,
-    pub shadow: String,
-    pub is_dark_mode: bool,
     pub shadows_enabled: bool,
 }
 
@@ -371,7 +363,6 @@ pub struct ThemePalette {
 
     // Critical backgrounds
     pub row_critical_background: String,
-    pub toast_critical_background: String,
 
     // Typography
     pub font_family: String,
@@ -498,7 +489,7 @@ impl ThemePalette {
         ))
     }
 
-    /// Generate CSS variable overrides scoped to `.vp-surface-popover`.
+    /// Generate CSS variable overrides scoped to `.popover`.
     ///
     /// Only emits polarity-dependent color variables (foregrounds, overlays,
     /// borders, shadows, slider tracks, critical backgrounds, accent derivatives,
@@ -523,7 +514,7 @@ impl ThemePalette {
 
         format!(
             r#"
-.vp-surface-popover {{
+.popover {{
     /* ===== Popover polarity override ===== */
     --widget-background-color: {widget_bg};
     --widget-hover-tint: {hover_tint};
@@ -557,7 +548,6 @@ impl ThemePalette {
 
     /* Contextual backgrounds */
     --color-row-critical-background: {row_critical_bg};
-    --color-toast-critical-background: {toast_critical_bg};
 }}
 "#,
             widget_bg = self.widget_background,
@@ -580,7 +570,6 @@ impl ThemePalette {
             slider_track = self.slider_track,
             slider_track_disabled = self.slider_track_disabled,
             row_critical_bg = self.row_critical_background,
-            toast_critical_bg = self.toast_critical_background,
         )
     }
 
@@ -686,7 +675,6 @@ impl ThemePalette {
     --color-row-background: var(--color-card-overlay-subtle);
     --color-row-background-hover: var(--color-card-overlay-hover);
     --color-row-critical-background: {row_critical_bg};
-    --color-toast-critical-background: {toast_critical_bg};
 
     /* ===== Radii ===== */
     --radius-bar: {radius_bar}px;
@@ -804,7 +792,6 @@ impl ThemePalette {
             slider_track = self.slider_track,
             slider_track_disabled = self.slider_track_disabled,
             row_critical_bg = self.row_critical_background,
-            toast_critical_bg = self.toast_critical_background,
             radius_bar = self.bar_border_radius,
             radius_surface = self.surface_border_radius,
             radius_widget = if self.widget_radius_percent >= 50 {
@@ -870,11 +857,6 @@ impl ThemePalette {
             text_color: self.foreground_primary.clone(),
             font_family: self.font_family.clone(),
             font_size: self.sizes.font_size,
-            border_radius: self.surface_border_radius,
-            border_color: self.border_subtle.clone(),
-            opacity: self.widget_opacity,
-            shadow: self.shadow_soft.clone(),
-            is_dark_mode: self.is_dark_mode,
             shadows_enabled: self.shadows_enabled,
         }
     }
@@ -1305,11 +1287,6 @@ impl ThemePalette {
                 "color-mix(in srgb, {} 18%, @view_bg_color)",
                 self.state_urgent
             );
-            self.toast_critical_background = format!(
-                "color-mix(in srgb, {} {:.0}%, @window_bg_color)",
-                self.state_urgent,
-                TOAST_CRITICAL_URGENT_WEIGHT * 100.0
-            );
             return;
         }
 
@@ -1318,19 +1295,6 @@ impl ThemePalette {
             match blend_colors(&self.state_urgent, &self.widget_background, 0.18) {
                 Some((r, g, b)) => rgba_str(r, g, b, 0.95),
                 None => "rgba(255, 100, 100, 0.15)".to_string(),
-            };
-
-        // Toast critical: darker, more opaque
-        let base = if self.is_dark_mode {
-            "#1a1a1a"
-        } else {
-            "#f5f5f5"
-        };
-
-        self.toast_critical_background =
-            match blend_colors(&self.state_urgent, base, TOAST_CRITICAL_URGENT_WEIGHT) {
-                Some((r, g, b)) => rgba_str(r, g, b, 0.95),
-                None => "rgba(40, 20, 20, 0.95)".to_string(),
             };
     }
 
@@ -1437,13 +1401,6 @@ impl ThemePalette {
             Some((r, g, b)) => rgba_str(r, g, b, 0.95),
             None => argb_to_hex(&scheme.error_container),
         };
-
-        let surface_hex = argb_to_hex(&scheme.surface);
-        self.toast_critical_background =
-            match blend_colors(&error_hex, &surface_hex, TOAST_CRITICAL_URGENT_WEIGHT) {
-                Some((r, g, b)) => rgba_str(r, g, b, 0.95),
-                None => argb_to_hex(&scheme.error_container),
-            };
     }
 
     fn compute_sizes(&mut self) {
@@ -1529,7 +1486,6 @@ impl Default for ThemePalette {
             slider_track: String::new(),
             slider_track_disabled: String::new(),
             row_critical_background: String::new(),
-            toast_critical_background: String::new(),
             font_family: DEFAULT_FONT_FAMILY.to_string(),
             bar_opacity: 0.0,
             widget_opacity: 1.0,
@@ -2084,13 +2040,6 @@ mod tests {
             "row_critical_background should reference @view_bg_color, got: {}",
             palette.row_critical_background
         );
-        assert!(
-            palette
-                .toast_critical_background
-                .contains("@window_bg_color"),
-            "toast_critical_background should reference @window_bg_color, got: {}",
-            palette.toast_critical_background
-        );
     }
 
     #[test]
@@ -2365,10 +2314,10 @@ mod tests {
         let popover = ThemePalette::popover_palette(&config, None, None).unwrap();
         let css = popover.css_popover_vars_block();
 
-        // Should be scoped under .vp-surface-popover
+        // Should be scoped under .popover
         assert!(
-            css.contains(".vp-surface-popover"),
-            "popover CSS should be scoped to .vp-surface-popover"
+            css.contains(".popover"),
+            "popover CSS should be scoped to .popover"
         );
         // Should contain polarity-dependent variables
         assert!(css.contains("--widget-background-color:"));

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -1134,7 +1134,7 @@ pub(crate) fn generate_css(
     // Per-widget CSS overrides (background_color, etc. from [widgets.xxx] sections)
     let per_widget_css = ThemePalette::generate_per_widget_css(config);
 
-    // Popover polarity overrides (scoped under .vp-surface-popover)
+    // Popover polarity overrides (scoped under .popover)
     let popover_css = popover_palette
         .map(|p| p.css_popover_vars_block())
         .unwrap_or_default();

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -630,7 +630,7 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
             "Surface style manager initialized with theme styles (pango_font_rendering={})",
             config_for_activate.advanced.pango_font_rendering
         );
-        services::tooltip::TooltipManager::init_global(surface_styles);
+        services::tooltip::TooltipManager::init_global();
         debug!("Tooltip manager initialized with theme styles");
 
         // Initialize idle inhibitor service (uses logind D-Bus API)

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -308,14 +308,14 @@ fn assert_widget_style_bindings(config: &Config) {
 
 fn production_popover_declarations(config: &Config) -> String {
     let css = crate::widgets::css::utility_css(config);
-    let selector = ".vp-surface-popover {";
+    let selector = ".popover {";
     let selector_pos = css
         .find(selector)
-        .expect("production utility CSS should contain the .vp-surface-popover selector");
+        .expect("production utility CSS should contain the .popover selector");
     let selector_block = &css[selector_pos..];
     let block_end = selector_block
         .find('}')
-        .expect("production .vp-surface-popover selector should have a declaration block");
+        .expect("production .popover selector should have a declaration block");
 
     selector_block[..block_end].to_string()
 }
@@ -325,11 +325,11 @@ fn assert_popover_style_bindings(config: &Config) {
 
     assert!(
         declarations.contains(&format!("background-color: {POPOVER_BG_WITH_OPACITY};")),
-        "production popover CSS should apply --widget-background-color and --popover-background-opacity to .vp-surface-popover"
+        "production popover CSS should apply --widget-background-color and --popover-background-opacity to .popover"
     );
     assert!(
         declarations.contains("border: var(--surface-outline-width) solid"),
-        "production popover CSS should apply --surface-outline-width to .vp-surface-popover"
+        "production popover CSS should apply --surface-outline-width to .popover"
     );
 }
 
@@ -1487,7 +1487,7 @@ fn run_test_surface_outline_css_gsk_parity() {
     config.widgets.popover_background_opacity = Some(1.0);
 
     set_ui_regression_config(&config);
-    let surface_fixture = painted_surface_fixture(&config, crate::styles::surface::SURFACE_POPOVER);
+    let surface_fixture = painted_surface_fixture(&config, crate::styles::surface::POPOVER);
     let css_edge = edge_pixel_of_surface(&surface_fixture);
     let gsk_rgba = crate::services::config_manager::ConfigManager::global()
         .surface_outline_rgba_for_widget("custom-a", &surface_fixture.surface);
@@ -1554,7 +1554,7 @@ fn run_test_theme_popover_polarity_pixel() {
     bar_fixture.window.close();
     flush_gtk();
 
-    let popover_fixture = painted_surface_fixture(&config, crate::styles::surface::SURFACE_POPOVER);
+    let popover_fixture = painted_surface_fixture(&config, crate::styles::surface::POPOVER);
     let popover_pixel = center_pixel_of_surface(&popover_fixture);
     maybe_hold_probe_window();
     popover_fixture.window.close();

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -50,7 +50,6 @@ use crate::services::bar_manager::BarManager;
 use crate::services::icons::IconsService;
 use crate::services::network::NetworkService;
 use crate::services::surfaces::SurfaceStyleManager;
-use crate::services::tooltip::TooltipManager;
 
 /// Messages sent from the file watcher thread to the GTK main thread.
 #[derive(Debug)]
@@ -871,9 +870,6 @@ impl ConfigManager {
                 new_config.advanced.pango_font_rendering,
             );
 
-            // Update tooltip manager
-            TooltipManager::global().reconfigure(surface_styles);
-
             // Update the cached palettes before load_css so they're available
             *self.palette.borrow_mut() = palette;
             *self.popover_palette.borrow_mut() = popover_palette;
@@ -1024,8 +1020,6 @@ impl ConfigManager {
 
                 SurfaceStyleManager::global()
                     .reconfigure(surface_styles.clone(), config.advanced.pango_font_rendering);
-                TooltipManager::global().reconfigure(surface_styles);
-
                 *mgr.palette.borrow_mut() = palette;
                 *mgr.popover_palette.borrow_mut() = popover_palette;
                 bar::load_css(&config);

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -1,9 +1,7 @@
 //! Surface styling helpers for vibepanel.
 //!
-//! This module owns `SurfaceStyles` derived from the theme and provides
-//! helpers to apply consistent styling to popovers, menus, and other
-//! overlay containers. It is intentionally separate from `TooltipManager`
-//! so that tooltip concerns and general surface styling remain decoupled.
+//! This module owns runtime surface helpers that cannot live in static CSS,
+//! such as shadow margins, animated outlines, and optional Pango font styling.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -15,17 +13,8 @@ use tracing::debug;
 use vibepanel_core::SurfaceStyles;
 
 use crate::services::config_manager::ConfigManager;
-use crate::styles::{icon, media, notification as notif, osd, surface};
-use crate::widgets::css::{POPOVER_BG_WITH_OPACITY, WIDGET_BG_WITH_OPACITY};
+use crate::styles::{icon, surface};
 use crate::widgets::scale_box::ScaleBox;
-
-// GTK 4.10 deprecated widget-scoped style contexts but didn't provide a replacement.
-// We need widget-scoped CSS to style individual surfaces without affecting the entire
-// display. The display-scoped alternative (style_context_add_provider_for_display)
-// would require unique CSS class names for every surface instance, which is impractical.
-// This import is used for StyleContextExt::add_provider().
-#[allow(deprecated)]
-use gtk4::prelude::StyleContextExt;
 
 // Thread-local singleton storage for SurfaceStyleManager
 thread_local! {
@@ -40,19 +29,14 @@ fn default_surface_styles() -> SurfaceStyles {
         text_color: "#ffffff".to_string(),
         font_family: "monospace".to_string(),
         font_size: 14,
-        border_radius: 8,
-        border_color: "rgba(255, 255, 255, 0.10)".to_string(),
-        opacity: 1.0,
-        shadow: "0 1px 2px rgba(0, 0, 0, 0.20), 0 1px 3px rgba(0, 0, 0, 0.24)".to_string(),
-        is_dark_mode: true,
         shadows_enabled: true,
     }
 }
 
 /// Process-wide surface styling manager.
 ///
-/// Provides `apply_surface_styles` for popovers, menus, and other containers
-/// that should share the same visual language as widgets.
+/// Provides runtime styling helpers for shadow margins, GSK outline coordination,
+/// Pango font workarounds, and tray contrast adjustments.
 pub struct SurfaceStyleManager {
     styles: RefCell<SurfaceStyles>,
     /// Whether to use Pango attributes for font rendering instead of CSS.
@@ -68,18 +52,6 @@ impl SurfaceStyleManager {
             styles: RefCell::new(styles),
             pango_font_rendering: Cell::new(false),
         })
-    }
-
-    /// Initialize the global SurfaceStyleManager with styles from ThemePalette.
-    ///
-    /// Should be called during application startup after loading config:
-    /// ```ignore
-    /// let palette = ThemePalette::from_config(&config, None, None);
-    /// SurfaceStyleManager::init_global(palette.surface_styles());
-    /// ```
-    #[allow(dead_code)]
-    pub fn init_global(styles: SurfaceStyles) {
-        Self::init_global_with_config(styles, false);
     }
 
     /// Initialize the global SurfaceStyleManager with styles and config options.
@@ -120,11 +92,6 @@ impl SurfaceStyleManager {
     }
 
     /// Reconfigure the manager with new styles (for live config reload).
-    ///
-    /// This updates the internal styles. Note that surfaces already styled
-    /// won't be automatically updated - they would need to call
-    /// `apply_surface_styles` again. For most use cases, newly created
-    /// surfaces will pick up the new styles automatically.
     pub fn reconfigure(&self, styles: SurfaceStyles, pango_font_rendering: bool) {
         debug!(
             "SurfaceStyleManager reconfiguring: bg={} -> {}, pango_font_rendering={}",
@@ -134,12 +101,6 @@ impl SurfaceStyleManager {
         );
         *self.styles.borrow_mut() = styles;
         self.pango_font_rendering.set(pango_font_rendering);
-    }
-
-    /// Get the current font family.
-    #[allow(dead_code)]
-    pub fn font_family(&self) -> String {
-        self.styles.borrow().font_family.clone()
     }
 
     /// Get the current background color.
@@ -180,7 +141,7 @@ impl SurfaceStyleManager {
         let width = config.surface_outline_width();
         let color = if active && width > 0.0 {
             debug_assert!(
-                shell.child_has_css_class(surface::SURFACE_POPOVER),
+                shell.child_has_css_class(surface::POPOVER),
                 "animated surface outline suppression expects a popover surface child"
             );
             config.surface_outline_rgba_for_widget(widget_name, shell)
@@ -359,193 +320,5 @@ impl SurfaceStyleManager {
         if self.pango_font_rendering.get() {
             self.style_all_labels(widget, self.font_size());
         }
-    }
-
-    /// Apply tooltip-like surface styling to a widget.
-    ///
-    /// Use this for popovers, menus, or any container that should have the
-    /// same visual language as widgets: dark background, rounded corners,
-    /// readable text, subtle border.
-    ///
-    /// The styles are applied at base priority so CSS classes can override
-    /// specific properties while GTK themes are still overridden.
-    ///
-    /// Background color is determined by CSS variables:
-    /// - Default: Uses `--widget-background-color` from `:root`
-    /// - Per-widget override: Add a class like `.clock-popover` to the widget,
-    ///   which overrides `--widget-background-color` via generated CSS
-    ///
-    /// # Arguments
-    /// * `widget` - The widget to style
-    /// * `with_padding` - Whether to apply padding to the widget
-    pub fn apply_surface_styles(&self, widget: &impl IsA<gtk4::Widget>, with_padding: bool) {
-        self.apply_surface_styles_inner(widget, with_padding, "var(--radius-surface)");
-    }
-
-    /// Apply surface styles with a custom border radius.
-    ///
-    /// # Arguments
-    /// * `widget` - The widget to style
-    /// * `with_padding` - Whether to apply padding to the widget
-    /// * `radius` - CSS value for border-radius (e.g., "var(--radius-widget)")
-    pub fn apply_surface_styles_with_radius(
-        &self,
-        widget: &impl IsA<gtk4::Widget>,
-        with_padding: bool,
-        radius: &str,
-    ) {
-        self.apply_surface_styles_inner(widget, with_padding, radius);
-    }
-
-    fn apply_surface_styles_inner(
-        &self,
-        widget: &impl IsA<gtk4::Widget>,
-        with_padding: bool,
-        radius: &str,
-    ) {
-        let widget = widget.as_ref();
-
-        let styles = self.styles.borrow();
-        let padding_css = if with_padding {
-            "padding: 16px;".to_string()
-        } else {
-            String::new()
-        };
-
-        // Use inline color-mix() so per-widget overrides work via CSS scoping
-        // (e.g., .clock-popover overrides --widget-background-color)
-
-        // Build CSS targeting the widget's CSS name
-        // For Popover, we need to target both the popover and its contents
-        // Use high-specificity selectors to override GTK themes
-        let css_name = widget.css_name();
-        let css = if css_name == "popover" {
-            let bg = POPOVER_BG_WITH_OPACITY;
-            format!(
-                r#"
-popover.widget-menu,
-popover.widget-menu.background {{
-    background-color: {bg};
-    background: {bg};
-    background-image: none;
-    border: none;
-    border-radius: {radius};
-    box-shadow: none;
-}}
-
-popover.widget-menu > contents,
-popover.widget-menu.background > contents {{
-    background-color: transparent;
-    background: transparent;
-    background-image: none;
-    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
-    border-radius: {radius};
-    font-family: {font};
-    font-size: var(--font-size);
-    color: var(--color-foreground-primary);
-    {padding}
-    margin: 0 6px 6px 6px;
-    box-shadow: var(--shadow-soft);
-}}
-
-popover.widget-menu > arrow,
-popover.widget-menu.background > arrow {{
-    background: transparent;
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-}}
-
-popover.widget-menu *,
-popover.widget-menu.background * {{
-    font-family: inherit;
-}}
-"#,
-                bg = bg,
-                font = styles.font_family,
-                padding = padding_css,
-                radius = radius,
-            )
-        } else {
-            // Layer-shell popovers are GtkBox, not native Popover widgets.
-            let is_popover_surface = widget.has_css_class(surface::POPOVER);
-            let is_floating_surface = widget.has_css_class(notif::TOAST)
-                || widget.has_css_class(osd::OSD)
-                || widget.has_css_class(media::CONTENT);
-            let bg = if is_popover_surface || is_floating_surface {
-                POPOVER_BG_WITH_OPACITY
-            } else {
-                WIDGET_BG_WITH_OPACITY
-            };
-            // Check if widget has the widget-menu-content class - if so, use
-            // that as the selector for more specific targeting. These inner panels
-            // should NOT get a shadow since popover contents node handles that.
-            let has_menu_content_class = widget.has_css_class(surface::WIDGET_MENU_CONTENT);
-
-            let selector = if has_menu_content_class {
-                format!(".{}", surface::WIDGET_MENU_CONTENT)
-            } else {
-                // Use the widget's first CSS class so the rule only targets
-                // the styled surface, not every descendant GtkBox.
-                let classes = widget.css_classes();
-                if let Some(first) = classes.first() {
-                    format!(".{}", first.as_str())
-                } else {
-                    css_name.to_string()
-                }
-            };
-
-            // Inner popover panels (.widget-menu-content) don't need shadow -
-            // the popover's contents node handles that.
-            let shadow_css = if has_menu_content_class {
-                "none".to_string()
-            } else {
-                "var(--shadow-soft)".to_string()
-            };
-
-            format!(
-                r#"
-{selector} {{
-    background-color: {bg};
-    background-image: none;
-    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
-    border-radius: {radius};
-    font-family: {font};
-    font-size: var(--font-size);
-    color: var(--color-foreground-primary);
-    {padding}
-    box-shadow: {shadow};
-}}
-
-{selector} * {{
-    font-family: inherit;
-}}
-"#,
-                selector = selector,
-                bg = bg,
-                font = styles.font_family,
-                padding = padding_css,
-                shadow = shadow_css,
-                radius = radius,
-            )
-        };
-
-        let provider = gtk4::CssProvider::new();
-        provider.load_from_string(&css);
-
-        // Apply styles to the widget's style context so they are scoped to
-        // this surface hierarchy instead of the entire display. GTK will
-        // propagate these styles to descendants automatically.
-        //
-        // NOTE: style_context() and add_provider() are deprecated in GTK 4.10+
-        // but GTK provides no replacement for widget-scoped CSS. The alternative
-        // (style_context_add_provider_for_display) applies CSS globally, which
-        // would require unique class names per surface instance. We use the
-        // deprecated API intentionally here as it's the only way to scope CSS
-        // to a specific widget subtree.
-        #[allow(deprecated)]
-        widget
-            .style_context()
-            .add_provider(&provider, gtk4::STYLE_PROVIDER_PRIORITY_USER);
     }
 }

--- a/crates/vibepanel/src/services/tooltip.rs
+++ b/crates/vibepanel/src/services/tooltip.rs
@@ -3,10 +3,6 @@
 //! Uses layer-shell positioned tooltip windows instead of GTK's native tooltips,
 //! which don't position correctly on layer-shell surfaces.
 //!
-//! Tooltip styling is derived from `ThemePalette::surface_styles()` for full
-//! theme integration. Initialize with `TooltipManager::init_global(styles)`
-//! before first use.
-
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -16,7 +12,6 @@ use gtk4::prelude::*;
 use gtk4::{Label, Window};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use tracing::debug;
-use vibepanel_core::SurfaceStyles;
 
 use crate::services::config_manager::ConfigManager;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -40,23 +35,6 @@ const SCREEN_EDGE_MARGIN: i32 = 8;
 /// Fallback tooltip width when measurement fails
 const FALLBACK_TOOLTIP_WIDTH: i32 = 300;
 
-/// Default tooltip styles, used when init_global is not called.
-/// Provides a reasonable dark-mode appearance as fallback.
-fn default_surface_styles() -> SurfaceStyles {
-    SurfaceStyles {
-        background_color: "#111217".to_string(),
-        text_color: "#ffffff".to_string(),
-        font_family: "monospace".to_string(),
-        font_size: 14,
-        border_radius: 8,
-        border_color: "rgba(255, 255, 255, 0.10)".to_string(),
-        opacity: 1.0,
-        shadow: "0 1px 2px rgba(0, 0, 0, 0.24)".to_string(),
-        is_dark_mode: true,
-        shadows_enabled: true,
-    }
-}
-
 /// A layer-shell tooltip window.
 struct TooltipWindow {
     window: Window,
@@ -73,7 +51,7 @@ enum TooltipAnchor {
 }
 
 impl TooltipWindow {
-    fn new(styles: &SurfaceStyles) -> Self {
+    fn new() -> Self {
         let window = Window::builder().decorated(false).resizable(false).build();
 
         window.add_css_class(tooltip::WINDOW);
@@ -97,50 +75,9 @@ impl TooltipWindow {
         label.add_css_class(tooltip::LABEL);
         window.set_child(Some(&label));
 
-        // Apply styles via inline CSS on the window
-        Self::apply_styles(&window, &label, styles);
+        SurfaceStyleManager::global().apply_pango_attrs(&label);
 
         Self { window, label }
-    }
-
-    fn apply_styles(window: &Window, label: &Label, styles: &SurfaceStyles) {
-        // Tooltip background: the popover base tinted 20% toward the hover-tint
-        // direction (white in dark mode, black in light mode) so that it is
-        // visibly elevated above any surface it appears over.
-        let css = format!(
-            r#"
-.vibepanel-tooltip {{
-    background-color: color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 90%, var(--widget-hover-tint));
-    border-radius: var(--radius-surface);
-    border: none;
-    padding: 6px 10px;
-    opacity: 0.90;
-}}
-
-.vibepanel-tooltip-label {{
-    font-family: {font};
-    font-size: {size}px;
-    color: {fg};
-}}
-"#,
-            font = styles.font_family,
-            size = styles.font_size,
-            fg = styles.text_color,
-        );
-
-        let provider = gtk4::CssProvider::new();
-        provider.load_from_string(&css);
-
-        // Apply to window and label via display-wide provider with USER priority to override GTK themes
-        let display = gtk4::prelude::WidgetExt::display(window);
-        gtk4::style_context_add_provider_for_display(
-            &display,
-            &provider,
-            gtk4::STYLE_PROVIDER_PRIORITY_USER + 10,
-        );
-
-        // Apply Pango font attributes if enabled (workaround for layer-shell font issues)
-        SurfaceStyleManager::global().apply_pango_attrs(label);
     }
 
     /// Measure the natural width of the tooltip with the given text.
@@ -194,10 +131,6 @@ impl TooltipWindow {
     fn hide(&self) {
         self.window.set_visible(false);
     }
-
-    fn update_styles(&self, styles: &SurfaceStyles) {
-        Self::apply_styles(&self.window, &self.label, styles);
-    }
 }
 
 /// Process-wide tooltip manager using layer-shell windows.
@@ -205,8 +138,6 @@ impl TooltipWindow {
 /// Provides `set_styled_tooltip` for applying tooltips to widgets.
 /// Unlike GTK's native tooltips, these are positioned correctly on layer-shell surfaces.
 pub struct TooltipManager {
-    /// Surface styling configuration.
-    styles: RefCell<SurfaceStyles>,
     /// The tooltip window (lazily created).
     tooltip_window: RefCell<Option<TooltipWindow>>,
     /// Pending show timer source ID.
@@ -224,10 +155,9 @@ pub struct TooltipManager {
 }
 
 impl TooltipManager {
-    /// Create a new TooltipManager with the given styles.
-    fn new(styles: SurfaceStyles) -> Rc<Self> {
+    /// Create a new TooltipManager.
+    fn new() -> Rc<Self> {
         Rc::new(Self {
-            styles: RefCell::new(styles),
             tooltip_window: RefCell::new(None),
             pending_show: RefCell::new(None),
             current_widget: RefCell::new(None),
@@ -238,53 +168,30 @@ impl TooltipManager {
         })
     }
 
-    /// Initialize the global TooltipManager with styles from ThemePalette.
-    ///
-    /// Should be called during application startup after loading config:
-    /// ```ignore
-    /// let palette = ThemePalette::from_config(&config, None, None);
-    /// TooltipManager::init_global(palette.surface_styles());
-    /// ```
-    pub fn init_global(styles: SurfaceStyles) {
+    /// Initialize the global TooltipManager.
+    pub fn init_global() {
         TOOLTIP_INSTANCE.with(|cell| {
             let mut opt = cell.borrow_mut();
             if opt.is_some() {
                 debug!("TooltipManager already initialized, ignoring init_global call");
                 return;
             }
-            *opt = Some(TooltipManager::new(styles));
+            *opt = Some(TooltipManager::new());
         });
     }
 
     /// Get the global TooltipManager singleton.
     ///
-    /// If not initialized via `init_global`, uses default dark-mode styles.
+    /// If not initialized via `init_global`, initializes on demand.
     pub fn global() -> Rc<Self> {
         TOOLTIP_INSTANCE.with(|cell| {
             let mut opt = cell.borrow_mut();
             if opt.is_none() {
                 debug!("TooltipManager not initialized, using defaults");
-                *opt = Some(TooltipManager::new(default_surface_styles()));
+                *opt = Some(TooltipManager::new());
             }
             opt.as_ref().unwrap().clone()
         })
-    }
-
-    /// Reconfigure the manager with new styles (for live config reload).
-    ///
-    /// This updates the internal styles and updates any existing tooltip window.
-    pub fn reconfigure(&self, styles: SurfaceStyles) {
-        debug!(
-            "TooltipManager reconfiguring: bg={} -> {}",
-            self.styles.borrow().background_color,
-            styles.background_color
-        );
-        *self.styles.borrow_mut() = styles.clone();
-
-        // Update existing tooltip window if it exists
-        if let Some(ref tooltip_window) = *self.tooltip_window.borrow() {
-            tooltip_window.update_styles(&styles);
-        }
     }
 
     /// Set a styled tooltip on a widget.
@@ -536,24 +443,7 @@ impl TooltipManager {
             return;
         }
 
-        let styles = self.styles.borrow();
-        let tooltip_window = TooltipWindow::new(&styles);
+        let tooltip_window = TooltipWindow::new();
         *self.tooltip_window.borrow_mut() = Some(tooltip_window);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_default_surface_styles() {
-        // Verify default styles are sensible
-        let styles = default_surface_styles();
-        assert_eq!(styles.background_color, "#111217");
-        assert_eq!(styles.text_color, "#ffffff");
-        assert!(styles.border_radius > 0);
-        assert!(styles.font_size > 0);
-        assert!(styles.is_dark_mode);
     }
 }

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -695,6 +695,7 @@ pub mod surface {
     pub const POPOVER_WRAPPER: &str = "popover-wrapper";
 
     /// Deprecated: use [`POPOVER`]. Internal popover surface marker (`.vp-surface-popover`).
+    /// Kept as a user-CSS compatibility alias; scheduled for removal in a future breaking release.
     pub const SURFACE_POPOVER: &str = "vp-surface-popover";
 
     /// Temporarily hide the CSS-painted outline while `ScaleBox` draws it on

--- a/crates/vibepanel/src/theme_vars.rs
+++ b/crates/vibepanel/src/theme_vars.rs
@@ -58,7 +58,6 @@ pub(super) const THEME_VAR_EXPECTATIONS: &[ThemeVarExpectation] = &[
     hover_var("--color-taskbar-button-active-hover-bg", Root, BuiltinCss),
     hover_var("--color-taskbar-button-hover-bg", Root, BuiltinCss),
     hover_var("--color-taskbar-button-urgent-hover-bg", Root, BuiltinCss),
-    var("--color-toast-critical-background", Root, BuiltinCss),
     hover_var("--color-widget-hover-bg", Root, BuiltinCss),
     hover_var(
         "--color-workspace-indicator-active-hover-bg",

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -69,6 +69,21 @@ tooltip.background label {{
     color: var(--color-foreground-primary);
 }}
 
+/* Layer-shell tooltips use custom windows so they share the same styling as native tooltips. */
+.vibepanel-tooltip {{
+    background-color: color-mix(in srgb, {popover_bg} 90%, var(--widget-hover-tint));
+    border-radius: var(--radius-surface);
+    border: none;
+    padding: 6px 10px;
+    opacity: 0.90;
+}}
+
+.vibepanel-tooltip-label {{
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+    color: var(--color-foreground-primary);
+}}
+
 /* Color utilities - applies to both text and icons */
 .vp-primary {{ color: var(--color-foreground-primary); }}
 .vp-muted {{ color: var(--color-foreground-muted); }}
@@ -119,9 +134,13 @@ label link:active {{
 }}
 
 /* Popover/surface background */
-/* color-mix() is inline here so per-widget popover --widget-background-color overrides work via CSS scoping */
-.vp-surface-popover {{
+/* color-mix() uses CSS custom properties so per-widget `.popover` descendants can override
+   --widget-background-color and have the mixed value recomputed via CSS scoping */
+/* NOTE: `.popover` is an explicit style class added by Vibepanel (LayerShellPopover etc.).
+   GTK's native Popover widget is the `popover` CSS *node* (no leading dot) — no collision. */
+.popover {{
     background-color: {popover_bg};
+    background-image: none;
     border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
     border-radius: var(--radius-surface);
     box-shadow: var(--shadow-soft);
@@ -131,8 +150,29 @@ label link:active {{
     color: var(--color-foreground-primary);
 }}
 
+.notification-toast,
+window.media-window > .media-content,
+.osd {{
+    background-color: {popover_bg};
+    background-image: none;
+    border: var(--surface-outline-width) solid color-mix(in srgb, var(--surface-outline-color) var(--surface-outline-opacity), transparent);
+    border-radius: var(--radius-surface);
+    box-shadow: var(--shadow-soft);
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+    color: var(--color-foreground-primary);
+}}
+
+window.media-window > .media-content {{
+    padding: 16px;
+}}
+
+.osd {{
+    border-radius: var(--radius-widget-lg);
+}}
+
 /* Mirrors the generated surface rule for static popover styles. */
-.vp-surface-popover.vp-suppress-css-outline {{
+.popover.vp-suppress-css-outline {{
     border-color: transparent;
 }}
 
@@ -155,12 +195,17 @@ popover.widget-menu.background > contents {{
     margin: 0 6px 6px 6px;
 }}
 
+/* Inner panel inside a native widget-menu popover already gets the shadow
+   from the contents node above; suppress the duplicate. */
+popover.widget-menu .popover.widget-menu-content {{
+    box-shadow: none;
+}}
+
 /* ===== FOCUS SUPPRESSION ===== */
 /* When GTK's 3 s focus_visible timeout fires, the focused widget keeps :focus
    but loses :focus-visible.  Suppress Adwaita's residual :focus outline so no
    faint ring lingers after keyboard nav times out. */
-.popover *:focus:not(:focus-visible),
-.vp-surface-popover *:focus:not(:focus-visible) {{
+.popover *:focus:not(:focus-visible) {{
     outline: none;
     box-shadow: none;
 }}
@@ -205,33 +250,33 @@ popover.widget-menu.background > contents {{
    color.  Rules must be self-contained (full outline shorthand) because
    transition:none at our priority (USER=800) blocks Adwaita's
    outline-width animation from 0→2px at THEME=200.
-   Scoped under .vp-surface-popover for specificity. */
-.vp-surface-popover button:focus-visible,
-.vp-surface-popover row:focus-visible,
-.vp-surface-popover switch:focus-visible,
-.vp-surface-popover entry:focus-visible {{
+   Scoped under .popover for specificity. */
+.popover button:focus-visible,
+.popover row:focus-visible,
+.popover switch:focus-visible,
+.popover entry:focus-visible {{
     outline: 2px solid var(--color-accent-primary);
     outline-offset: -2px;
     transition: none;
 }}
-.vp-surface-popover scale:focus-visible > trough > slider {{
+.popover scale:focus-visible > trough > slider {{
     outline: 2px solid var(--color-accent-primary);
     outline-offset: -2px;
     transition: none;
 }}
 /* Suppress Adwaita's outline transition on entries so the accent color
    doesn't flash blue when focus leaves. */
-.vp-surface-popover entry {{
+.popover entry {{
     transition: none;
 }}
 
 /* Rows with inline action buttons delegate focus to the button.  GTK still
    sets :focus-visible on the row even when non-focusable, so suppress it.
-   Must come after focus color rules and use .vp-surface-popover scope to
+   Must come after focus color rules and use .popover scope to
    beat the accent color rule's specificity. */
-.vp-surface-popover row.vp-row-has-action,
-.vp-surface-popover row.vp-row-has-action:focus,
-.vp-surface-popover row.vp-row-has-action:focus-visible {{
+.popover row.vp-row-has-action,
+.popover row.vp-row-has-action:focus,
+.popover row.vp-row-has-action:focus-visible {{
     outline: none;
     box-shadow: none;
     transition: none;
@@ -240,14 +285,14 @@ popover.widget-menu.background > contents {{
 /* Suppress :focus-within outlines on rows whose children handle their own
    focus rings (e.g. password entry row).  The child widget (entry, button)
    already shows the accent-colored ring. */
-.vp-surface-popover row:focus-within {{
+.popover row:focus-within {{
     outline: none;
     box-shadow: none;
 }}
 
 /* Power action rows are directly focusable (hold-to-confirm on the row
    itself).  Restore the accent focus ring that :focus-within above kills. */
-.vp-surface-popover row.qs-power-row:focus-visible {{
+.popover row.qs-power-row:focus-visible {{
     outline: 2px solid var(--color-accent-primary);
     outline-offset: -2px;
     transition: none;

--- a/crates/vibepanel/src/widgets/css/calendar.rs
+++ b/crates/vibepanel/src/widgets/css/calendar.rs
@@ -5,7 +5,7 @@ pub fn css() -> &'static str {
     r#"
 /* ===== CALENDAR ===== */
 
-/* Note: padding comes from apply_surface_styles() in base.rs */
+/* Popover padding comes from the shared .popover rule. */
 .calendar-popover .vp-popover-icon-btn {
     margin-top: 0;
 }

--- a/crates/vibepanel/src/widgets/css/media.rs
+++ b/crates/vibepanel/src/widgets/css/media.rs
@@ -66,7 +66,7 @@ pub fn css(animations: bool) -> String {
 }}
 
 /* Popover styling */
-.media-popover.vp-surface-popover {{
+.media-popover.popover {{
     min-width: 340px;
 }}
 

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -96,18 +96,12 @@ pub fn css(animations: bool) -> String {
     margin-right: -3px;
 }}
 
-/* Shared urgency styling (row + toast) */
-.notification-row.notification-critical,
-.notification-toast-critical {{
+.notification-row.notification-critical {{
     border-left: 3px solid var(--color-state-warning);
 }}
 
 .notification-row.notification-critical {{
     background-color: var(--color-row-critical-background);
-}}
-
-.notification-toast-critical {{
-    background-color: var(--color-toast-critical-background);
 }}
 
 .notification-row.notification-low {{

--- a/crates/vibepanel/src/widgets/css/osd.rs
+++ b/crates/vibepanel/src/widgets/css/osd.rs
@@ -11,7 +11,6 @@ pub fn css() -> &'static str {
 }
 
 /* Container - tight padding for compact appearance */
-/* Note: border-radius set via apply_surface_styles_with_radius() */
 .osd-container {
     padding: 10px 16px;
 }

--- a/crates/vibepanel/src/widgets/media_popover.rs
+++ b/crates/vibepanel/src/widgets/media_popover.rs
@@ -218,10 +218,6 @@ fn show_player_menu(parent: &Button) {
 
     popover.set_child(Some(&panel));
 
-    // Apply surface styling to the panel for background, font, etc.
-    // The popover's contents node styling (shadow, margin) comes from base CSS.
-    SurfaceStyleManager::global().apply_surface_styles(&panel, true);
-
     // Apply Pango font attributes to all labels if enabled
     SurfaceStyleManager::global().apply_pango_attrs_all(&panel);
 

--- a/crates/vibepanel/src/widgets/media_window.rs
+++ b/crates/vibepanel/src/widgets/media_window.rs
@@ -12,7 +12,6 @@ use crate::services::background_effect::attach_blur_surface_lifecycle;
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::media::MediaService;
-use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{media, surface};
 use crate::widgets::media_components::{
     MediaViewController, build_album_art, build_media_controls, build_seek_section,
@@ -97,9 +96,6 @@ where
     main_box.add_css_class(media::CONTENT);
     main_box.add_css_class(surface::NO_FOCUS);
     main_box.set_size_request(260, 150);
-
-    // Apply surface styles for consistent theming
-    SurfaceStyleManager::global().apply_surface_styles(&main_box, true);
 
     // Apply opacity to the entire window content (background + children)
     // We use CSS opacity on the main_box since Wayland doesn't support window-level opacity

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -309,17 +309,13 @@ fn build_toast_content(
     outer.add_css_class(notif::TOAST_CONTAINER);
     outer.add_css_class(notif::TOAST);
 
-    // Add urgency styling before applying widget-scoped surface styles, so the
-    // surface provider can preserve urgency-specific border/background rules at
-    // the same CSS priority.
+    // Add urgency styling before the widget is attached so static CSS can match
+    // the final toast class set immediately.
     if notification.urgency == URGENCY_CRITICAL {
         outer.add_css_class(notif::TOAST_CRITICAL);
     } else if notification.urgency == URGENCY_LOW {
         outer.add_css_class(notif::TOAST_LOW);
     }
-
-    // Apply surface styling
-    SurfaceStyleManager::global().apply_surface_styles(&outer, false);
 
     // Apply uniform shadow margins so the CSS box-shadow is not clipped at
     // the layer-shell surface boundary.  Unlike popovers (which are flush

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -40,20 +40,24 @@ fn run_toast_ui_regression_subprocess(test_case: &str) {
 }
 
 #[test]
-fn test_notification_toast_critical_class_consumes_critical_tokens() {
+fn test_notification_toast_critical_class_does_not_apply_visual_tokens() {
     let css = crate::widgets::css::widget_css(&Config::default());
 
     assert!(
         css.contains(
-            ".notification-row.notification-critical,\n.notification-toast-critical {\n    border-left: 3px solid var(--color-state-warning);"
+            ".notification-row.notification-critical {\n    border-left: 3px solid var(--color-state-warning);"
         ),
-        "critical toast selector should consume the shared warning border token"
+        "critical notification rows should consume the shared warning border token"
     );
     assert!(
         css.contains(
-            ".notification-toast-critical {\n    background-color: var(--color-toast-critical-background);"
+            ".notification-row.notification-critical {\n    background-color: var(--color-row-critical-background);"
         ),
-        "critical toast selector should consume the toast critical background token"
+        "critical notification rows should consume the row critical background token"
+    );
+    assert!(
+        !css.contains(".notification-toast-critical {"),
+        "critical toasts intentionally keep main's neutral visual styling"
     );
 }
 

--- a/crates/vibepanel/src/widgets/osd.rs
+++ b/crates/vibepanel/src/widgets/osd.rs
@@ -195,12 +195,6 @@ fn build_osd_content(orientation: Orientation, show_value: bool) -> OsdContent {
         container.add_css_class(osd::HORIZONTAL);
     }
 
-    SurfaceStyleManager::global().apply_surface_styles_with_radius(
-        &container,
-        false,
-        "var(--radius-widget-lg)",
-    );
-
     let osd_widget = OsdWidget::new(orientation, 24, show_value);
     container.append(osd_widget.widget());
     SurfaceStyleManager::global().apply_pango_attrs_all(&container);

--- a/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
@@ -389,8 +389,6 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
         content_box.append(&action);
 
         panel.append(&content_box);
-        SurfaceStyleManager::global().apply_surface_styles(&panel, true);
-
         popover.set_child(Some(&panel));
         popover.set_parent(btn);
 

--- a/crates/vibepanel/src/widgets/quick_settings/network_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/network_card.rs
@@ -1355,9 +1355,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
         }
 
         panel.append(&content_box);
-        let style_mgr = SurfaceStyleManager::global();
-        style_mgr.apply_surface_styles(&panel, true);
-        style_mgr.apply_pango_attrs_all(&content_box);
+        SurfaceStyleManager::global().apply_pango_attrs_all(&content_box);
 
         popover.set_child(Some(&panel));
         popover.set_parent(btn);

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -100,7 +100,7 @@ fn clear_current_qs_window() {
 }
 
 const QUICK_SETTINGS_CONTENT_WIDTH: i32 = 320;
-/// CSS `padding: 16px` on `.vp-surface-popover` (both sides).
+/// CSS `padding: 16px` on `.popover` (both sides).
 const QUICK_SETTINGS_POPOVER_PADDING: i32 = 32;
 const QUICK_SETTINGS_OUTER_MARGIN: i32 = 4;
 const QUICK_SETTINGS_FAR_EDGE_MARGIN: i32 = 8;

--- a/crates/vibepanel/src/widgets/tray.rs
+++ b/crates/vibepanel/src/widgets/tray.rs
@@ -938,10 +938,6 @@ fn toggle_menu(state: &Rc<RefCell<WidgetState>>, identifier: &str, parent: &Widg
         // Add tray-specific popover class for CSS variable-based styling
         container.add_css_class("tray-popover");
 
-        // Apply surface styling - background color comes from CSS variables
-        // which may be overridden by the tray-popover class
-        SurfaceStyleManager::global().apply_surface_styles(&container, true);
-
         popover.set_child(Some(&container));
 
         // Set up menu state


### PR DESCRIPTION
Moves styling for popovers, toasts, and OSD from runtime per-widget `CssProvider` injection to the global generated CSS removing the surface stylings dependency on a deprecated GTK API.

No theme/style regressions are expected since the new static selectors map to the same surface classes and values as the old runtime-generated CSS. 

Also migrates internals from `.vp-surface-popover` to `.popover` since the former is deprecated.