### PR TITLE
feat(cpu): add format option to match gpu/mem and show temp

### DIFF
--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -54,7 +54,11 @@ impl CpuFormat {
 pub struct CpuConfig {
     /// Whether to show an icon.
     pub show_icon: bool,
-    /// Whether to show the CPU usage percentage.
+    /// Whether to show the CPU value label.
+    ///
+    /// Deprecated: prefer leaving this enabled and using `format` to choose the
+    /// label contents. This legacy option gates the whole label, including
+    /// temperature.
     pub show_percentage: bool,
     /// Display format for CPU metrics.
     pub format: CpuFormat,
@@ -217,11 +221,7 @@ fn update_cpu_widget(
         icon_handle.remove_css_class(widget::CPU_HIGH);
     }
 
-    if options.show_icon {
-        icon_handle.widget().set_visible(true);
-    } else {
-        icon_handle.widget().set_visible(false);
-    }
+    icon_handle.widget().set_visible(options.show_icon);
 
     if options.show_percentage {
         let text = format_cpu_label(snapshot, &options.format, options.is_vertical);
@@ -258,16 +258,22 @@ fn format_cpu_label(snapshot: &SystemSnapshot, format: &CpuFormat, is_vertical: 
     match format {
         CpuFormat::Usage => format_cpu_usage(snapshot.cpu_usage, is_vertical),
         CpuFormat::Temperature => match snapshot.cpu_temp {
+            Some(temp) if is_vertical => format!("{temp:.0}°"),
             Some(temp) => format!("{temp:.0}°C"),
             None => "—".to_string(),
         },
         CpuFormat::Both => {
             let usage_part = format_cpu_usage(snapshot.cpu_usage, is_vertical);
             let temp_part = match snapshot.cpu_temp {
+                Some(temp) if is_vertical => format!("{temp:.0}°"),
                 Some(temp) => format!("{temp:.0}°C"),
                 None => "—".to_string(),
             };
-            format!("{usage_part} {temp_part}")
+            if is_vertical {
+                format!("{usage_part}\n{temp_part}")
+            } else {
+                format!("{usage_part} {temp_part}")
+            }
         }
     }
 }
@@ -320,7 +326,11 @@ mod tests {
         assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, true), "42");
         assert_eq!(
             format_cpu_label(&snapshot, &CpuFormat::Both, true),
-            "42 72°C"
+            "42\n72°"
+        );
+        assert_eq!(
+            format_cpu_label(&snapshot, &CpuFormat::Temperature, true),
+            "72°"
         );
     }
 

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -27,6 +27,28 @@ use crate::widgets::{WidgetConfig, warn_unknown_options};
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_SHOW_PERCENTAGE: bool = true;
 
+/// CPU display format options.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum CpuFormat {
+    /// "76%"
+    #[default]
+    Usage,
+    /// "72°C"
+    Temperature,
+    /// "76% 72°C"
+    Both,
+}
+
+impl CpuFormat {
+    fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "temperature" | "temp" => Self::Temperature,
+            "both" => Self::Both,
+            _ => Self::Usage,
+        }
+    }
+}
+
 /// Configuration for the CPU widget.
 #[derive(Debug, Clone)]
 pub struct CpuConfig {
@@ -34,11 +56,21 @@ pub struct CpuConfig {
     pub show_icon: bool,
     /// Whether to show the CPU usage percentage.
     pub show_percentage: bool,
+    /// Display format for CPU metrics.
+    pub format: CpuFormat,
+}
+
+#[derive(Clone)]
+struct CpuRenderOptions {
+    show_icon: bool,
+    show_percentage: bool,
+    format: CpuFormat,
+    is_vertical: bool,
 }
 
 impl WidgetConfig for CpuConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("cpu", entry, &["show_icon", "show_percentage"]);
+        warn_unknown_options("cpu", entry, &["show_icon", "show_percentage", "format"]);
 
         let show_icon = entry
             .options
@@ -52,9 +84,17 @@ impl WidgetConfig for CpuConfig {
             .and_then(|v| v.as_bool())
             .unwrap_or(DEFAULT_SHOW_PERCENTAGE);
 
+        let format = entry
+            .options
+            .get("format")
+            .and_then(|v| v.as_str())
+            .map(CpuFormat::from_str)
+            .unwrap_or_default();
+
         Self {
             show_icon,
             show_percentage,
+            format,
         }
     }
 }
@@ -64,6 +104,7 @@ impl Default for CpuConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             show_percentage: DEFAULT_SHOW_PERCENTAGE,
+            format: CpuFormat::default(),
         }
     }
 }
@@ -107,9 +148,12 @@ impl CpuWidget {
             let container = base.widget().clone();
             let icon_handle = icon_handle.clone();
             let percentage_label = percentage_label.clone();
-            let show_icon = config.show_icon;
-            let show_percentage = config.show_percentage;
-            let is_vertical = ConfigManager::global().bar_position().is_vertical();
+            let render_options = CpuRenderOptions {
+                show_icon: config.show_icon,
+                show_percentage: config.show_percentage,
+                format: config.format.clone(),
+                is_vertical: ConfigManager::global().bar_position().is_vertical(),
+            };
             let popover_binding = popover_binding.clone();
 
             system_service.connect(move |snapshot: &SystemSnapshot| {
@@ -117,9 +161,7 @@ impl CpuWidget {
                     &container,
                     &icon_handle,
                     &percentage_label,
-                    show_icon,
-                    show_percentage,
-                    is_vertical,
+                    &render_options,
                     snapshot,
                 );
 
@@ -150,16 +192,14 @@ fn update_cpu_widget(
     container: &gtk4::Box,
     icon_handle: &IconHandle,
     percentage_label: &Label,
-    show_icon: bool,
-    show_percentage: bool,
-    is_vertical: bool,
+    options: &CpuRenderOptions,
     snapshot: &SystemSnapshot,
 ) {
     if !snapshot.available {
-        if show_icon {
+        if options.show_icon {
             icon_handle.widget().set_visible(true);
         }
-        if show_percentage {
+        if options.show_percentage {
             percentage_label.set_label("?");
             percentage_label.set_visible(true);
         }
@@ -177,33 +217,58 @@ fn update_cpu_widget(
         icon_handle.remove_css_class(widget::CPU_HIGH);
     }
 
-    if show_icon {
+    if options.show_icon {
         icon_handle.widget().set_visible(true);
     } else {
         icon_handle.widget().set_visible(false);
     }
 
-    if show_percentage {
-        let text = format_cpu_label(snapshot.cpu_usage, is_vertical);
+    if options.show_percentage {
+        let text = format_cpu_label(snapshot, &options.format, options.is_vertical);
         percentage_label.set_label(&text);
         percentage_label.set_visible(true);
     } else {
         percentage_label.set_visible(false);
     }
 
-    let tooltip = format!(
-        "CPU: {:.1}%\nCores: {}",
-        snapshot.cpu_usage, snapshot.cpu_core_count
-    );
+    let tooltip = match snapshot.cpu_temp {
+        Some(temp) => format!(
+            "CPU: {:.1}%\nTemp: {:.0}°C\nCores: {}",
+            snapshot.cpu_usage, temp, snapshot.cpu_core_count
+        ),
+        None => format!(
+            "CPU: {:.1}%\nCores: {}",
+            snapshot.cpu_usage, snapshot.cpu_core_count
+        ),
+    };
     let tooltip_manager = TooltipManager::global();
     tooltip_manager.set_styled_tooltip(container, &tooltip);
 }
 
-fn format_cpu_label(cpu_usage: f32, is_vertical: bool) -> String {
+fn format_cpu_usage(cpu_usage: f32, is_vertical: bool) -> String {
     if is_vertical {
         format!("{cpu_usage:.0}")
     } else {
         format!("{cpu_usage:.0}%")
+    }
+}
+
+/// Format CPU label text according to the selected format.
+fn format_cpu_label(snapshot: &SystemSnapshot, format: &CpuFormat, is_vertical: bool) -> String {
+    match format {
+        CpuFormat::Usage => format_cpu_usage(snapshot.cpu_usage, is_vertical),
+        CpuFormat::Temperature => match snapshot.cpu_temp {
+            Some(temp) => format!("{temp:.0}°C"),
+            None => "—".to_string(),
+        },
+        CpuFormat::Both => {
+            let usage_part = format_cpu_usage(snapshot.cpu_usage, is_vertical);
+            let temp_part = match snapshot.cpu_temp {
+                Some(temp) => format!("{temp:.0}°C"),
+                None => "—".to_string(),
+            };
+            format!("{usage_part} {temp_part}")
+        }
     }
 }
 
@@ -220,6 +285,7 @@ mod tests {
         let config = CpuConfig::from_entry(&entry);
         assert!(config.show_icon);
         assert!(config.show_percentage);
+        assert_eq!(config.format, CpuFormat::Usage);
     }
 
     #[test]
@@ -227,6 +293,10 @@ mod tests {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
         options.insert("show_percentage".to_string(), toml::Value::Boolean(true));
+        options.insert(
+            "format".to_string(),
+            toml::Value::String("both".to_string()),
+        );
 
         let entry = WidgetEntry {
             name: "cpu".to_string(),
@@ -235,11 +305,45 @@ mod tests {
         let config = CpuConfig::from_entry(&entry);
         assert!(!config.show_icon);
         assert!(config.show_percentage);
+        assert_eq!(config.format, CpuFormat::Both);
     }
 
     #[test]
     fn test_format_cpu_label_compacts_vertical() {
-        assert_eq!(format_cpu_label(42.4, false), "42%");
-        assert_eq!(format_cpu_label(42.4, true), "42");
+        let snapshot = SystemSnapshot {
+            available: true,
+            cpu_usage: 42.4,
+            cpu_temp: Some(72.0),
+            ..Default::default()
+        };
+        assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, false), "42%");
+        assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, true), "42");
+        assert_eq!(
+            format_cpu_label(&snapshot, &CpuFormat::Both, true),
+            "42 72°C"
+        );
+    }
+
+    #[test]
+    fn test_cpu_format_from_str() {
+        assert_eq!(CpuFormat::from_str("usage"), CpuFormat::Usage);
+        assert_eq!(CpuFormat::from_str("temperature"), CpuFormat::Temperature);
+        assert_eq!(CpuFormat::from_str("temp"), CpuFormat::Temperature);
+        assert_eq!(CpuFormat::from_str("both"), CpuFormat::Both);
+        assert_eq!(CpuFormat::from_str("unknown"), CpuFormat::Usage);
+    }
+
+    #[test]
+    fn test_format_cpu_label_temperature_unavailable() {
+        let snapshot = SystemSnapshot {
+            available: true,
+            cpu_usage: 76.0,
+            cpu_temp: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            format_cpu_label(&snapshot, &CpuFormat::Temperature, false),
+            "—"
+        );
     }
 }

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -56,20 +56,12 @@ pub struct CpuConfig {
     pub show_icon: bool,
     /// Whether to show the CPU value label.
     ///
-    /// Deprecated: prefer leaving this enabled and using `format` to choose the
-    /// label contents. This legacy option gates the whole label, including
-    /// temperature.
+    /// Deprecated for user configuration: prefer leaving this enabled and using
+    /// `format` to choose the label contents. This legacy option gates the whole
+    /// label, including temperature.
     pub show_percentage: bool,
     /// Display format for CPU metrics.
     pub format: CpuFormat,
-}
-
-#[derive(Clone)]
-struct CpuRenderOptions {
-    show_icon: bool,
-    show_percentage: bool,
-    format: CpuFormat,
-    is_vertical: bool,
 }
 
 impl WidgetConfig for CpuConfig {
@@ -113,7 +105,7 @@ impl Default for CpuConfig {
     }
 }
 
-/// CPU widget that displays icon, usage percentage, and opens a shared system
+/// CPU widget that displays icon, usage/temperature label, and opens a shared system
 /// popover on click.
 pub struct CpuWidget {
     /// Shared base widget container.
@@ -152,20 +144,20 @@ impl CpuWidget {
             let container = base.widget().clone();
             let icon_handle = icon_handle.clone();
             let percentage_label = percentage_label.clone();
-            let render_options = CpuRenderOptions {
-                show_icon: config.show_icon,
-                show_percentage: config.show_percentage,
-                format: config.format.clone(),
-                is_vertical: ConfigManager::global().bar_position().is_vertical(),
-            };
+            let show_icon = config.show_icon;
+            let show_percentage = config.show_percentage;
+            let format = config.format.clone();
+            let is_vertical = ConfigManager::global().bar_position().is_vertical();
             let popover_binding = popover_binding.clone();
 
             system_service.connect(move |snapshot: &SystemSnapshot| {
                 update_cpu_widget(
                     &container,
                     &icon_handle,
-                    &percentage_label,
-                    &render_options,
+                    show_percentage.then_some(&percentage_label),
+                    show_icon,
+                    &format,
+                    is_vertical,
                     snapshot,
                 );
 
@@ -195,15 +187,17 @@ impl Drop for CpuWidget {
 fn update_cpu_widget(
     container: &gtk4::Box,
     icon_handle: &IconHandle,
-    percentage_label: &Label,
-    options: &CpuRenderOptions,
+    percentage_label: Option<&Label>,
+    show_icon: bool,
+    format: &CpuFormat,
+    is_vertical: bool,
     snapshot: &SystemSnapshot,
 ) {
     if !snapshot.available {
-        if options.show_icon {
+        if show_icon {
             icon_handle.widget().set_visible(true);
         }
-        if options.show_percentage {
+        if let Some(percentage_label) = percentage_label {
             percentage_label.set_label("?");
             percentage_label.set_visible(true);
         }
@@ -221,14 +215,12 @@ fn update_cpu_widget(
         icon_handle.remove_css_class(widget::CPU_HIGH);
     }
 
-    icon_handle.widget().set_visible(options.show_icon);
+    icon_handle.widget().set_visible(show_icon);
 
-    if options.show_percentage {
-        let text = format_cpu_label(snapshot, &options.format, options.is_vertical);
+    if let Some(percentage_label) = percentage_label {
+        let text = format_cpu_label(snapshot, format, is_vertical);
         percentage_label.set_label(&text);
         percentage_label.set_visible(true);
-    } else {
-        percentage_label.set_visible(false);
     }
 
     let tooltip = match snapshot.cpu_temp {


### PR DESCRIPTION
Adds a format option to the CPU widget, mirroring the existing GPU widget behavior.
```toml
[widgets.cpu]
format = "usage" # What to show, "usage"(default), "temperature"/"temp", or "both"
```
cpu_temp was already available on SystemSnapshot (used by the system popover), so this is purely a presentation change.