### PR TITLE
feat(mango): show overview as a single workspace in workspace widget

### DIFF
--- a/crates/vibepanel/src/services/compositor/mango.rs
+++ b/crates/vibepanel/src/services/compositor/mango.rs
@@ -14,7 +14,7 @@
 //! Events are double-buffered: state is collected and applied on `frame` events.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::rc::Rc;
@@ -39,6 +39,11 @@ use super::{
 
 /// Default number of workspaces/tags for DWL.
 const DEFAULT_WORKSPACE_COUNT: u32 = 9;
+const OVERVIEW_WORKSPACE_ID: i32 = 0;
+const OVERVIEW_WORKSPACE_NAME: &str = "overview";
+// Mango's DWL IPC path exposes only the layout symbol. This is Mango's
+// default overview symbol; custom compositor configs may need updating here.
+const OVERVIEW_LAYOUT_SYMBOL: &str = "󰃇";
 
 /// Per-output state accumulated during a frame.
 #[derive(Debug, Clone, Default)]
@@ -51,6 +56,8 @@ struct OutputFrameState {
     title: Option<String>,
     /// Window app_id update.
     appid: Option<String>,
+    /// Layout symbol update.
+    layout_symbol: Option<String>,
 }
 
 impl OutputFrameState {
@@ -59,6 +66,7 @@ impl OutputFrameState {
         self.tags.clear();
         self.title = None;
         self.appid = None;
+        self.layout_symbol = None;
     }
 }
 
@@ -129,6 +137,8 @@ struct WaylandState {
     snapshot: WorkspaceSnapshot,
     /// Current focused output ID.
     focused_output: Option<ObjectId>,
+    /// Outputs currently reporting Mango's overview layout symbol.
+    overview_outputs: HashSet<ObjectId>,
     /// Workspace update callback.
     on_workspace_update: Option<WorkspaceCallback>,
     /// Window update callback.
@@ -149,6 +159,7 @@ impl WaylandState {
             pending_outputs: Vec::new(),
             snapshot: WorkspaceSnapshot::default(),
             focused_output: None,
+            overview_outputs: HashSet::new(),
             on_workspace_update: None,
             on_window_update: None,
             on_keyboard_layout_update: None,
@@ -181,6 +192,17 @@ impl WaylandState {
                 },
             );
         }
+    }
+
+    fn output_name(output_id: &ObjectId, output: &TrackedOutput) -> String {
+        output
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("output-{output_id:?}"))
+    }
+
+    fn is_overview_layout_symbol(symbol: &str) -> bool {
+        symbol == OVERVIEW_LAYOUT_SYMBOL || symbol.eq_ignore_ascii_case("overview")
     }
 
     /// Check for and process any pending workspace switch.
@@ -225,18 +247,15 @@ impl WaylandState {
     /// Apply buffered frame state for an output.
     fn apply_frame(&mut self, output_id: &ObjectId) {
         // First, extract all the data we need from the output
-        let (output_name, is_focused_output, frame_tags, frame_title, frame_appid) = {
+        let (output_name, is_focused_output, frame_tags, frame_title, frame_appid, layout_symbol) = {
             let Some(output) = self.outputs.get_mut(output_id) else {
                 return;
             };
 
-            let frame = &mut output.frame_state;
-
             // Get output name for per-output tracking
-            let output_name = output
-                .name
-                .clone()
-                .unwrap_or_else(|| format!("output-{:?}", output_id));
+            let output_name = Self::output_name(output_id, output);
+
+            let frame = &mut output.frame_state;
 
             // Handle active output change
             if let Some(active) = frame.active
@@ -251,12 +270,22 @@ impl WaylandState {
             let tags = frame.tags.clone();
             let title = frame.title.take();
             let appid = frame.appid.take();
+            let layout_symbol = frame.layout_symbol.take();
 
             // Clear frame state for next frame
             frame.clear();
 
-            (output_name, is_focused, tags, title, appid)
+            (output_name, is_focused, tags, title, appid, layout_symbol)
         };
+
+        if let Some(symbol) = layout_symbol {
+            if Self::is_overview_layout_symbol(&symbol) {
+                self.overview_outputs.insert(output_id.clone());
+            } else {
+                self.overview_outputs.remove(output_id);
+            }
+        }
+        let is_overview = self.overview_outputs.contains(output_id);
 
         // Get or create per-output state
         let per_output = self
@@ -281,17 +310,20 @@ impl WaylandState {
             // Tags are 0-indexed in protocol, we use 1-indexed IDs
             let workspace_id = (tag + 1) as i32;
 
-            // Update per-output state
-            per_output.window_counts.insert(workspace_id, clients);
-            if clients > 0 {
-                per_output.occupied_workspaces.insert(workspace_id);
+            // In Mango overview, ext-workspace-v1 exposes only workspace 0.
+            // Keep the widget-facing per-output tag list equally narrow.
+            if !is_overview {
+                per_output.window_counts.insert(workspace_id, clients);
+                if clients > 0 {
+                    per_output.occupied_workspaces.insert(workspace_id);
+                }
             }
-            if is_active {
+            if is_active && !is_overview {
                 per_output.active_workspace.insert(workspace_id);
             }
 
             // Update global active workspace (only for focused output)
-            if is_active && is_focused_output {
+            if is_active && is_focused_output && !is_overview {
                 self.snapshot.active_workspace.insert(workspace_id);
             }
 
@@ -306,6 +338,13 @@ impl WaylandState {
                 "Tag {} on {}: active={}, urgent={}, clients={}",
                 workspace_id, output_name, is_active, is_urgent, clients
             );
+        }
+
+        if is_overview {
+            per_output.active_workspace.insert(OVERVIEW_WORKSPACE_ID);
+            if is_focused_output {
+                self.snapshot.active_workspace.insert(OVERVIEW_WORKSPACE_ID);
+            }
         }
 
         // Rebuild global window_counts and occupied from all per-output states
@@ -524,7 +563,9 @@ impl Dispatch<ZdwlIpcOutputV2, ObjectId> for WaylandState {
             }
             zdwl_ipc_output_v2::Event::ToggleVisibility => {}
             zdwl_ipc_output_v2::Event::Layout { layout: _ } => {}
-            zdwl_ipc_output_v2::Event::LayoutSymbol { layout: _ } => {}
+            zdwl_ipc_output_v2::Event::LayoutSymbol { layout } => {
+                tracked.frame_state.layout_symbol = Some(layout);
+            }
             zdwl_ipc_output_v2::Event::Fullscreen { is_fullscreen: _ } => {}
             zdwl_ipc_output_v2::Event::Floating { is_floating: _ } => {}
             zdwl_ipc_output_v2::Event::KbLayout { kb_layout } => {
@@ -834,14 +875,30 @@ impl CompositorBackend for MangoBackend {
 
     fn list_workspaces(&self) -> Vec<WorkspaceMeta> {
         let count = self.shared.tag_count.load(Ordering::Relaxed);
-        (1..=count as i32)
+        let mut workspaces: Vec<_> = (1..=count as i32)
             .map(|id| WorkspaceMeta {
                 id,
                 idx: id,
                 name: id.to_string(),
                 output: None, // MangoWC/DWL tags are global
             })
-            .collect()
+            .collect();
+
+        let snapshot = self.shared.snapshot.read();
+        if snapshot
+            .per_output
+            .values()
+            .any(|state| state.active_workspace.contains(&OVERVIEW_WORKSPACE_ID))
+        {
+            workspaces.push(WorkspaceMeta {
+                id: OVERVIEW_WORKSPACE_ID,
+                idx: OVERVIEW_WORKSPACE_ID,
+                name: OVERVIEW_WORKSPACE_NAME.to_string(),
+                output: None,
+            });
+        }
+
+        workspaces
     }
 
     fn get_workspace_snapshot(&self) -> WorkspaceSnapshot {
@@ -956,5 +1013,53 @@ impl Drop for MangoBackend {
         self.running.store(false, Ordering::SeqCst);
         self.shared.pending_switch.store(i32::MIN, Ordering::SeqCst);
         // Eventfd is dropped automatically via OwnedFd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::compositor::PerOutputState;
+
+    #[test]
+    fn overview_layout_symbol_matches_mango_symbol_and_name() {
+        assert!(WaylandState::is_overview_layout_symbol(
+            OVERVIEW_LAYOUT_SYMBOL
+        ));
+        assert!(WaylandState::is_overview_layout_symbol("overview"));
+        assert!(!WaylandState::is_overview_layout_symbol("tile"));
+    }
+
+    #[test]
+    fn list_workspaces_adds_single_overview_when_any_output_active() {
+        let backend = MangoBackend::new(None);
+        backend.shared.tag_count.store(2, Ordering::Relaxed);
+
+        let mut snapshot = WorkspaceSnapshot::default();
+        let mut overview_state = PerOutputState::default();
+        overview_state
+            .active_workspace
+            .insert(OVERVIEW_WORKSPACE_ID);
+        snapshot
+            .per_output
+            .insert("eDP-1".to_string(), overview_state);
+        let mut other_overview_state = PerOutputState::default();
+        other_overview_state
+            .active_workspace
+            .insert(OVERVIEW_WORKSPACE_ID);
+        snapshot
+            .per_output
+            .insert("DP-1".to_string(), other_overview_state);
+        *backend.shared.snapshot.write() = snapshot;
+
+        let workspaces = backend.list_workspaces();
+
+        assert_eq!(workspaces.len(), 3);
+        assert_eq!(workspaces[0].id, 1);
+        assert_eq!(workspaces[1].id, 2);
+        assert_eq!(workspaces[2].id, OVERVIEW_WORKSPACE_ID);
+        assert_eq!(workspaces[2].idx, OVERVIEW_WORKSPACE_ID);
+        assert_eq!(workspaces[2].name, OVERVIEW_WORKSPACE_NAME);
+        assert_eq!(workspaces[2].output, None);
     }
 }

--- a/crates/vibepanel/src/services/workspace.rs
+++ b/crates/vibepanel/src/services/workspace.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use tracing::debug;
 
 use super::callbacks::{CallbackId, Callbacks};
-use super::compositor::{CompositorManager, WorkspaceMeta, WorkspaceSnapshot};
+use super::compositor::{CompositorManager, PerOutputState, WorkspaceMeta, WorkspaceSnapshot};
 
 /// Enriched workspace object for widget consumption.
 ///
@@ -96,6 +96,49 @@ impl Workspace {
             output: meta.output.clone(),
         }
     }
+}
+
+fn active_output_overview_workspace<'a>(
+    workspaces_meta: &'a [WorkspaceMeta],
+    active_workspace: &HashSet<i32>,
+) -> Option<&'a WorkspaceMeta> {
+    workspaces_meta
+        .iter()
+        .find(|meta| is_overview_workspace_meta(meta) && active_workspace.contains(&meta.id))
+}
+
+fn is_overview_workspace_meta(meta: &WorkspaceMeta) -> bool {
+    meta.id == 0 && meta.name.eq_ignore_ascii_case("overview")
+}
+
+fn workspaces_for_output(
+    workspaces_meta: &[WorkspaceMeta],
+    snapshot: &WorkspaceSnapshot,
+    output_name: &str,
+    output_state: &PerOutputState,
+) -> Vec<Workspace> {
+    if let Some(active_output_meta) =
+        active_output_overview_workspace(workspaces_meta, &output_state.active_workspace)
+    {
+        return vec![Workspace::from_meta_per_output(
+            active_output_meta,
+            snapshot,
+            output_name,
+        )];
+    }
+
+    workspaces_meta
+        .iter()
+        .filter(|meta| {
+            if is_overview_workspace_meta(meta) {
+                return false;
+            }
+
+            // Include if workspace is global (output is None) or belongs to this output
+            meta.output.is_none() || meta.output.as_deref() == Some(output_name)
+        })
+        .map(|meta| Workspace::from_meta_per_output(meta, snapshot, output_name))
+        .collect()
 }
 
 /// Per-output workspace state for widget consumption.
@@ -265,14 +308,8 @@ impl WorkspaceService {
             // Filter workspaces for this output:
             // - For Niri: only include workspaces that belong to this output
             // - For MangoWC: include all workspaces (tags are global) but with per-output state
-            let output_workspaces: Vec<Workspace> = workspaces_meta
-                .iter()
-                .filter(|meta| {
-                    // Include if workspace is global (output is None) or belongs to this output
-                    meta.output.is_none() || meta.output.as_ref() == Some(output_name)
-                })
-                .map(|meta| Workspace::from_meta_per_output(meta, &snapshot, output_name))
-                .collect();
+            let output_workspaces =
+                workspaces_for_output(&workspaces_meta, &snapshot, output_name, output_state);
 
             per_output.insert(
                 output_name.clone(),
@@ -311,6 +348,19 @@ mod tests {
             name: id.to_string(),
             output: None,
         }
+    }
+
+    fn make_meta_with_name(id: i32, name: &str) -> WorkspaceMeta {
+        WorkspaceMeta {
+            id,
+            idx: id,
+            name: name.to_string(),
+            output: None,
+        }
+    }
+
+    fn workspace_ids(workspaces: &[Workspace]) -> Vec<i32> {
+        workspaces.iter().map(|workspace| workspace.id).collect()
     }
 
     #[test]
@@ -445,5 +495,48 @@ mod tests {
         let ws = Workspace::from_meta_per_output(&make_meta(1), &snapshot, "HDMI-1");
         assert!(ws.active);
         assert!(ws.occupied);
+    }
+
+    #[test]
+    fn test_workspaces_for_output_replaces_tags_with_active_overview() {
+        let workspaces_meta = vec![
+            make_meta(1),
+            make_meta(2),
+            make_meta_with_name(0, "Overview"),
+        ];
+        let mut snapshot = WorkspaceSnapshot::default();
+        let mut per_output_state = PerOutputState::default();
+        per_output_state.active_workspace.insert(0);
+        snapshot
+            .per_output
+            .insert("eDP-1".to_string(), per_output_state.clone());
+
+        let workspaces =
+            workspaces_for_output(&workspaces_meta, &snapshot, "eDP-1", &per_output_state);
+
+        assert_eq!(workspace_ids(&workspaces), vec![0]);
+        assert_eq!(workspaces[0].name, "Overview");
+        assert!(workspaces[0].active);
+    }
+
+    #[test]
+    fn test_workspaces_for_output_keeps_normal_tags_on_other_outputs() {
+        let workspaces_meta = vec![
+            make_meta(1),
+            make_meta(2),
+            make_meta_with_name(0, "Overview"),
+        ];
+        let mut snapshot = WorkspaceSnapshot::default();
+        let mut per_output_state = PerOutputState::default();
+        per_output_state.active_workspace.insert(2);
+        snapshot
+            .per_output
+            .insert("DP-1".to_string(), per_output_state.clone());
+
+        let workspaces =
+            workspaces_for_output(&workspaces_meta, &snapshot, "DP-1", &per_output_state);
+
+        assert_eq!(workspace_ids(&workspaces), vec![1, 2]);
+        assert!(workspaces[1].active);
     }
 }


### PR DESCRIPTION
When using Mango with `ext-workspace-v1` the overview is exposed as workspace/tag `0` named `"overview"`, while when using the DWL IPC overview is reported as all 9 tags being active. In the workspace widget that makes overview appear as every tag being active:
<img width="321" height="39" alt="image" src="https://github.com/user-attachments/assets/f526514b-4461-4dd7-b0b8-66e60917f417" />

While if using `ext-workspaces-v1` it shows as a single indicator,
<img width="60" height="43" alt="image" src="https://github.com/user-attachments/assets/a5192605-c8e2-4a9c-9155-874791260d8a" />

Or with name:
<img width="117" height="44" alt="image" src="https://github.com/user-attachments/assets/c74d0c70-2f31-42fc-9c69-6995c79fc7b0" />

I prefer the `ext-workspaces-v1` behaviour. This PR uses the layout symbol sent over DWL IPC to detect overview mode and then replaces the normal tag list for that output with a pseudo workspace/tag `0` named `"overview"`.

Fixes #137 