### PR TITLE
feat(custom): support Waybar JSON format and streaming mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +398,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1320,6 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2012,7 @@ name = "vibepanel"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "async-channel",
  "cargo-husky",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ sysinfo = { version = "0.33", default-features = false, features = ["system", "n
 nvml-wrapper = "0.12"
 
 # Synchronization
+async-channel = "2.3"
 parking_lot = "0.12"
 
 # HTTP

--- a/crates/vibepanel/Cargo.toml
+++ b/crates/vibepanel/Cargo.toml
@@ -35,6 +35,7 @@ udev = { workspace = true }
 toml = { workspace = true }
 sysinfo = { workspace = true }
 nvml-wrapper = { workspace = true }
+async-channel = { workspace = true }
 parking_lot = { workspace = true }
 minreq = { workspace = true }
 material-colors = { workspace = true }

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1077,33 +1077,6 @@ fn run_test_custom_widget_json_exec_output() {
     flush_gtk();
 }
 
-fn run_test_custom_widget_empty_json_hides_without_fallback() {
-    let mut config = custom_exec_config("empty-json", "printf '%s\\n' '{\"text\":\"\"}'");
-    config
-        .widgets
-        .widget_configs
-        .get_mut("custom-empty-json")
-        .expect("custom-empty-json config should exist")
-        .options
-        .remove("template");
-    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
-    let left_section = bar
-        .section("left")
-        .expect("bar should build a left section");
-    let wrapper = left_section
-        .first_child()
-        .expect("custom-empty-json wrapper should be present");
-
-    wait_until(
-        || !wrapper.is_visible(),
-        "empty JSON custom output to hide the widget wrapper",
-    );
-
-    maybe_hold_probe_window();
-    window.close();
-    flush_gtk();
-}
-
 fn run_test_widgets_grouping_explicit_group() {
     let mut baseline = test_config();
     baseline.widgets.left = vec![
@@ -1934,11 +1907,6 @@ ui_regression_config_tests!(
         test_ui_regression_custom_widget_json_exec_output,
         "custom_widget.json_exec_output",
         run_test_custom_widget_json_exec_output
-    ),
-    (
-        test_ui_regression_custom_widget_empty_json_hides_without_fallback,
-        "custom_widget.empty_json_hides_without_fallback",
-        run_test_custom_widget_empty_json_hides_without_fallback
     ),
     (
         test_ui_regression_widgets_grouping_explicit_group,

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -2,13 +2,14 @@ use super::*;
 use crate::theme_vars::{THEME_VAR_EXPECTATIONS, ThemeVarRole, ThemeVarScope};
 use crate::ui_regression_test_support::{
     CssProviderGuard, Rgba8, assert_pixel_close, center_pixel_of_surface, edge_pixel_of_surface,
-    find_descendant_with_class, flush_gtk, init_gtk_or_skip, maybe_hold_probe_window,
-    painted_surface_fixture_with_classes, run_ignored_contract_subprocess, sample_widget_pixel,
+    find_descendant_with_class, flush_gtk, init_gtk_or_skip, label_with_text,
+    maybe_hold_probe_window, painted_surface_fixture_with_classes, run_ignored_contract_subprocess,
+    sample_widget_pixel,
 };
 use crate::widgets::css::{POPOVER_BG_WITH_OPACITY, WIDGET_BG_WITH_OPACITY};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use vibepanel_core::Config;
 
 fn bounds_in_window(
@@ -39,6 +40,20 @@ fn count_descendants_with_class(root: &gtk4::Widget, class_name: &str) -> usize 
         child = widget.next_sibling();
     }
     count
+}
+
+fn wait_until(mut condition: impl FnMut() -> bool, description: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let ctx = gtk4::glib::MainContext::default();
+    while Instant::now() < deadline {
+        ctx.iteration(false);
+        if condition() {
+            return;
+        }
+    }
+
+    flush_gtk();
+    assert!(condition(), "timed out waiting for {description}");
 }
 
 fn collect_descendants_with_class(root: &gtk4::Widget, class_name: &str) -> Vec<gtk4::Widget> {
@@ -998,6 +1013,97 @@ fn run_test_widgets_disabled() {
     flush_gtk();
 }
 
+fn custom_exec_config(id: &str, exec: &str) -> Config {
+    let mut config = test_config();
+    let widget_name = format!("custom-{id}");
+    config.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Single(
+        widget_name.clone(),
+    )];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+
+    let mut options = vibepanel_core::config::WidgetOptions::default();
+    options.options.insert(
+        "label".to_string(),
+        toml::Value::String("fallback".to_string()),
+    );
+    options
+        .options
+        .insert("exec".to_string(), toml::Value::String(exec.to_string()));
+    options.options.insert(
+        "template".to_string(),
+        toml::Value::String("{text} {percentage}%".to_string()),
+    );
+    options.options.insert(
+        "icons".to_string(),
+        toml::Value::Table(toml::map::Map::from_iter([(
+            "high".to_string(),
+            toml::Value::String("cpu-high".to_string()),
+        )])),
+    );
+    config.widgets.widget_configs.insert(widget_name, options);
+
+    config
+}
+
+fn run_test_custom_widget_json_exec_output() {
+    let config = custom_exec_config(
+        "json",
+        "printf '%s\\n' '{\"text\":\"cpu\",\"percentage\":42,\"class\":[\"warning\"],\"alt\":\"high\",\"tooltip\":\"details\"}'",
+    );
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let surface = find_descendant_with_class(&left_section, "custom-json")
+        .expect("custom-json widget surface should be present");
+
+    wait_until(
+        || label_with_text(&surface, "cpu 42%"),
+        "custom JSON exec label update",
+    );
+
+    assert!(
+        surface.has_css_class("warning"),
+        "JSON class should be applied to the custom widget surface"
+    );
+    assert!(
+        left_section.is_visible(),
+        "non-empty JSON output should keep the custom widget visible"
+    );
+
+    maybe_hold_probe_window();
+    window.close();
+    flush_gtk();
+}
+
+fn run_test_custom_widget_empty_json_hides_without_fallback() {
+    let mut config = custom_exec_config("empty-json", "printf '%s\\n' '{\"text\":\"\"}'");
+    config
+        .widgets
+        .widget_configs
+        .get_mut("custom-empty-json")
+        .expect("custom-empty-json config should exist")
+        .options
+        .remove("template");
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let wrapper = left_section
+        .first_child()
+        .expect("custom-empty-json wrapper should be present");
+
+    wait_until(
+        || !wrapper.is_visible(),
+        "empty JSON custom output to hide the widget wrapper",
+    );
+
+    maybe_hold_probe_window();
+    window.close();
+    flush_gtk();
+}
+
 fn run_test_widgets_grouping_explicit_group() {
     let mut baseline = test_config();
     baseline.widgets.left = vec![
@@ -1823,6 +1929,16 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_disabled,
         "widgets.disabled",
         run_test_widgets_disabled
+    ),
+    (
+        test_ui_regression_custom_widget_json_exec_output,
+        "custom_widget.json_exec_output",
+        run_test_custom_widget_json_exec_output
+    ),
+    (
+        test_ui_regression_custom_widget_empty_json_hides_without_fallback,
+        "custom_widget.empty_json_hides_without_fallback",
+        run_test_custom_widget_empty_json_hides_without_fallback
     ),
     (
         test_ui_regression_widgets_grouping_explicit_group,

--- a/crates/vibepanel/src/services/tooltip.rs
+++ b/crates/vibepanel/src/services/tooltip.rs
@@ -365,6 +365,21 @@ impl TooltipManager {
         widget.add_controller(motion);
     }
 
+    /// Clear any styled tooltip registered for a widget.
+    pub fn clear_tooltip(&self, widget: &impl IsA<gtk4::Widget>) {
+        let widget = widget.as_ref();
+        let widget_addr = widget.as_ptr() as usize;
+
+        self.tooltip_texts.borrow_mut().remove(&widget_addr);
+
+        if let Some(ref current_weak) = *self.current_widget.borrow()
+            && let Some(current) = current_weak.upgrade()
+            && current.as_ptr() as usize == widget_addr
+        {
+            self.cancel_and_hide();
+        }
+    }
+
     /// Schedule showing a tooltip after the delay.
     fn schedule_show(&self, widget: &gtk4::Widget, text: &str) {
         // Cancel any pending show

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -693,6 +693,9 @@ pub mod widget {
     /// Each instance gets a dynamic `custom-{id}` class built from this prefix.
     pub const CUSTOM_PREFIX: &str = "custom-";
 
+    /// Custom widget literal glyph icon (`.custom-icon-glyph`).
+    pub const CUSTOM_ICON_GLYPH: &str = "custom-icon-glyph";
+
     // Keyboard layout
     /// Keyboard layout widget (`.keyboard-layout`).
     pub const KEYBOARD_LAYOUT: &str = "keyboard-layout";

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -8,6 +8,7 @@ use gtk4::{
     Align, Box as GtkBox, GestureClick, Label, Orientation, Overlay, Popover, PositionType, gdk,
 };
 use std::cell::{Cell, RefCell};
+use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::time::Duration;
@@ -498,9 +499,30 @@ fn click_target_matches(
 /// In **passive** mode (see [`new_passive`](Self::new_passive)), the overlay,
 /// ripple, menu, and gesture fields are `None` — the merge-group wrapper
 /// provides those instead.
+#[derive(Clone)]
+pub(crate) struct VisibilityHandle {
+    container: GtkBox,
+    content_visible: Rc<Cell<bool>>,
+    show_if_visible: Rc<Cell<bool>>,
+}
+
+impl VisibilityHandle {
+    pub(crate) fn set_content_visible(&self, visible: bool) {
+        self.content_visible.set(visible);
+        BaseWidget::apply_visibility(
+            &self.container,
+            &self.content_visible,
+            &self.show_if_visible,
+        );
+    }
+}
+
 pub struct BaseWidget {
     container: GtkBox,
+    surface: GtkBox,
     content: GtkBox,
+    content_visible: Rc<Cell<bool>>,
+    show_if_visible: Rc<Cell<bool>>,
     overlay: Option<Overlay>,
     ripple_handle: Option<RippleHandle>,
     menu: Option<Rc<RefCell<Option<Rc<MenuHandle>>>>>,
@@ -587,11 +609,21 @@ impl BaseWidget {
 
         if passive {
             container.append(&content);
-            let show_if_timer = Self::setup_show_if_timer(&widget_name, &container);
+            let content_visible = Rc::new(Cell::new(true));
+            let show_if_visible = Rc::new(Cell::new(true));
+            let show_if_timer = Self::setup_show_if_timer(
+                &widget_name,
+                &container,
+                Rc::clone(&content_visible),
+                Rc::clone(&show_if_visible),
+            );
 
             return Self {
+                surface: container.clone(),
                 container,
                 content,
+                content_visible,
+                show_if_visible,
                 overlay: None,
                 ripple_handle: None,
                 menu: None,
@@ -719,11 +751,21 @@ impl BaseWidget {
 
         container.add_controller(gesture_click.clone());
 
-        let show_if_timer = Self::setup_show_if_timer(&widget_name, &container);
+        let content_visible = Rc::new(Cell::new(true));
+        let show_if_visible = Rc::new(Cell::new(true));
+        let show_if_timer = Self::setup_show_if_timer(
+            &widget_name,
+            &container,
+            Rc::clone(&content_visible),
+            Rc::clone(&show_if_visible),
+        );
 
         Self {
             container,
+            surface,
             content,
+            content_visible,
+            show_if_visible,
             overlay: Some(overlay),
             ripple_handle: Some(ripple_handle),
             menu: Some(menu),
@@ -740,13 +782,19 @@ impl BaseWidget {
     /// `show_if_interval` is set (and > 0), a periodic timer continues
     /// re-evaluating after the first check. Commands that exceed
     /// `SHOW_IF_TIMEOUT_SECS` are killed and treated as "hide".
-    fn setup_show_if_timer(widget_name: &str, container: &GtkBox) -> Option<glib::SourceId> {
+    fn setup_show_if_timer(
+        widget_name: &str,
+        container: &GtkBox,
+        content_visible: Rc<Cell<bool>>,
+        show_if_visible: Rc<Cell<bool>>,
+    ) -> Option<glib::SourceId> {
         let (show_if, interval) = ConfigManager::global().get_show_if(widget_name);
 
         let cmd = show_if?;
 
         // Start hidden; async evaluation will show the widget if appropriate.
-        container.set_visible(false);
+        show_if_visible.set(false);
+        Self::apply_visibility(container, &content_visible, &show_if_visible);
 
         let has_interval = interval.filter(|&i| i > 0).is_some();
         let prev_visible = Rc::new(Cell::new(false));
@@ -757,6 +805,8 @@ impl BaseWidget {
         {
             let cmd = cmd.clone();
             let container = container_clone.clone();
+            let content_visible = content_visible.clone();
+            let show_if_visible = show_if_visible.clone();
             let name = name.clone();
             let prev_visible = prev_visible.clone();
 
@@ -765,19 +815,19 @@ impl BaseWidget {
                 let result =
                     gio::spawn_blocking(move || Self::run_show_if_command_with_timeout(&cmd)).await;
 
-                let (visible, stderr) = match result {
+                let visible = match result {
                     Ok(v) => v,
                     Err(e) => {
                         warn!(widget = %name, error = ?e, "show_if spawn_blocking failed");
-                        (false, String::new())
+                        false
                     }
                 };
 
-                container.set_visible(visible);
+                show_if_visible.set(visible);
+                Self::apply_visibility(&container, &content_visible, &show_if_visible);
                 debug!(
                     widget = %name,
                     visible,
-                    stderr = %stderr.trim(),
                     "show_if initial check"
                 );
                 prev_visible.set(visible);
@@ -789,6 +839,8 @@ impl BaseWidget {
                 // transition hidden → visible.
                 if !visible && !has_interval {
                     let container = container.clone();
+                    let content_visible = content_visible.clone();
+                    let show_if_visible = show_if_visible.clone();
                     let name = name.clone();
                     glib::timeout_add_local_once(Duration::from_millis(500), move || {
                         glib::spawn_future_local(async move {
@@ -797,7 +849,7 @@ impl BaseWidget {
                             })
                             .await;
 
-                            let (visible, _stderr) = match result {
+                            let visible = match result {
                                 Ok(v) => v,
                                 Err(e) => {
                                     warn!(
@@ -805,12 +857,17 @@ impl BaseWidget {
                                         error = ?e,
                                         "show_if retry spawn_blocking failed"
                                     );
-                                    (false, String::new())
+                                    false
                                 }
                             };
 
                             if visible {
-                                container.set_visible(true);
+                                show_if_visible.set(true);
+                                Self::apply_visibility(
+                                    &container,
+                                    &content_visible,
+                                    &show_if_visible,
+                                );
                                 debug!(widget = %name, "show_if retry: now visible");
                             }
                         });
@@ -826,6 +883,8 @@ impl BaseWidget {
             glib::timeout_add_seconds_local(interval.min(u32::MAX as u64) as u32, move || {
                 let cmd = cmd.clone();
                 let container = container_clone.clone();
+                let content_visible = content_visible.clone();
+                let show_if_visible = show_if_visible.clone();
                 let name = name.clone();
                 let prev_visible = prev_visible.clone();
 
@@ -834,20 +893,20 @@ impl BaseWidget {
                         gio::spawn_blocking(move || Self::run_show_if_command_with_timeout(&cmd))
                             .await;
 
-                    let (visible, stderr) = match result {
+                    let visible = match result {
                         Ok(v) => v,
                         Err(e) => {
                             warn!(widget = %name, error = ?e, "show_if spawn_blocking failed");
-                            (false, String::new())
+                            false
                         }
                     };
 
                     if visible != prev_visible.get() {
-                        container.set_visible(visible);
+                        show_if_visible.set(visible);
+                        Self::apply_visibility(&container, &content_visible, &show_if_visible);
                         info!(
                             widget = %name,
                             visible,
-                            stderr = %stderr.trim(),
                             "show_if visibility changed"
                         );
                         prev_visible.set(visible);
@@ -860,28 +919,28 @@ impl BaseWidget {
         Some(source_id)
     }
 
-    /// Cancel the periodic `show_if` timer, if any.
-    ///
-    /// Used by widgets that handle `show_if` themselves (e.g., custom widgets
-    /// piggyback on their exec polling cycle instead of running a separate timer).
-    pub(super) fn cancel_show_if_timer(&mut self) {
-        if let Some(source_id) = self._show_if_timer.take() {
-            source_id.remove();
-        }
+    fn apply_visibility(
+        container: &GtkBox,
+        content_visible: &Cell<bool>,
+        show_if_visible: &Cell<bool>,
+    ) {
+        container.set_visible(content_visible.get() && show_if_visible.get());
     }
 
     /// Run a `show_if` shell command synchronously with a timeout.
-    /// Returns `(visible, stderr)` where visible = exit 0.
+    /// Returns true when the command exits 0.
     /// Commands exceeding `SHOW_IF_TIMEOUT_SECS` are killed and treated as hidden.
-    pub(super) fn run_show_if_command_with_timeout(cmd: &str) -> (bool, String) {
+    pub(super) fn run_show_if_command_with_timeout(cmd: &str) -> bool {
         let mut child = match Command::new("sh")
             .args(["-c", cmd])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0)
             .spawn()
         {
             Ok(child) => child,
-            Err(_) => return (false, String::new()),
+            Err(_) => return false,
         };
 
         let pid = child.id() as libc::pid_t;
@@ -892,11 +951,12 @@ impl BaseWidget {
                 .recv_timeout(Duration::from_secs(SHOW_IF_TIMEOUT_SECS))
                 .is_err()
             {
-                // Timeout expired — kill the child.
-                // SAFETY: Sending SIGKILL to a process. If the process already
+                // Timeout expired — kill the child's process group so
+                // descendants do not outlive the predicate check.
+                // SAFETY: Sending SIGKILL to a process group. If it already
                 // exited and was reaped, kill() returns ESRCH which is harmless.
                 unsafe {
-                    libc::kill(pid, libc::SIGKILL);
+                    libc::kill(-pid, libc::SIGKILL);
                 }
             }
         });
@@ -914,27 +974,12 @@ impl BaseWidget {
                         cmd,
                         "show_if command timed out after {SHOW_IF_TIMEOUT_SECS}s"
                     );
-                    return (false, String::new());
+                    return false;
                 }
-                (s.success(), String::new())
+                s.success()
             }
-            Err(_) => (false, String::new()),
+            Err(_) => false,
         }
-    }
-
-    /// Run a `show_if` shell command synchronously (no timeout).
-    /// Returns `(visible, stderr)` where visible = exit 0.
-    pub(super) fn run_show_if_command(cmd: &str) -> (bool, String) {
-        Command::new("sh")
-            .args(["-c", cmd])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .output()
-            .map(|o| {
-                let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
-                (o.status.success(), stderr)
-            })
-            .unwrap_or((false, String::new()))
     }
 
     /// Get the root GTK container for this widget.
@@ -945,6 +990,14 @@ impl BaseWidget {
         &self.container
     }
 
+    /// Get the painted surface for state/background classes.
+    ///
+    /// Passive widgets have no separate surface, so this falls back to the root
+    /// widget carrying their static classes.
+    pub(crate) fn surface(&self) -> &GtkBox {
+        &self.surface
+    }
+
     /// Get the ripple handle for triggering ripple animations.
     pub fn ripple_handle(&self) -> Option<&RippleHandle> {
         self.ripple_handle.as_ref()
@@ -953,6 +1006,16 @@ impl BaseWidget {
     /// Get the inner `.content` box for adding widget children.
     pub fn content(&self) -> &GtkBox {
         &self.content
+    }
+
+    /// Handle for composing content visibility with the BaseWidget-owned
+    /// `show_if` visibility gate.
+    pub(crate) fn visibility_handle(&self) -> VisibilityHandle {
+        VisibilityHandle {
+            container: self.container.clone(),
+            content_visible: Rc::clone(&self.content_visible),
+            show_if_visible: Rc::clone(&self.show_if_visible),
+        }
     }
 
     /// Get the overlay wrapping the content box.

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -1123,3 +1123,25 @@ impl Drop for BaseWidget {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_show_if_command_true() {
+        assert!(BaseWidget::run_show_if_command_with_timeout("true"));
+    }
+
+    #[test]
+    fn test_run_show_if_command_false() {
+        assert!(!BaseWidget::run_show_if_command_with_timeout("false"));
+    }
+
+    #[test]
+    fn test_run_show_if_command_nonexistent_binary() {
+        assert!(!BaseWidget::run_show_if_command_with_timeout(
+            "/nonexistent/binary/that/does/not/exist"
+        ));
+    }
+}

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -1,62 +1,96 @@
-//! Custom widget - user-defined icon/label with optional script polling and click actions.
+//! Custom widget - user-defined icon/label with optional script polling, streaming, and click actions.
 //!
 //! Supports multiple instances via the `custom-` naming prefix.
 //! Each `custom-<name>` entry becomes its own widget with a unique CSS class.
 //!
-//! `on_click` is custom-widget-specific (runs the command, then refreshes `exec`
-//! output). `on_click_right` and `on_click_middle` are handled by BaseWidget and
-//! available on all widgets.
+//! Two exec modes, both supporting auto-detected Waybar-style JSON output:
+//! - **Poll** (default): `exec` runs every `interval` seconds. First stdout line is processed;
+//!   if it parses as JSON with a supported structured field (`text`, `tooltip`, `class`, `alt`,
+//!   or `percentage`), those fields are applied. Otherwise the line is treated as plain text.
+//! - **Continuous** (`continuous = true`): `exec` spawns a long-running process; each stdout line
+//!   updates the widget in real-time with the same auto-detection.
 //!
-//! Configuration example:
+//! ## State semantics
+//!
+//! Each output line fully defines dynamic state:
+//! - Plain text or JSON without `class` clears all previously applied CSS classes.
+//! - JSON without `tooltip` falls back to the static `tooltip` config key, or clears the tooltip.
+//! - JSON `alt` selects an icon from the optional `icons` table; unmatched states fall back to
+//!   the static `icon` config key.
+//! - Empty output hides the custom widget content; `show_if` additionally gates the outer
+//!   widget wrapper. For live gating in streaming widgets, set `show_if_interval`.
+//!
+//! ## Waybar-style JSON output
+//!
+//! A subset of Waybar custom-module JSON fields is supported: `text`, `tooltip`, `class`
+//! (string or array), `alt`, `percentage`.
+//! Auto-detection means no `return-type = "json"` config key is needed.
+//! VibePanel does not implement Waybar config keys such as `format`, percentage-based
+//! `format-icons`, `signal`, or `return-type`; use VibePanel's `template` with
+//! `{output}`/`{text}` and `icons` for exact `alt` -> icon mapping instead.
+//!
+//! ### Compatibility notes
+//!
+//! - JSON must contain at least one supported field (`text`, `tooltip`, `class`, `alt`,
+//!   or `percentage`) for VibePanel to interpret it as structured output.
+//! - `show_if` is evaluated by BaseWidget. In continuous mode, set `show_if_interval`
+//!   if the gate should be re-evaluated while the stream is running.
+//!
+//! For continuous mode, ensure your command flushes stdout per-line (e.g. `stdbuf -oL`).
+//! Optional `restart_interval` (seconds) auto-restarts on exit, with a 5-in-60s crash-loop cap.
+//!
+//! Configuration examples:
 //! ```toml
-//! [widgets]
-//! right = ["custom-power", "custom-os", "custom-weather", "clock"]
-//!
-//! [widgets.custom-power]
-//! icon = "system-shutdown-symbolic"
-//! label = "Power"
-//! tooltip = "Power menu"
-//! on_click = "wlogout"
-//! # on_click_right and on_click_middle are available on all widgets
-//! on_click_right = "systemctl suspend"
-//!
-//! [widgets.custom-os]
-//! image = "/usr/share/pixmaps/distro-logo.svg"
-//! tooltip = "My Distro"
-//!
 //! [widgets.custom-weather]
 //! exec = "curl -s 'wttr.in/?format=1'"
 //! template = " {output}"
 //! interval = 600
-//! on_click = "xdg-open https://wttr.in"
 //! tooltip = "Weather"
-//! max_chars = 30
+//!
+//! [widgets.custom-json]
+//! exec = "printf '%s\\n' '{\"text\":\"CPU 42%\",\"tooltip\":\"details\",\"class\":\"normal\"}'"
+//! interval = 5
+//! tooltip = "Default tooltip"
+//!
+//! [widgets.custom-monitor]
+//! exec = "stdbuf -oL my-monitor --json"
+//! continuous = true
+//! restart_interval = 5
 //! ```
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use gtk4::gio;
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, GestureClick, Image, Label, Orientation, gdk};
+use parking_lot::Mutex;
+use serde::Deserialize;
 use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::config_manager::ConfigManager;
 use crate::services::icons::{IconHandle, has_material_mapping};
+use crate::services::tooltip::TooltipManager;
 use crate::styles::{icon, state, widget as wgt};
-use crate::widgets::base::{BaseWidget, describe_exit_status};
+use crate::widgets::base::{BaseWidget, VisibilityHandle, describe_exit_status};
 use crate::widgets::{WidgetConfig, warn_unknown_options};
 
 /// Known config keys for the custom widget.
 const KNOWN_OPTIONS: &[&str] = &[
     "icon",
+    "icons",
     "image",
     "label",
     "exec",
     "template",
     "interval",
+    "continuous",
+    "restart_interval",
     "on_click",
     "tooltip",
     "max_chars",
@@ -65,11 +99,23 @@ const KNOWN_OPTIONS: &[&str] = &[
 /// Default exec timeout in seconds.
 const EXEC_TIMEOUT_SECS: u64 = 10;
 
+/// Max automatic restarts within [`RESTART_WINDOW_SECS`] before giving up.
+const MAX_RESTARTS: u32 = 5;
+
+/// Time window (seconds) over which [`MAX_RESTARTS`] is enforced.
+const RESTART_WINDOW_SECS: u64 = 60;
+
+/// Grace period after SIGTERM before continuous custom scripts are SIGKILLed.
+const CONTINUOUS_KILL_GRACE_MS: u64 = 250;
+
 /// Configuration for a custom widget instance.
 #[derive(Debug, Clone, Default)]
 pub struct CustomConfig {
     /// Logical icon name (e.g., "system-shutdown-symbolic").
     pub icon: Option<String>,
+    /// Exact `alt` -> icon-name mapping. Each key is matched literally against the
+    /// JSON `alt` field; unmatched or missing `alt` falls back to the top-level `icon`.
+    pub icons: BTreeMap<String, String>,
     /// Image file path (PNG, SVG, etc.). Supports absolute paths, `file://` URIs,
     /// and `~/`. Takes precedence over `icon` if both are set.
     pub image: Option<String>,
@@ -81,8 +127,13 @@ pub struct CustomConfig {
     /// first line of exec stdout. When absent, exec output replaces the
     /// label wholesale.
     pub template: Option<String>,
-    /// Polling interval in seconds. 0 = run once at startup.
+    /// Polling interval in seconds. 0 = run once at startup. Only used in poll mode.
     pub interval: u64,
+    /// When `true`, `exec` is spawned as a long-running process and each stdout
+    /// line updates the label in real-time.
+    pub continuous: bool,
+    /// Auto-restart delay (seconds) for continuous mode. `None` = no restart.
+    pub restart_interval: Option<u64>,
     /// Shell command to execute on left click.
     pub on_click: Option<String>,
     /// Static tooltip text.
@@ -100,6 +151,22 @@ impl WidgetConfig for CustomConfig {
             .get("icon")
             .and_then(|v| v.as_str())
             .map(String::from);
+
+        let icons = entry
+            .options
+            .get("icons")
+            .and_then(toml::Value::as_table)
+            .map(|table| {
+                table
+                    .iter()
+                    .filter_map(|(alt, icon)| {
+                        icon.as_str()
+                            .filter(|name| !name.is_empty())
+                            .map(|name| (alt.clone(), name.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let image = entry
             .options
@@ -133,6 +200,19 @@ impl WidgetConfig for CustomConfig {
             .and_then(toml::Value::as_integer)
             .map_or(0, |v| u64::try_from(v.max(0)).unwrap_or(0));
 
+        let continuous = entry
+            .options
+            .get("continuous")
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(false);
+
+        let restart_interval = entry
+            .options
+            .get("restart_interval")
+            .and_then(toml::Value::as_integer)
+            .and_then(|v| u64::try_from(v.max(0)).ok())
+            .filter(|&v| v > 0);
+
         let on_click = entry
             .options
             .get("on_click")
@@ -153,11 +233,14 @@ impl WidgetConfig for CustomConfig {
 
         Self {
             icon,
+            icons,
             image,
             label,
             exec,
             template,
             interval,
+            continuous,
+            restart_interval,
             on_click,
             tooltip,
             max_chars,
@@ -174,13 +257,262 @@ struct ExecState {
     template: Option<String>,
     custom_id: String,
     widget: gtk4::Box,
+    visibility: VisibilityHandle,
+    class_target: gtk4::Box,
+    icon_handle: Option<IconHandle>,
+    icons: BTreeMap<String, String>,
+    static_icon: Option<String>,
+    static_tooltip: Option<String>,
+    prev_classes: Rc<RefCell<Vec<String>>>,
+    has_static_image: bool,
 }
 
-/// Pre-exec show_if gate: when present, the show_if command is evaluated
-/// before each exec cycle. Non-zero exit hides the widget and skips exec.
+fn record_restart_attempt(times: &mut Vec<std::time::Instant>, now: std::time::Instant) -> bool {
+    if let Some(cutoff) = now.checked_sub(std::time::Duration::from_secs(RESTART_WINDOW_SECS)) {
+        times.retain(|t| *t > cutoff);
+    }
+    if times.len() >= MAX_RESTARTS as usize {
+        return false;
+    }
+    times.push(now);
+    true
+}
+
 #[derive(Clone)]
-struct ShowIfGate {
-    cmd: String,
+struct ContinuousContext {
+    label: Label,
+    icon_handle: Option<IconHandle>,
+    icons: BTreeMap<String, String>,
+    static_icon: Option<String>,
+    fallback: String,
+    static_tooltip: Option<String>,
+    template: Option<String>,
+    custom_id: String,
+    widget: gtk4::Box,
+    visibility: VisibilityHandle,
+    class_target: gtk4::Box,
+    restart_interval: Option<u64>,
+    stop_flag: Arc<AtomicBool>,
+    pid_slot: Arc<AtomicU32>,
+    restart_times: Rc<RefCell<Vec<std::time::Instant>>>,
+    restart_source_slot: Rc<RefCell<Option<SourceId>>>,
+    has_static_image: bool,
+}
+
+#[derive(Debug, PartialEq)]
+struct OutputPlan {
+    label: String,
+    tooltip: Option<String>,
+    icon: Option<String>,
+    classes: Vec<String>,
+    should_show: bool,
+}
+
+// --- Structured JSON output (Waybar-compatible subset) ---
+
+/// A string or list of strings (for CSS `class` deserialization).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum StringOrVec {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl StringOrVec {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::Single(s) => vec![s],
+            Self::Multiple(v) => v,
+        }
+    }
+}
+
+/// Structured output from an exec command (auto-detected JSON).
+#[derive(Debug, Default, Deserialize)]
+struct ExecOutput {
+    text: Option<String>,
+    tooltip: Option<String>,
+    class: Option<StringOrVec>,
+    alt: Option<String>,
+    percentage: Option<f64>,
+}
+
+impl ExecOutput {
+    fn has_supported_field(&self) -> bool {
+        self.text.is_some()
+            || self.tooltip.is_some()
+            || self.class.is_some()
+            || self.alt.is_some()
+            || self.percentage.is_some()
+    }
+}
+
+/// Try to parse a line as structured JSON. Returns `Some` only if the line
+/// is valid JSON **and** contains at least one supported structured field.
+fn try_parse_json(line: &str) -> Option<ExecOutput> {
+    let out: ExecOutput = serde_json::from_str(line).ok()?;
+    out.has_supported_field().then_some(out)
+}
+
+/// Expand template placeholders: `{output}`/`{text}`, `{alt}`, `{percentage}`.
+fn expand_template(tmpl: &str, text: &str, out: Option<&ExecOutput>) -> String {
+    let mut s = tmpl.replace("{output}", text).replace("{text}", text);
+    let alt = out.and_then(|o| o.alt.as_deref()).unwrap_or("");
+    let percentage = out
+        .and_then(|o| o.percentage)
+        .map(|pct| format!("{pct:.0}"))
+        .unwrap_or_default();
+    s = s.replace("{alt}", alt);
+    s = s.replace("{percentage}", &percentage);
+    s
+}
+
+fn plan_output(
+    raw: &str,
+    fallback: &str,
+    tmpl: Option<&str>,
+    static_tooltip: Option<&str>,
+    icons: &BTreeMap<String, String>,
+    static_icon: Option<&str>,
+    has_static_image: bool,
+) -> OutputPlan {
+    let line = raw.trim();
+    let parsed = try_parse_json(line);
+    let json_present = parsed.is_some();
+    let text = match parsed.as_ref() {
+        Some(o) => o.text.as_deref().unwrap_or(""),
+        None => line,
+    };
+
+    let display = match tmpl {
+        Some(t) => expand_template(t, text, parsed.as_ref()),
+        None => text.to_string(),
+    };
+
+    let tooltip = match parsed.as_ref().and_then(|o| o.tooltip.as_deref()) {
+        Some("") => None,
+        Some(tip) => Some(tip.to_string()),
+        None => static_tooltip.map(String::from),
+    };
+
+    let icon = resolve_icon(
+        parsed.as_ref().and_then(|o| o.alt.as_deref()),
+        icons,
+        static_icon,
+    );
+
+    let classes = parsed
+        .as_ref()
+        .and_then(|o| o.class.clone())
+        .map(StringOrVec::into_vec)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|c| !c.is_empty())
+        .collect();
+
+    let should_show = if parsed.is_some() {
+        !display.is_empty() || icon.is_some() || has_static_image
+    } else {
+        !line.is_empty() || !fallback.is_empty() || has_static_image
+    };
+
+    OutputPlan {
+        label: if display.is_empty() && !json_present {
+            fallback.to_string()
+        } else {
+            display
+        },
+        tooltip,
+        icon,
+        classes,
+        should_show,
+    }
+}
+
+fn resolve_icon(
+    alt: Option<&str>,
+    icons: &BTreeMap<String, String>,
+    static_icon: Option<&str>,
+) -> Option<String> {
+    if let Some(icon) = alt
+        .filter(|value| !value.is_empty())
+        .and_then(|value| icons.get(value))
+    {
+        return Some(icon.clone());
+    }
+
+    static_icon.map(String::from)
+}
+
+/// Apply a single line of output to the widget. Handles both plain text and
+/// auto-detected JSON structured output (tooltip, CSS classes).
+///
+/// State semantics: each output line fully defines dynamic state.
+/// - Plain text or JSON without `class` clears all previously applied CSS classes.
+/// - JSON without `tooltip` falls back to the static `tooltip` config key, or clears the tooltip.
+#[allow(clippy::too_many_arguments)]
+fn apply_output(
+    raw: &str,
+    label: &Label,
+    fallback: &str,
+    tmpl: Option<&str>,
+    icon_handle: Option<&IconHandle>,
+    icons: &BTreeMap<String, String>,
+    static_icon: Option<&str>,
+    static_tooltip: Option<&str>,
+    widget: &gtk4::Box,
+    visibility: &VisibilityHandle,
+    class_target: &gtk4::Box,
+    prev_classes: &mut Vec<String>,
+    has_static_image: bool,
+) {
+    let plan = plan_output(
+        raw,
+        fallback,
+        tmpl,
+        static_tooltip,
+        icons,
+        static_icon,
+        has_static_image,
+    );
+    label.set_label(&plan.label);
+    label.set_visible(!plan.label.is_empty());
+
+    visibility.set_content_visible(plan.should_show);
+
+    // Tooltip: each update fully defines the tooltip state.
+    // JSON tooltip overrides, plain text falls back to static config or clears it.
+    if let Some(ref tip) = plan.tooltip {
+        TooltipManager::global().set_styled_tooltip(widget, tip);
+    } else {
+        TooltipManager::global().clear_tooltip(widget);
+    }
+
+    // Waybar-style dynamic icons: JSON `alt` selects from config `icons`.
+    // Plain text or unmatched alt falls back to the static `icon`.
+    if let Some(ref name) = plan.icon
+        && let Some(h) = icon_handle
+    {
+        h.set_icon(name);
+        h.widget().set_visible(true);
+    } else if let Some(h) = icon_handle {
+        h.widget().set_visible(false);
+    }
+
+    // CSS class rotation: always remove previous classes on every update.
+    // Each output line fully defines dynamic state — plain text clears all classes.
+    for c in prev_classes.drain(..) {
+        class_target.remove_css_class(&c);
+    }
+    for c in plan.classes {
+        // Guard against removing static/pre-existing classes: GTK CSS
+        // classes are not reference-counted, so blindly tracking and
+        // removing a class that was already present would strip it.
+        if !class_target.has_css_class(&c) {
+            class_target.add_css_class(&c);
+            prev_classes.push(c);
+        }
+    }
 }
 
 /// Resolve `file://` URIs and `~/` paths to absolute paths.
@@ -200,22 +532,40 @@ fn resolve_image_path(value: &str) -> String {
     }
 }
 
+fn warn_invalid_icon_name(custom_id: &str, icon_name: &str) {
+    if icon_name.starts_with('/') || icon_name.starts_with("~/") || icon_name.starts_with("file://")
+    {
+        warn!(
+            "Custom widget '{}': icon '{}' looks like a file path — \
+             use the 'image' field for file-based images instead of 'icon'.",
+            custom_id, icon_name
+        );
+    } else if !has_material_mapping(icon_name) {
+        warn!(
+            "Custom widget '{}': icon '{}' has no Material Symbol mapping. \
+             Use theme.icons.theme = \"gtk\" or a Nerd Font glyph in the label field.",
+            custom_id, icon_name
+        );
+    }
+}
+
 /// Custom widget that displays a user-configured icon/label with optional
 /// script polling and click handlers.
 pub struct CustomWidget {
     /// Shared base widget container.
     base: BaseWidget,
-    /// Held to prevent GTK from dropping the label widget.
-    #[allow(dead_code)]
-    label: Option<Label>,
-    /// Held to prevent GTK from dropping the icon widget.
+    /// Kept alive so icon handles remain registered for theme changes even
+    /// when no exec closure also owns a clone.
     #[allow(dead_code)]
     icon_handle: Option<IconHandle>,
-    /// Held to prevent GTK from dropping the image widget.
-    #[allow(dead_code)]
-    image_widget: Option<Image>,
-    /// Active timer source ID for cancellation on drop.
+    /// Active timer source ID for cancellation on drop (poll mode).
     timer_source: Rc<RefCell<Option<SourceId>>>,
+    /// Stop flag for the continuous-mode background reader thread.
+    continuous_stop: Option<Arc<AtomicBool>>,
+    /// PID of the continuous-mode child process (for SIGTERM on drop).
+    continuous_pid: Arc<AtomicU32>,
+    /// Pending continuous-mode restart timer source ID.
+    continuous_restart_source: Rc<RefCell<Option<SourceId>>>,
 }
 
 impl CustomWidget {
@@ -230,28 +580,24 @@ impl CustomWidget {
                 custom_id
             );
         }
+        if config.continuous && config.exec.is_none() {
+            warn!(
+                "Custom widget '{}': continuous is set but no exec command configured",
+                custom_id
+            );
+        }
+        if config.continuous && config.interval > 0 {
+            warn!(
+                "Custom widget '{}': interval is ignored in continuous mode",
+                custom_id
+            );
+        }
 
         let css_class_name = format!("{}{custom_id}", wgt::CUSTOM_PREFIX);
-        let mut base = BaseWidget::new(&[&css_class_name]);
 
-        // Retrieve show_if config from WidgetOptions (not CustomConfig — these
-        // are cross-cutting fields parsed at the WidgetOptions level).
-        let (show_if_cmd, show_if_interval) = ConfigManager::global().get_show_if(&css_class_name);
-
-        // When exec + interval is active, show_if piggybacks on the exec cycle
-        // instead of running a separate timer. Cancel BaseWidget's show_if timer.
-        let piggyback = config.exec.is_some() && config.interval > 0 && show_if_cmd.is_some();
-        if piggyback {
-            base.cancel_show_if_timer();
-
-            if show_if_interval.is_some() {
-                warn!(
-                    "Custom widget '{}': show_if_interval is ignored when exec + interval \
-                     is set (show_if piggybacks on the exec cycle)",
-                    custom_id
-                );
-            }
-        }
+        // Custom output visibility AND-composes with show_if on the outer wrapper;
+        // both must be true for the widget to be visible.
+        let base = BaseWidget::new(&[&css_class_name]);
 
         // Enables hover styling for left-click action.
         // BaseWidget handles CLICKABLE for on_click_right / on_click_middle.
@@ -263,10 +609,20 @@ impl CustomWidget {
             base.set_tooltip(tip);
         }
 
-        let (icon_handle, image_widget) = if let Some(ref image_path) = config.image {
+        let static_icon = config.icon.clone();
+        let has_static_image = config.image.is_some();
+
+        let icon_handle = if let Some(ref image_path) = config.image {
             if config.icon.is_some() {
                 warn!(
                     "Custom widget '{}': both 'image' and 'icon' are set; using 'image'",
+                    custom_id
+                );
+            }
+            if !config.icons.is_empty() {
+                warn!(
+                    "Custom widget '{}': both 'image' and 'icons' are set; dynamic icon mapping \
+                     is ignored because 'image' takes precedence",
                     custom_id
                 );
             }
@@ -298,27 +654,24 @@ impl CustomWidget {
             icon_root.append(&image);
             base.content().append(&icon_root);
 
-            (None, Some(image))
-        } else if let Some(ref icon_name) = config.icon {
-            if icon_name.starts_with('/')
-                || icon_name.starts_with("~/")
-                || icon_name.starts_with("file://")
-            {
-                warn!(
-                    "Custom widget '{}': icon '{}' looks like a file path — \
-                     use the 'image' field for file-based images instead of 'icon'.",
-                    custom_id, icon_name
-                );
-            } else if !has_material_mapping(icon_name) {
-                warn!(
-                    "Custom widget '{}': icon '{}' has no Material Symbol mapping. \
-                     Use theme.icons.theme = \"gtk\" or a Nerd Font glyph in the label field.",
-                    custom_id, icon_name
-                );
+            None
+        } else if config.icon.is_some() || !config.icons.is_empty() {
+            let initial_icon = config.icon.as_deref().unwrap_or("image-missing");
+
+            if let Some(ref icon) = config.icon {
+                warn_invalid_icon_name(custom_id, icon);
             }
-            (Some(base.add_icon(icon_name, &[])), None)
+            for icon in config.icons.values() {
+                warn_invalid_icon_name(custom_id, icon);
+            }
+
+            let handle = base.add_icon(initial_icon, &[]);
+            if config.icon.is_none() {
+                handle.widget().set_visible(false);
+            }
+            Some(handle)
         } else {
-            (None, None)
+            None
         };
 
         let label = if !config.label.is_empty() || config.exec.is_some() {
@@ -341,69 +694,95 @@ impl CustomWidget {
 
         let timer_source = Rc::new(RefCell::new(None));
 
-        let exec_show_if = if piggyback {
-            show_if_cmd.map(|cmd| ShowIfGate { cmd })
-        } else {
-            None
-        };
+        let continuous_stop: Option<Arc<AtomicBool>>;
+        let continuous_pid = Arc::new(AtomicU32::new(0));
+        let continuous_restart_source = Rc::new(RefCell::new(None));
 
-        // Must be set up before click handlers to share exec_state
-        let exec_state = if let Some(exec_cmd) = config.exec {
-            let state = ExecState {
-                cmd: exec_cmd,
-                label: label.clone(),
-                fallback_text: config.label,
-                template: config.template,
-                custom_id: custom_id.to_string(),
-                widget: base.widget().clone(),
-            };
-
-            // Run the exec command once immediately (with show_if gate if piggybacking)
-            run_exec(
-                &state.cmd,
-                state.label.as_ref(),
-                &state.fallback_text,
-                state.template.as_deref(),
-                &state.custom_id,
-                &state.widget,
-                exec_show_if.as_ref(),
-            );
-
-            if config.interval > 0 {
-                let state_for_timer = state.clone();
-                let show_if_for_timer = exec_show_if.clone();
-
-                let source_id = glib::timeout_add_seconds_local(
-                    u32::try_from(config.interval).unwrap_or(u32::MAX),
-                    move || {
-                        run_exec(
-                            &state_for_timer.cmd,
-                            state_for_timer.label.as_ref(),
-                            &state_for_timer.fallback_text,
-                            state_for_timer.template.as_deref(),
-                            &state_for_timer.custom_id,
-                            &state_for_timer.widget,
-                            show_if_for_timer.as_ref(),
-                        );
-                        glib::ControlFlow::Continue
+        // Continuous mode: spawn long-running process, skip poll setup.
+        let exec_state = if config.continuous {
+            continuous_stop = config
+                .exec
+                .as_ref()
+                .map(|_| Arc::new(AtomicBool::new(false)));
+            if let (Some(exec_cmd), Some(lbl), Some(stop)) =
+                (config.exec, label.clone(), &continuous_stop)
+            {
+                start_continuous(
+                    &exec_cmd,
+                    ContinuousContext {
+                        label: lbl,
+                        icon_handle: icon_handle.clone(),
+                        icons: config.icons.clone(),
+                        static_icon: static_icon.clone(),
+                        fallback: config.label,
+                        static_tooltip: config.tooltip.clone(),
+                        template: config.template,
+                        custom_id: custom_id.to_string(),
+                        widget: base.widget().clone(),
+                        visibility: base.visibility_handle(),
+                        class_target: base.surface().clone(),
+                        restart_interval: config.restart_interval,
+                        stop_flag: stop.clone(),
+                        pid_slot: continuous_pid.clone(),
+                        restart_times: Rc::new(RefCell::new(Vec::<std::time::Instant>::new())),
+                        restart_source_slot: continuous_restart_source.clone(),
+                        has_static_image,
                     },
                 );
-
-                *timer_source.borrow_mut() = Some(source_id);
             }
-
-            Some(state)
+            None // no ExecState needed — continuous manages its own updates
         } else {
-            None
+            // Poll mode
+            continuous_stop = None;
+
+            if let Some(exec_cmd) = config.exec {
+                let state = ExecState {
+                    cmd: exec_cmd,
+                    label: label.clone(),
+                    fallback_text: config.label.clone(),
+                    template: config.template.clone(),
+                    custom_id: custom_id.to_string(),
+                    widget: base.widget().clone(),
+                    visibility: base.visibility_handle(),
+                    class_target: base.surface().clone(),
+                    icon_handle: icon_handle.clone(),
+                    icons: config.icons.clone(),
+                    static_icon: static_icon.clone(),
+                    static_tooltip: config.tooltip.clone(),
+                    prev_classes: Rc::new(RefCell::new(Vec::new())),
+                    has_static_image,
+                };
+
+                // Run the exec command once immediately.
+                run_exec(&state);
+
+                if config.interval > 0 {
+                    let state_for_timer = state.clone();
+
+                    let source_id = glib::timeout_add_seconds_local(
+                        u32::try_from(config.interval).unwrap_or(u32::MAX),
+                        move || {
+                            run_exec(&state_for_timer);
+                            glib::ControlFlow::Continue
+                        },
+                    );
+
+                    *timer_source.borrow_mut() = Some(source_id);
+                }
+
+                Some(state)
+            } else {
+                None
+            }
         };
 
         if let Some(on_click) = config.on_click {
             // Custom widget's own left-click handler. Runs the command, then
-            // re-runs exec to refresh the label immediately.
-            // Right-click and middle-click are handled by BaseWidget via
-            // on_click_right / on_click_middle in the widget config.
+            // re-runs exec to refresh the label immediately (poll mode only —
+            // continuous mode updates via the stream, not exec re-run).
             let click = GestureClick::new();
             let click_widget_name = css_class_name.clone();
+            let is_continuous = config.continuous;
             click.set_button(gdk::BUTTON_PRIMARY);
             click.connect_released(move |_gesture, _n_press, _x, _y| {
                 let cmd = on_click.to_string();
@@ -448,19 +827,10 @@ impl CustomWidget {
                     })
                     .await;
 
-                    // Re-run exec after the click command finishes so the
-                    // label reflects the new state immediately.
-                    // No show_if gate — the user explicitly clicked.
-                    if let Some(ref state) = exec_state {
-                        run_exec(
-                            &state.cmd,
-                            state.label.as_ref(),
-                            &state.fallback_text,
-                            state.template.as_deref(),
-                            &state.custom_id,
-                            &state.widget,
-                            None,
-                        );
+                    // Re-run exec after click — poll mode only.
+                    // Continuous mode gets updates from the stream.
+                    if !is_continuous && let Some(ref state) = exec_state {
+                        run_exec(state);
                     }
                 });
             });
@@ -469,10 +839,11 @@ impl CustomWidget {
 
         Self {
             base,
-            label,
             icon_handle,
-            image_widget,
             timer_source,
+            continuous_stop,
+            continuous_pid,
+            continuous_restart_source,
         }
     }
 
@@ -484,87 +855,89 @@ impl CustomWidget {
 
 impl Drop for CustomWidget {
     fn drop(&mut self) {
-        // In-flight run_exec futures are safe: cloned GTK refs keep widgets alive,
-        // and set_label/set_visible on a detached widget is a harmless no-op.
         if let Some(source_id) = self.timer_source.borrow_mut().take() {
             source_id.remove();
-            debug!("Custom widget timer cancelled on drop");
+        }
+        if let Some(source_id) = self.continuous_restart_source.borrow_mut().take() {
+            source_id.remove();
+        }
+        // Stop continuous-mode process group (shell + descendants).
+        if let Some(ref flag) = self.continuous_stop {
+            flag.store(true, Ordering::Relaxed);
+        }
+        let pid = self.continuous_pid.load(Ordering::Relaxed);
+        if pid != 0 {
+            // Negative PID sends SIGTERM to the entire process group,
+            // ensuring pipelines and child processes are reaped.
+            let pgid = pid as libc::pid_t;
+            unsafe {
+                libc::kill(-pgid, libc::SIGTERM);
+            }
+            // Escalate after a short grace period for scripts that ignore SIGTERM.
+            // Guard against PID-reuse: the reader thread zeroes the atomic immediately
+            // after child.wait() returns, so a non-zero pid_slot means the process
+            // hasn't been reaped yet and the PID is still valid.
+            let pid_slot = self.continuous_pid.clone();
+            glib::timeout_add_local_once(
+                std::time::Duration::from_millis(CONTINUOUS_KILL_GRACE_MS),
+                move || {
+                    if pid_slot.load(Ordering::Relaxed) == pid {
+                        // SAFETY: Killing a process group. PID is still tracked,
+                        // process hasn't been reaped by the reader thread yet.
+                        unsafe {
+                            libc::kill(-pgid, libc::SIGKILL);
+                        }
+                    }
+                },
+            );
+            debug!(
+                "Custom widget continuous process group stopping (pgid {})",
+                pid
+            );
         }
     }
 }
 
-/// Run an exec command asynchronously and update the label with its output.
+/// Run an exec command asynchronously and update the widget with its output.
 ///
 /// Uses `glib::spawn_future_local` + `gio::spawn_blocking` to avoid blocking
 /// the GTK event loop. The command is run via `sh -c` with a 10-second timeout.
 ///
-/// Auto-hides the widget when exec returns empty output and no fallback label
-/// is configured. Shows the widget again when exec returns non-empty output.
-///
-/// When `show_if` is set, the show_if command is evaluated first as a gate:
-/// non-zero exit hides the widget and skips exec entirely.
-fn run_exec(
-    exec_cmd: &str,
-    label: Option<&Label>,
-    fallback_text: &str,
-    template: Option<&str>,
-    custom_id: &str,
-    widget: &gtk4::Box,
-    show_if: Option<&ShowIfGate>,
-) {
-    let Some(label) = label else { return };
+/// Output is processed through [`apply_output`], so JSON lines with any
+/// supported field (`text`, `tooltip`, `class`, `alt`, `percentage`) are
+/// auto-detected and applied. Plain text lines work as before.
+fn run_exec(state: &ExecState) {
+    let Some(label) = state.label.as_ref() else {
+        return;
+    };
 
     let label = label.clone();
-    let exec_cmd = exec_cmd.to_string();
-    let fallback_text = fallback_text.to_string();
-    let template = template.map(String::from);
-    let custom_id = custom_id.to_string();
-    let widget = widget.clone();
-    let show_if_cmd = show_if.map(|g| g.cmd.clone());
+    let fallback_text = state.fallback_text.clone();
+    let template = state.template.clone();
+    let custom_id = state.custom_id.clone();
+    let widget = state.widget.clone();
+    let visibility = state.visibility.clone();
+    let class_target = state.class_target.clone();
+    let exec_cmd = state.cmd.clone();
+    let icon_handle = state.icon_handle.clone();
+    let icons = state.icons.clone();
+    let static_icon = state.static_icon.clone();
+    let static_tooltip = state.static_tooltip.clone();
+    let prev_classes = Rc::clone(&state.prev_classes);
+    let has_static_image = state.has_static_image;
 
     glib::spawn_future_local(async move {
-        // Pre-exec show_if gate: if the command exits non-zero, hide and skip exec.
-        if let Some(ref cmd) = show_if_cmd {
-            let cmd = cmd.clone();
-            let custom_id_for_check = custom_id.clone();
-            let result = gio::spawn_blocking(move || BaseWidget::run_show_if_command(&cmd)).await;
-
-            let (visible, stderr) = match result {
-                Ok(v) => v,
-                Err(e) => {
-                    warn!(
-                        widget = %custom_id_for_check,
-                        error = ?e,
-                        "show_if spawn_blocking failed"
-                    );
-                    (false, String::new())
-                }
-            };
-
-            widget.set_visible(visible);
-            if !stderr.is_empty() {
-                debug!(
-                    widget = %custom_id,
-                    visible,
-                    stderr = %stderr.trim(),
-                    "show_if check"
-                );
-            }
-
-            if !visible {
-                return;
-            }
-        }
-
         let result = gio::spawn_blocking(move || {
-            use std::os::unix::process::ExitStatusExt;
+            use std::os::unix::process::{CommandExt, ExitStatusExt};
             use std::process::{Command, Stdio};
             use std::time::Duration;
 
             let child = match Command::new("sh")
                 .args(["-c", &exec_cmd])
+                .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
+                .process_group(0)
                 .spawn()
             {
                 Ok(child) => child,
@@ -584,8 +957,9 @@ fn run_exec(
                     .recv_timeout(Duration::from_secs(EXEC_TIMEOUT_SECS))
                     .is_err()
                 {
-                    // Timeout expired and sender didn't signal — kill the child.
-                    // SAFETY: Sending SIGKILL to a process. If the process already
+                    // Timeout expired and sender didn't signal — kill the child
+                    // process group so descendants cannot keep stdout open.
+                    // SAFETY: Sending SIGKILL to a process group. If it already
                     // exited and was reaped, kill() returns ESRCH which is harmless.
                     // Theoretical PID reuse: if the child exits and its PID is
                     // recycled before the timeout fires, we'd kill an unrelated
@@ -595,7 +969,7 @@ fn run_exec(
                     // cancels the watchdog. If it hasn't completed, the child is
                     // still alive and owns the PID.
                     unsafe {
-                        libc::kill(pid, libc::SIGKILL);
+                        libc::kill(-pid, libc::SIGKILL);
                     }
                 }
             });
@@ -626,23 +1000,21 @@ fn run_exec(
 
         match result {
             Ok(Ok(output)) => {
-                // Trim whitespace (including the trailing newline from read_line)
-                let text = output.trim();
-                if text.is_empty() {
-                    label.set_label(&fallback_text);
-                    // Auto-hide when exec returns empty and no fallback is configured
-                    if fallback_text.is_empty() {
-                        widget.set_visible(false);
-                    }
-                } else {
-                    let display = if let Some(ref tmpl) = template {
-                        tmpl.replace("{output}", text)
-                    } else {
-                        text.to_string()
-                    };
-                    label.set_label(&display);
-                    widget.set_visible(true);
-                }
+                apply_output(
+                    &output,
+                    &label,
+                    &fallback_text,
+                    template.as_deref(),
+                    icon_handle.as_ref(),
+                    &icons,
+                    static_icon.as_deref(),
+                    static_tooltip.as_deref(),
+                    &widget,
+                    &visibility,
+                    &class_target,
+                    &mut prev_classes.borrow_mut(),
+                    has_static_image,
+                );
             }
             Ok(Err(err)) => {
                 warn!("'custom-{}' exec failed: {}", custom_id, err);
@@ -654,6 +1026,208 @@ fn run_exec(
             }
         }
     });
+}
+
+// ---------------------------------------------------------------------------
+// Continuous (streaming) mode
+// ---------------------------------------------------------------------------
+
+/// Schedule a bounded restart after process exit or spawn failure.
+/// Enforces crash-loop cap ([`MAX_RESTARTS`] per [`RESTART_WINDOW_SECS`]).
+fn schedule_restart(ctx: &ContinuousContext, cmd: &str, reason: &str) {
+    let delay = match ctx.restart_interval {
+        Some(d) => d,
+        None => return,
+    };
+    let mut times = ctx.restart_times.borrow_mut();
+    if !record_restart_attempt(&mut times, std::time::Instant::now()) {
+        warn!(
+            "'custom-{}' continuous: restart cap reached ({} in {}s) — {}",
+            ctx.custom_id, MAX_RESTARTS, RESTART_WINDOW_SECS, reason
+        );
+        return;
+    }
+    drop(times);
+
+    let restart_ctx = ctx.clone();
+    let cmd = cmd.to_string();
+    let reason = reason.to_string();
+    let source_id =
+        glib::timeout_add_seconds_local_once(u32::try_from(delay).unwrap_or(u32::MAX), move || {
+            *restart_ctx.restart_source_slot.borrow_mut() = None;
+            if restart_ctx.stop_flag.load(Ordering::Relaxed) {
+                return;
+            }
+            debug!(
+                "'custom-{}' continuous: restarting ({})",
+                restart_ctx.custom_id, reason
+            );
+            start_continuous(&cmd, restart_ctx);
+        });
+    *ctx.restart_source_slot.borrow_mut() = Some(source_id);
+}
+
+/// Spawn a continuous-mode exec process. Background thread reads stdout lines
+/// and posts them to the main thread via mpsc + gio::spawn_blocking.
+fn start_continuous(cmd: &str, ctx: ContinuousContext) {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let child = match Command::new("sh")
+        .args(["-c", cmd])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .process_group(0)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                "'custom-{}' continuous: failed to spawn: {}",
+                ctx.custom_id, e
+            );
+            schedule_restart(&ctx, cmd, "after spawn failure");
+            return;
+        }
+    };
+
+    let pid = child.id();
+    ctx.pid_slot.store(pid, Ordering::Relaxed);
+    debug!(
+        "'custom-{}' continuous started (pid {})",
+        ctx.custom_id, pid
+    );
+
+    let (tx, rx) = std::sync::mpsc::channel::<Option<String>>();
+    let thread_stop = ctx.stop_flag.clone();
+    let thread_id = ctx.custom_id.clone();
+
+    // Background reader thread: stdout via BufRead, stderr logged.
+    let reader_pid_slot = ctx.pid_slot.clone();
+    std::thread::spawn(move || {
+        continuous_reader(child, thread_stop, thread_id, tx, reader_pid_slot);
+    });
+
+    let rx = Arc::new(Mutex::new(rx));
+    let stop = ctx.stop_flag.clone();
+    let cmd = cmd.to_string();
+
+    glib::spawn_future_local(async move {
+        let mut prev_classes = Vec::new();
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            let rx2 = rx.clone();
+            let msg = gio::spawn_blocking(move || rx2.lock().recv().ok().flatten()).await;
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+
+            match msg {
+                Ok(Some(line)) => {
+                    apply_output(
+                        &line,
+                        &ctx.label,
+                        &ctx.fallback,
+                        ctx.template.as_deref(),
+                        ctx.icon_handle.as_ref(),
+                        &ctx.icons,
+                        ctx.static_icon.as_deref(),
+                        ctx.static_tooltip.as_deref(),
+                        &ctx.widget,
+                        &ctx.visibility,
+                        &ctx.class_target,
+                        &mut prev_classes,
+                        ctx.has_static_image,
+                    );
+                }
+                _ => {
+                    // Channel closed — process exited.
+                    // Clear CSS classes from the old process so the next
+                    // incarnation starts with a clean slate.
+                    for c in prev_classes.drain(..) {
+                        ctx.class_target.remove_css_class(&c);
+                    }
+                    schedule_restart(&ctx, &cmd, "after exit");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Background reader thread: reads stdout lines, logs stderr, sends `Some(line)`
+/// per stdout line and `None` on exit through the channel.
+fn continuous_reader(
+    mut child: std::process::Child,
+    stop: Arc<AtomicBool>,
+    id: String,
+    tx: std::sync::mpsc::Sender<Option<String>>,
+    pid_slot: Arc<AtomicU32>,
+) {
+    use std::io::BufRead;
+
+    // Stderr in a separate thread to avoid deadlock.
+    let stderr = child.stderr.take();
+    let tx2 = tx.clone();
+    let stop2 = stop.clone();
+    let id_for_stderr = id.clone();
+    let stderr_handle = stderr.map(|se| {
+        std::thread::spawn(move || {
+            for line in std::io::BufReader::new(se).lines().map_while(Result::ok) {
+                if stop2.load(Ordering::Relaxed) {
+                    break;
+                }
+                if !line.is_empty() {
+                    debug!("'custom-{}' stderr: {}", id_for_stderr, line);
+                }
+            }
+            drop(tx2); // ensure channel closes if stderr thread outlives stdout
+        })
+    });
+
+    if let Some(stdout) = child.stdout.take() {
+        for line in std::io::BufReader::new(stdout).lines() {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            match line {
+                Ok(l) => {
+                    if tx.send(Some(l)).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    let status = child.wait();
+    // Zero the PID slot immediately after wait returns so the Drop-delayed
+    // SIGKILL guard never fires against a freed/reused PID.
+    pid_slot.store(0, Ordering::Relaxed);
+
+    match status {
+        Ok(s) if s.success() => {
+            debug!("'custom-{}' continuous process exited cleanly", id);
+        }
+        Ok(s) => {
+            warn!(
+                "'custom-{}' continuous process exited: {}",
+                id,
+                describe_exit_status(s)
+            );
+        }
+        Err(e) => {
+            warn!("'custom-{}' continuous process wait failed: {}", id, e);
+        }
+    }
+    let _ = tx.send(None); // signal exit before joining stderr
+    // Drop stderr reader without joining; if a background descendant
+    // inherits stderr, the join could block and prevent restart signaling.
+    drop(stderr_handle);
 }
 
 #[cfg(test)]
@@ -670,12 +1244,46 @@ mod tests {
     }
 
     #[test]
+    fn test_record_restart_attempt_enforces_cap_within_window() {
+        let now = std::time::Instant::now();
+        let mut times = Vec::new();
+
+        for _ in 0..MAX_RESTARTS {
+            assert!(record_restart_attempt(&mut times, now));
+        }
+        assert!(!record_restart_attempt(&mut times, now));
+    }
+
+    #[test]
+    fn test_record_restart_attempt_prunes_old_attempts() {
+        let now = std::time::Instant::now();
+        let old = now - std::time::Duration::from_secs(RESTART_WINDOW_SECS + 1);
+        let mut times = vec![old; MAX_RESTARTS as usize];
+
+        assert!(record_restart_attempt(&mut times, now));
+        assert_eq!(times, vec![now]);
+    }
+
+    #[test]
+    fn test_record_restart_attempt_handles_early_instant_without_underflow() {
+        let now = std::time::Instant::now();
+        let early = now
+            .checked_sub(std::time::Duration::from_secs(RESTART_WINDOW_SECS + 1))
+            .unwrap_or(now);
+        let mut times = Vec::new();
+
+        assert!(record_restart_attempt(&mut times, early));
+        assert_eq!(times, vec![early]);
+    }
+
+    #[test]
     fn test_custom_config_defaults() {
         let entry = make_entry(HashMap::new());
         let config = CustomConfig::from_entry(&entry);
 
         assert!(config.icon.is_none());
         assert!(config.image.is_none());
+        assert!(config.icons.is_empty());
         assert_eq!(config.label, "");
         assert!(config.exec.is_none());
         assert!(config.template.is_none());
@@ -691,6 +1299,19 @@ mod tests {
         options.insert(
             "icon".to_string(),
             Value::String("system-shutdown-symbolic".to_string()),
+        );
+        options.insert(
+            "icons".to_string(),
+            Value::Table(toml::map::Map::from_iter([
+                (
+                    "dnd".to_string(),
+                    Value::String("notifications-disabled".to_string()),
+                ),
+                (
+                    "enabled".to_string(),
+                    Value::String("notifications".to_string()),
+                ),
+            ])),
         );
         options.insert("label".to_string(), Value::String("Power".to_string()));
         options.insert("exec".to_string(), Value::String("echo hello".to_string()));
@@ -710,6 +1331,14 @@ mod tests {
         let config = CustomConfig::from_entry(&entry);
 
         assert_eq!(config.icon, Some("system-shutdown-symbolic".to_string()));
+        assert_eq!(
+            config.icons.get("dnd").map(String::as_str),
+            Some("notifications-disabled")
+        );
+        assert_eq!(
+            config.icons.get("enabled").map(String::as_str),
+            Some("notifications")
+        );
         assert_eq!(config.label, "Power");
         assert_eq!(config.exec, Some("echo hello".to_string()));
         assert_eq!(config.template, Some(" {output}".to_string()));
@@ -744,6 +1373,24 @@ mod tests {
         let entry = make_entry(options);
         let config = CustomConfig::from_entry(&entry);
         assert!(config.icon.is_none());
+    }
+
+    #[test]
+    fn test_custom_config_icons_ignores_non_string_values() {
+        let mut icons = toml::map::Map::new();
+        icons.insert("dnd".to_string(), Value::String("disabled".to_string()));
+        icons.insert("count".to_string(), Value::Integer(3));
+
+        let mut options = HashMap::new();
+        options.insert("icons".to_string(), Value::Table(icons));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+
+        assert_eq!(config.icons.len(), 1);
+        assert_eq!(
+            config.icons.get("dnd").map(String::as_str),
+            Some("disabled")
+        );
     }
 
     #[test]
@@ -823,33 +1470,419 @@ mod tests {
         assert!(result.ends_with("/icons/logo.png"));
     }
 
-    // --- show_if piggyback tests ---
+    // --- show_if command tests ---
 
     #[test]
     fn test_run_show_if_command_true() {
-        let (visible, stderr) = BaseWidget::run_show_if_command("true");
-        assert!(visible);
-        assert!(stderr.is_empty());
+        assert!(BaseWidget::run_show_if_command_with_timeout("true"));
     }
 
     #[test]
     fn test_run_show_if_command_false() {
-        let (visible, stderr) = BaseWidget::run_show_if_command("false");
-        assert!(!visible);
-        assert!(stderr.is_empty());
-    }
-
-    #[test]
-    fn test_run_show_if_command_captures_stderr() {
-        let (visible, stderr) = BaseWidget::run_show_if_command("echo err >&2");
-        assert!(visible);
-        assert!(stderr.trim() == "err");
+        assert!(!BaseWidget::run_show_if_command_with_timeout("false"));
     }
 
     #[test]
     fn test_run_show_if_command_nonexistent_binary() {
-        let (visible, _stderr) =
-            BaseWidget::run_show_if_command("/nonexistent/binary/that/does/not/exist");
-        assert!(!visible);
+        assert!(!BaseWidget::run_show_if_command_with_timeout(
+            "/nonexistent/binary/that/does/not/exist"
+        ));
+    }
+
+    // --- continuous mode config tests ---
+
+    #[test]
+    fn test_custom_config_continuous_defaults_false() {
+        let entry = make_entry(HashMap::new());
+        let config = CustomConfig::from_entry(&entry);
+        assert!(!config.continuous);
+        assert!(config.restart_interval.is_none());
+    }
+
+    #[test]
+    fn test_custom_config_continuous_true() {
+        let mut options = HashMap::new();
+        options.insert("continuous".to_string(), Value::Boolean(true));
+        options.insert("restart_interval".to_string(), Value::Integer(5));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.continuous);
+        assert_eq!(config.restart_interval, Some(5));
+    }
+
+    #[test]
+    fn test_custom_config_restart_interval_zero_is_none() {
+        let mut options = HashMap::new();
+        options.insert("restart_interval".to_string(), Value::Integer(0));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.restart_interval.is_none());
+    }
+
+    #[test]
+    fn test_custom_config_restart_interval_negative_is_none() {
+        let mut options = HashMap::new();
+        options.insert("restart_interval".to_string(), Value::Integer(-3));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.restart_interval.is_none());
+    }
+
+    // --- ExecOutput / JSON deserialization tests ---
+
+    #[test]
+    fn test_try_parse_json_plain_text() {
+        assert!(try_parse_json("hello world").is_none());
+    }
+
+    #[test]
+    fn test_try_parse_json_unsupported_json_object() {
+        assert!(try_parse_json(r#"{"status":"ok"}"#).is_none());
+    }
+
+    #[test]
+    fn test_try_parse_json_supported_fields_without_text() {
+        assert_eq!(
+            try_parse_json(r#"{"tooltip":"hi"}"#)
+                .unwrap()
+                .tooltip
+                .as_deref(),
+            Some("hi")
+        );
+        assert_eq!(
+            try_parse_json(r#"{"alt":"dark"}"#).unwrap().alt.as_deref(),
+            Some("dark")
+        );
+        assert!(
+            try_parse_json(r#"{"class":"active"}"#)
+                .unwrap()
+                .class
+                .is_some()
+        );
+        assert_eq!(
+            try_parse_json(r#"{"percentage":80}"#).unwrap().percentage,
+            Some(80.0)
+        );
+    }
+
+    #[test]
+    fn test_try_parse_json_with_text() {
+        let out = try_parse_json(r#"{"text":"hello"}"#).unwrap();
+        assert_eq!(out.text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_try_parse_json_full() {
+        let json = r#"{"text":"cpu 42%","tooltip":"details","class":"warning","alt":"high","percentage":42.5}"#;
+        let out = try_parse_json(json).unwrap();
+        assert_eq!(out.text.as_deref(), Some("cpu 42%"));
+        assert_eq!(out.tooltip.as_deref(), Some("details"));
+        assert_eq!(out.alt.as_deref(), Some("high"));
+        assert!((out.percentage.unwrap() - 42.5).abs() < f64::EPSILON);
+    }
+
+    fn icon_map(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(alt, icon)| ((*alt).to_string(), (*icon).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_resolve_icon_exact_match_and_static_fallback() {
+        let icons = icon_map(&[("dnd", "notifications-disabled")]);
+        assert_eq!(
+            resolve_icon(Some("dnd"), &icons, Some("static")),
+            Some("notifications-disabled".to_string())
+        );
+        assert_eq!(
+            resolve_icon(Some("unknown"), &icons, Some("static")),
+            Some("static".to_string())
+        );
+        assert_eq!(
+            resolve_icon(None, &icons, Some("static")),
+            Some("static".to_string())
+        );
+        assert_eq!(
+            resolve_icon(Some(""), &icons, Some("static")),
+            Some("static".to_string())
+        );
+        assert_eq!(
+            resolve_icon(Some("unknown"), &BTreeMap::new(), Some("static")),
+            Some("static".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_json_class_single() {
+        let out = try_parse_json(r#"{"text":"x","class":"warning"}"#).unwrap();
+        assert_eq!(out.class.unwrap().into_vec(), vec!["warning"]);
+    }
+
+    #[test]
+    fn test_try_parse_json_class_array() {
+        let out = try_parse_json(r#"{"text":"x","class":["a","b"]}"#).unwrap();
+        assert_eq!(out.class.unwrap().into_vec(), vec!["a", "b"]);
+    }
+
+    // --- StringOrVec tests ---
+
+    #[test]
+    fn test_string_or_vec_single() {
+        let s: StringOrVec = serde_json::from_str(r#""hello""#).unwrap();
+        assert_eq!(s, StringOrVec::Single("hello".to_string()));
+        assert_eq!(s.into_vec(), vec!["hello"]);
+    }
+
+    #[test]
+    fn test_string_or_vec_multiple() {
+        let s: StringOrVec = serde_json::from_str(r#"["a","b","c"]"#).unwrap();
+        assert_eq!(
+            s,
+            StringOrVec::Multiple(vec!["a".into(), "b".into(), "c".into()])
+        );
+        assert_eq!(s.into_vec(), vec!["a", "b", "c"]);
+    }
+
+    // --- expand_template tests ---
+
+    #[test]
+    fn test_expand_template_output() {
+        assert_eq!(expand_template("{output}!", "hello", None), "hello!");
+    }
+
+    #[test]
+    fn test_expand_template_text_alias() {
+        assert_eq!(expand_template("{text}!", "hello", None), "hello!");
+    }
+
+    #[test]
+    fn test_expand_template_with_exec_output() {
+        let out = ExecOutput {
+            text: Some("val".into()),
+            alt: Some("high".into()),
+            percentage: Some(75.0),
+            ..Default::default()
+        };
+        let result = expand_template("{text} ({alt}) {percentage}%", "val", Some(&out));
+        assert_eq!(result, "val (high) 75%");
+    }
+
+    #[test]
+    fn test_expand_template_missing_json_fields_clear_placeholders() {
+        let out = ExecOutput {
+            text: Some("val".into()),
+            ..Default::default()
+        };
+
+        let result = expand_template("{text} ({alt}) {percentage}%", "val", Some(&out));
+        assert_eq!(result, "val () %");
+    }
+
+    #[test]
+    fn test_plan_output_plain_text_clears_dynamic_state() {
+        let plan = plan_output(
+            "hello",
+            "fallback",
+            Some("[{output}]"),
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(
+            plan,
+            OutputPlan {
+                label: "[hello]".to_string(),
+                tooltip: None,
+                icon: None,
+                classes: Vec::new(),
+                should_show: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_plan_output_json_class_and_tooltip() {
+        let icons = icon_map(&[("high", "cpu-high")]);
+        let plan = plan_output(
+            r#"{"text":"cpu 42%","tooltip":"details","class":["warning",""],"alt":"high","icon":"ignored"}"#,
+            "fallback",
+            Some("{text}"),
+            Some("static"),
+            &icons,
+            Some("static-icon"),
+            false,
+        );
+
+        assert_eq!(
+            plan,
+            OutputPlan {
+                label: "cpu 42%".to_string(),
+                tooltip: Some("details".to_string()),
+                icon: Some("cpu-high".to_string()),
+                classes: vec!["warning".to_string()],
+                should_show: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_plan_output_json_alt_without_text_selects_icon() {
+        let icons = icon_map(&[("dark", "moon")]);
+        let plan = plan_output(
+            r#"{"alt":"dark"}"#,
+            "fallback",
+            None,
+            None,
+            &icons,
+            None,
+            false,
+        );
+
+        assert_eq!(plan.label, "");
+        assert_eq!(plan.icon, Some("moon".to_string()));
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_plan_output_json_percentage_template_shows_without_text() {
+        let plan = plan_output(
+            r#"{"percentage":80}"#,
+            "fallback",
+            Some("{percentage}%"),
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.label, "80%");
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_plan_output_ignores_json_icon_extension() {
+        let plan = plan_output(
+            r#"{"text":"cpu 42%","alt":"missing","icon":"json-icon"}"#,
+            "fallback",
+            None,
+            None,
+            &BTreeMap::new(),
+            Some("static-icon"),
+            false,
+        );
+
+        assert_eq!(plan.icon, Some("static-icon".to_string()));
+    }
+
+    #[test]
+    fn test_plan_output_json_missing_tooltip_falls_back_to_static() {
+        let plan = plan_output(
+            r#"{"text":"x"}"#,
+            "fallback",
+            None,
+            Some("static"),
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.tooltip, Some("static".to_string()));
+        assert_eq!(plan.classes, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_plan_output_json_empty_tooltip_clears_static() {
+        let plan = plan_output(
+            r#"{"text":"x","tooltip":""}"#,
+            "fallback",
+            None,
+            Some("static"),
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.tooltip, None);
+    }
+
+    #[test]
+    fn test_plan_output_json_tooltip_overrides_static() {
+        let plan = plan_output(
+            r#"{"text":"x","tooltip":"dynamic"}"#,
+            "fallback",
+            None,
+            Some("static"),
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.tooltip, Some("dynamic".to_string()));
+    }
+
+    #[test]
+    fn test_plan_output_json_missing_tooltip_clears_when_no_static() {
+        let plan = plan_output(
+            r#"{"text":"x"}"#,
+            "fallback",
+            None,
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.tooltip, None);
+        assert_eq!(plan.classes, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_output_should_show_plain_text_uses_fallback() {
+        let with_fallback = plan_output("", "fallback", None, None, &BTreeMap::new(), None, false);
+        assert_eq!(with_fallback.label, "fallback");
+        assert!(with_fallback.should_show);
+        let without_fallback = plan_output("", "", None, None, &BTreeMap::new(), None, false);
+        assert!(!without_fallback.should_show);
+    }
+
+    #[test]
+    fn test_output_should_show_plain_text_with_static_image() {
+        let plan = plan_output("", "", None, None, &BTreeMap::new(), None, true);
+
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_output_should_show_json_empty_text_does_not_use_fallback() {
+        let plan = plan_output(
+            r#"{"text":""}"#,
+            "fallback",
+            None,
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+        assert_eq!(plan.label, "");
+        assert!(!plan.should_show);
+    }
+
+    #[test]
+    fn test_output_should_show_json_empty_text_with_static_image() {
+        let plan = plan_output(
+            r#"{"text":""}"#,
+            "fallback",
+            None,
+            None,
+            &BTreeMap::new(),
+            None,
+            true,
+        );
+
+        assert_eq!(plan.label, "");
+        assert!(plan.should_show);
     }
 }

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -354,6 +354,8 @@ impl CustomIconView {
         if self.named.borrow().is_none() {
             let handle = IconsService::global().create_icon(name, &[]);
             let widget = handle.widget();
+            widget.set_halign(gtk4::Align::Center);
+            widget.set_hexpand(true);
             widget.set_visible(false);
             self.content.prepend(&widget);
             *self.named.borrow_mut() = Some(handle);

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -74,7 +74,7 @@ use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::config_manager::ConfigManager;
-use crate::services::icons::{IconHandle, has_material_mapping};
+use crate::services::icons::{IconHandle, IconsService, has_material_mapping};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::{icon, state, widget as wgt};
 use crate::widgets::base::{BaseWidget, VisibilityHandle, describe_exit_status};
@@ -108,14 +108,47 @@ const RESTART_WINDOW_SECS: u64 = 60;
 /// Grace period after SIGTERM before continuous custom scripts are SIGKILLed.
 const CONTINUOUS_KILL_GRACE_MS: u64 = 250;
 
+/// Side-icon value for a custom widget.
+///
+/// Unprefixed values are named icons resolved through VibePanel's icon service.
+/// `glyph:<value>` renders a literal glyph/emoji/Nerd Font character in the
+/// side-icon slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CustomIconValue {
+    Named(String),
+    Glyph(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CustomIconKind {
+    Named,
+    Glyph,
+}
+
+fn parse_custom_icon_value(custom_id: &str, value: &str) -> Option<CustomIconValue> {
+    if let Some(glyph) = value.strip_prefix("glyph:") {
+        if glyph.is_empty() {
+            warn!(
+                "Custom widget '{}': empty glyph icon value; ignoring",
+                custom_id
+            );
+            return None;
+        }
+        return Some(CustomIconValue::Glyph(glyph.to_string()));
+    }
+
+    Some(CustomIconValue::Named(value.to_string()))
+}
+
 /// Configuration for a custom widget instance.
 #[derive(Debug, Clone, Default)]
 pub struct CustomConfig {
-    /// Logical icon name (e.g., "system-shutdown-symbolic").
-    pub icon: Option<String>,
-    /// Exact `alt` -> icon-name mapping. Each key is matched literally against the
+    /// Side icon value. Unprefixed values are named icons; `glyph:<value>` renders
+    /// a literal glyph/emoji/Nerd Font character.
+    icon: Option<CustomIconValue>,
+    /// Exact `alt` -> side-icon mapping. Each key is matched literally against the
     /// JSON `alt` field; unmatched or missing `alt` falls back to the top-level `icon`.
-    pub icons: BTreeMap<String, String>,
+    icons: BTreeMap<String, CustomIconValue>,
     /// Image file path (PNG, SVG, etc.). Supports absolute paths, `file://` URIs,
     /// and `~/`. Takes precedence over `icon` if both are set.
     pub image: Option<String>,
@@ -150,7 +183,7 @@ impl WidgetConfig for CustomConfig {
             .options
             .get("icon")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .and_then(|value| parse_custom_icon_value(&entry.name, value));
 
         let icons = entry
             .options
@@ -160,9 +193,13 @@ impl WidgetConfig for CustomConfig {
                 table
                     .iter()
                     .filter_map(|(alt, icon)| {
-                        icon.as_str()
-                            .filter(|name| !name.is_empty())
-                            .map(|name| (alt.clone(), name.to_string()))
+                        icon.as_str().and_then(|value| {
+                            if value.is_empty() {
+                                return None;
+                            }
+                            parse_custom_icon_value(&entry.name, value)
+                                .map(|value| (alt.clone(), value))
+                        })
                     })
                     .collect()
             })
@@ -259,9 +296,9 @@ struct ExecState {
     widget: gtk4::Box,
     visibility: VisibilityHandle,
     class_target: gtk4::Box,
-    icon_handle: Option<IconHandle>,
-    icons: BTreeMap<String, String>,
-    static_icon: Option<String>,
+    icon_view: Option<CustomIconView>,
+    icons: BTreeMap<String, CustomIconValue>,
+    static_icon: Option<CustomIconValue>,
     static_tooltip: Option<String>,
     prev_classes: Rc<RefCell<Vec<String>>>,
     has_static_image: bool,
@@ -281,9 +318,9 @@ fn record_restart_attempt(times: &mut Vec<std::time::Instant>, now: std::time::I
 #[derive(Clone)]
 struct ContinuousContext {
     label: Label,
-    icon_handle: Option<IconHandle>,
-    icons: BTreeMap<String, String>,
-    static_icon: Option<String>,
+    icon_view: Option<CustomIconView>,
+    icons: BTreeMap<String, CustomIconValue>,
+    static_icon: Option<CustomIconValue>,
     fallback: String,
     static_tooltip: Option<String>,
     template: Option<String>,
@@ -299,11 +336,124 @@ struct ContinuousContext {
     has_static_image: bool,
 }
 
+#[derive(Clone)]
+struct CustomIconView {
+    content: gtk4::Box,
+    named: Rc<RefCell<Option<IconHandle>>>,
+    glyph_root: Rc<RefCell<Option<gtk4::Box>>>,
+    glyph_label: Rc<RefCell<Option<Label>>>,
+    active: Rc<RefCell<Option<CustomIconKind>>>,
+}
+
+impl CustomIconView {
+    fn new(content: &gtk4::Box) -> Self {
+        Self {
+            content: content.clone(),
+            named: Rc::new(RefCell::new(None)),
+            glyph_root: Rc::new(RefCell::new(None)),
+            glyph_label: Rc::new(RefCell::new(None)),
+            active: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn set_icon(&self, icon: Option<&CustomIconValue>) {
+        match icon {
+            Some(CustomIconValue::Named(name)) => self.show_named(name),
+            Some(CustomIconValue::Glyph(glyph)) => self.show_glyph(glyph),
+            None => self.hide(),
+        }
+    }
+
+    fn show_named(&self, name: &str) {
+        if self.named.borrow().is_none() {
+            *self.named.borrow_mut() = Some(IconsService::global().create_icon(name, &[]));
+        }
+
+        let widget = {
+            let named = self.named.borrow();
+            let handle = named.as_ref().expect("named icon handle exists");
+            handle.set_icon(name);
+            handle.widget()
+        };
+
+        self.activate(CustomIconKind::Named, &widget);
+    }
+
+    fn show_glyph(&self, glyph: &str) {
+        if self.glyph_label.borrow().is_none() {
+            let root = GtkBox::new(Orientation::Horizontal, 0);
+            root.add_css_class(icon::ROOT);
+            root.set_halign(gtk4::Align::Center);
+            root.set_hexpand(true);
+
+            let label = Label::new(None);
+            label.add_css_class(wgt::CUSTOM_ICON_GLYPH);
+            label.set_halign(gtk4::Align::Center);
+            label.set_hexpand(true);
+            label.set_xalign(0.5);
+            root.append(&label);
+
+            *self.glyph_root.borrow_mut() = Some(root);
+            *self.glyph_label.borrow_mut() = Some(label);
+        }
+
+        if let Some(label) = self.glyph_label.borrow().as_ref() {
+            label.set_label(glyph);
+        }
+        let root = self
+            .glyph_root
+            .borrow()
+            .as_ref()
+            .expect("glyph root exists")
+            .clone()
+            .upcast::<gtk4::Widget>();
+
+        self.activate(CustomIconKind::Glyph, &root);
+    }
+
+    fn hide(&self) {
+        self.detach_active();
+        *self.active.borrow_mut() = None;
+    }
+
+    fn activate(&self, kind: CustomIconKind, widget: &gtk4::Widget) {
+        if *self.active.borrow() != Some(kind) {
+            self.detach_active();
+            self.content.prepend(widget);
+            *self.active.borrow_mut() = Some(kind);
+        }
+        widget.set_visible(true);
+    }
+
+    fn detach_active(&self) {
+        match *self.active.borrow() {
+            Some(CustomIconKind::Named) => {
+                if let Some(handle) = self.named.borrow().as_ref() {
+                    let widget = handle.widget();
+                    widget.set_visible(false);
+                    if widget.parent().is_some() {
+                        self.content.remove(&widget);
+                    }
+                }
+            }
+            Some(CustomIconKind::Glyph) => {
+                if let Some(root) = self.glyph_root.borrow().as_ref() {
+                    root.set_visible(false);
+                    if root.parent().is_some() {
+                        self.content.remove(root);
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 struct OutputPlan {
     label: String,
     tooltip: Option<String>,
-    icon: Option<String>,
+    icon: Option<CustomIconValue>,
     classes: Vec<String>,
     should_show: bool,
 }
@@ -372,8 +522,8 @@ fn plan_output(
     fallback: &str,
     tmpl: Option<&str>,
     static_tooltip: Option<&str>,
-    icons: &BTreeMap<String, String>,
-    static_icon: Option<&str>,
+    icons: &BTreeMap<String, CustomIconValue>,
+    static_icon: Option<&CustomIconValue>,
     has_static_image: bool,
 ) -> OutputPlan {
     let line = raw.trim();
@@ -431,9 +581,9 @@ fn plan_output(
 
 fn resolve_icon(
     alt: Option<&str>,
-    icons: &BTreeMap<String, String>,
-    static_icon: Option<&str>,
-) -> Option<String> {
+    icons: &BTreeMap<String, CustomIconValue>,
+    static_icon: Option<&CustomIconValue>,
+) -> Option<CustomIconValue> {
     if let Some(icon) = alt
         .filter(|value| !value.is_empty())
         .and_then(|value| icons.get(value))
@@ -441,7 +591,7 @@ fn resolve_icon(
         return Some(icon.clone());
     }
 
-    static_icon.map(String::from)
+    static_icon.cloned()
 }
 
 /// Apply a single line of output to the widget. Handles both plain text and
@@ -456,9 +606,9 @@ fn apply_output(
     label: &Label,
     fallback: &str,
     tmpl: Option<&str>,
-    icon_handle: Option<&IconHandle>,
-    icons: &BTreeMap<String, String>,
-    static_icon: Option<&str>,
+    icon_view: Option<&CustomIconView>,
+    icons: &BTreeMap<String, CustomIconValue>,
+    static_icon: Option<&CustomIconValue>,
     static_tooltip: Option<&str>,
     widget: &gtk4::Box,
     visibility: &VisibilityHandle,
@@ -490,13 +640,8 @@ fn apply_output(
 
     // Waybar-style dynamic icons: JSON `alt` selects from config `icons`.
     // Plain text or unmatched alt falls back to the static `icon`.
-    if let Some(ref name) = plan.icon
-        && let Some(h) = icon_handle
-    {
-        h.set_icon(name);
-        h.widget().set_visible(true);
-    } else if let Some(h) = icon_handle {
-        h.widget().set_visible(false);
+    if let Some(view) = icon_view {
+        view.set_icon(plan.icon.as_ref());
     }
 
     // CSS class rotation: always remove previous classes on every update.
@@ -532,7 +677,11 @@ fn resolve_image_path(value: &str) -> String {
     }
 }
 
-fn warn_invalid_icon_name(custom_id: &str, icon_name: &str) {
+fn warn_invalid_custom_icon_value(custom_id: &str, icon_value: &CustomIconValue) {
+    let CustomIconValue::Named(icon_name) = icon_value else {
+        return;
+    };
+
     if icon_name.starts_with('/') || icon_name.starts_with("~/") || icon_name.starts_with("file://")
     {
         warn!(
@@ -543,7 +692,7 @@ fn warn_invalid_icon_name(custom_id: &str, icon_name: &str) {
     } else if !has_material_mapping(icon_name) {
         warn!(
             "Custom widget '{}': icon '{}' has no Material Symbol mapping. \
-             Use theme.icons.theme = \"gtk\" or a Nerd Font glyph in the label field.",
+             Use theme.icons.theme = \"gtk\" or prefix a literal glyph with 'glyph:'.",
             custom_id, icon_name
         );
     }
@@ -554,10 +703,10 @@ fn warn_invalid_icon_name(custom_id: &str, icon_name: &str) {
 pub struct CustomWidget {
     /// Shared base widget container.
     base: BaseWidget,
-    /// Kept alive so icon handles remain registered for theme changes even
-    /// when no exec closure also owns a clone.
+    /// Kept alive so custom icon handles remain registered for theme changes
+    /// even when no exec closure also owns a clone.
     #[allow(dead_code)]
-    icon_handle: Option<IconHandle>,
+    icon_view: Option<CustomIconView>,
     /// Active timer source ID for cancellation on drop (poll mode).
     timer_source: Rc<RefCell<Option<SourceId>>>,
     /// Stop flag for the continuous-mode background reader thread.
@@ -612,7 +761,7 @@ impl CustomWidget {
         let static_icon = config.icon.clone();
         let has_static_image = config.image.is_some();
 
-        let icon_handle = if let Some(ref image_path) = config.image {
+        let icon_view = if let Some(ref image_path) = config.image {
             if config.icon.is_some() {
                 warn!(
                     "Custom widget '{}': both 'image' and 'icon' are set; using 'image'",
@@ -656,20 +805,16 @@ impl CustomWidget {
 
             None
         } else if config.icon.is_some() || !config.icons.is_empty() {
-            let initial_icon = config.icon.as_deref().unwrap_or("image-missing");
-
             if let Some(ref icon) = config.icon {
-                warn_invalid_icon_name(custom_id, icon);
+                warn_invalid_custom_icon_value(custom_id, icon);
             }
             for icon in config.icons.values() {
-                warn_invalid_icon_name(custom_id, icon);
+                warn_invalid_custom_icon_value(custom_id, icon);
             }
 
-            let handle = base.add_icon(initial_icon, &[]);
-            if config.icon.is_none() {
-                handle.widget().set_visible(false);
-            }
-            Some(handle)
+            let view = CustomIconView::new(base.content());
+            view.set_icon(config.icon.as_ref());
+            Some(view)
         } else {
             None
         };
@@ -711,7 +856,7 @@ impl CustomWidget {
                     &exec_cmd,
                     ContinuousContext {
                         label: lbl,
-                        icon_handle: icon_handle.clone(),
+                        icon_view: icon_view.clone(),
                         icons: config.icons.clone(),
                         static_icon: static_icon.clone(),
                         fallback: config.label,
@@ -745,7 +890,7 @@ impl CustomWidget {
                     widget: base.widget().clone(),
                     visibility: base.visibility_handle(),
                     class_target: base.surface().clone(),
-                    icon_handle: icon_handle.clone(),
+                    icon_view: icon_view.clone(),
                     icons: config.icons.clone(),
                     static_icon: static_icon.clone(),
                     static_tooltip: config.tooltip.clone(),
@@ -839,7 +984,7 @@ impl CustomWidget {
 
         Self {
             base,
-            icon_handle,
+            icon_view,
             timer_source,
             continuous_stop,
             continuous_pid,
@@ -919,7 +1064,7 @@ fn run_exec(state: &ExecState) {
     let visibility = state.visibility.clone();
     let class_target = state.class_target.clone();
     let exec_cmd = state.cmd.clone();
-    let icon_handle = state.icon_handle.clone();
+    let icon_view = state.icon_view.clone();
     let icons = state.icons.clone();
     let static_icon = state.static_icon.clone();
     let static_tooltip = state.static_tooltip.clone();
@@ -1005,9 +1150,9 @@ fn run_exec(state: &ExecState) {
                     &label,
                     &fallback_text,
                     template.as_deref(),
-                    icon_handle.as_ref(),
+                    icon_view.as_ref(),
                     &icons,
-                    static_icon.as_deref(),
+                    static_icon.as_ref(),
                     static_tooltip.as_deref(),
                     &widget,
                     &visibility,
@@ -1132,9 +1277,9 @@ fn start_continuous(cmd: &str, ctx: ContinuousContext) {
                         &ctx.label,
                         &ctx.fallback,
                         ctx.template.as_deref(),
-                        ctx.icon_handle.as_ref(),
+                        ctx.icon_view.as_ref(),
                         &ctx.icons,
-                        ctx.static_icon.as_deref(),
+                        ctx.static_icon.as_ref(),
                         ctx.static_tooltip.as_deref(),
                         &ctx.widget,
                         &ctx.visibility,
@@ -1293,6 +1438,14 @@ mod tests {
         assert!(config.max_chars.is_none());
     }
 
+    fn named_icon(name: &str) -> CustomIconValue {
+        CustomIconValue::Named(name.to_string())
+    }
+
+    fn glyph_icon(glyph: &str) -> CustomIconValue {
+        CustomIconValue::Glyph(glyph.to_string())
+    }
+
     #[test]
     fn test_custom_config_full() {
         let mut options = HashMap::new();
@@ -1330,14 +1483,14 @@ mod tests {
         let entry = make_entry(options);
         let config = CustomConfig::from_entry(&entry);
 
-        assert_eq!(config.icon, Some("system-shutdown-symbolic".to_string()));
+        assert_eq!(config.icon, Some(named_icon("system-shutdown-symbolic")));
         assert_eq!(
-            config.icons.get("dnd").map(String::as_str),
-            Some("notifications-disabled")
+            config.icons.get("dnd"),
+            Some(&named_icon("notifications-disabled"))
         );
         assert_eq!(
-            config.icons.get("enabled").map(String::as_str),
-            Some("notifications")
+            config.icons.get("enabled"),
+            Some(&named_icon("notifications"))
         );
         assert_eq!(config.label, "Power");
         assert_eq!(config.exec, Some("echo hello".to_string()));
@@ -1376,6 +1529,33 @@ mod tests {
     }
 
     #[test]
+    fn test_custom_config_icon_glyph_parsed() {
+        let mut options = HashMap::new();
+        options.insert("icon".to_string(), Value::String("glyph:🔋".to_string()));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert_eq!(config.icon, Some(glyph_icon("🔋")));
+    }
+
+    #[test]
+    fn test_custom_config_icon_unknown_prefix_stays_named() {
+        let mut options = HashMap::new();
+        options.insert("icon".to_string(), Value::String("foo:bar".to_string()));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert_eq!(config.icon, Some(named_icon("foo:bar")));
+    }
+
+    #[test]
+    fn test_custom_config_empty_prefixed_icon_ignored() {
+        let mut options = HashMap::new();
+        options.insert("icon".to_string(), Value::String("glyph:".to_string()));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+        assert!(config.icon.is_none());
+    }
+
+    #[test]
     fn test_custom_config_icons_ignores_non_string_values() {
         let mut icons = toml::map::Map::new();
         icons.insert("dnd".to_string(), Value::String("disabled".to_string()));
@@ -1387,10 +1567,22 @@ mod tests {
         let config = CustomConfig::from_entry(&entry);
 
         assert_eq!(config.icons.len(), 1);
-        assert_eq!(
-            config.icons.get("dnd").map(String::as_str),
-            Some("disabled")
-        );
+        assert_eq!(config.icons.get("dnd"), Some(&named_icon("disabled")));
+    }
+
+    #[test]
+    fn test_custom_config_icons_glyph_value_parsed() {
+        let mut icons = toml::map::Map::new();
+        icons.insert("unknown".to_string(), Value::String("glyph:?".to_string()));
+        icons.insert("dnd".to_string(), Value::String("disabled".to_string()));
+
+        let mut options = HashMap::new();
+        options.insert("icons".to_string(), Value::Table(icons));
+        let entry = make_entry(options);
+        let config = CustomConfig::from_entry(&entry);
+
+        assert_eq!(config.icons.get("unknown"), Some(&glyph_icon("?")));
+        assert_eq!(config.icons.get("dnd"), Some(&named_icon("disabled")));
     }
 
     #[test]
@@ -1581,35 +1773,46 @@ mod tests {
         assert!((out.percentage.unwrap() - 42.5).abs() < f64::EPSILON);
     }
 
-    fn icon_map(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+    fn icon_map(entries: &[(&str, &str)]) -> BTreeMap<String, CustomIconValue> {
         entries
             .iter()
-            .map(|(alt, icon)| ((*alt).to_string(), (*icon).to_string()))
+            .map(|(alt, icon)| ((*alt).to_string(), named_icon(icon)))
             .collect()
     }
 
     #[test]
     fn test_resolve_icon_exact_match_and_static_fallback() {
         let icons = icon_map(&[("dnd", "notifications-disabled")]);
+        let static_icon = named_icon("static");
         assert_eq!(
-            resolve_icon(Some("dnd"), &icons, Some("static")),
-            Some("notifications-disabled".to_string())
+            resolve_icon(Some("dnd"), &icons, Some(&static_icon)),
+            Some(named_icon("notifications-disabled"))
         );
         assert_eq!(
-            resolve_icon(Some("unknown"), &icons, Some("static")),
-            Some("static".to_string())
+            resolve_icon(Some("unknown"), &icons, Some(&static_icon)),
+            Some(named_icon("static"))
         );
         assert_eq!(
-            resolve_icon(None, &icons, Some("static")),
-            Some("static".to_string())
+            resolve_icon(None, &icons, Some(&static_icon)),
+            Some(named_icon("static"))
         );
         assert_eq!(
-            resolve_icon(Some(""), &icons, Some("static")),
-            Some("static".to_string())
+            resolve_icon(Some(""), &icons, Some(&static_icon)),
+            Some(named_icon("static"))
         );
         assert_eq!(
-            resolve_icon(Some("unknown"), &BTreeMap::new(), Some("static")),
-            Some("static".to_string())
+            resolve_icon(Some("unknown"), &BTreeMap::new(), Some(&static_icon)),
+            Some(named_icon("static"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_icon_exact_match_can_return_glyph() {
+        let icons = BTreeMap::from([("unknown".to_string(), glyph_icon("?"))]);
+        let static_icon = named_icon("static");
+        assert_eq!(
+            resolve_icon(Some("unknown"), &icons, Some(&static_icon)),
+            Some(glyph_icon("?"))
         );
     }
 
@@ -1706,13 +1909,14 @@ mod tests {
     #[test]
     fn test_plan_output_json_class_and_tooltip() {
         let icons = icon_map(&[("high", "cpu-high")]);
+        let static_icon = named_icon("static-icon");
         let plan = plan_output(
             r#"{"text":"cpu 42%","tooltip":"details","class":["warning",""],"alt":"high","icon":"ignored"}"#,
             "fallback",
             Some("{text}"),
             Some("static"),
             &icons,
-            Some("static-icon"),
+            Some(&static_icon),
             false,
         );
 
@@ -1721,7 +1925,7 @@ mod tests {
             OutputPlan {
                 label: "cpu 42%".to_string(),
                 tooltip: Some("details".to_string()),
-                icon: Some("cpu-high".to_string()),
+                icon: Some(named_icon("cpu-high")),
                 classes: vec!["warning".to_string()],
                 should_show: true,
             }
@@ -1742,7 +1946,25 @@ mod tests {
         );
 
         assert_eq!(plan.label, "");
-        assert_eq!(plan.icon, Some("moon".to_string()));
+        assert_eq!(plan.icon, Some(named_icon("moon")));
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_plan_output_json_alt_can_select_glyph_icon() {
+        let icons = BTreeMap::from([("unknown".to_string(), glyph_icon("?"))]);
+        let plan = plan_output(
+            r#"{"alt":"unknown"}"#,
+            "fallback",
+            None,
+            None,
+            &icons,
+            None,
+            false,
+        );
+
+        assert_eq!(plan.label, "");
+        assert_eq!(plan.icon, Some(glyph_icon("?")));
         assert!(plan.should_show);
     }
 
@@ -1764,17 +1986,18 @@ mod tests {
 
     #[test]
     fn test_plan_output_ignores_json_icon_extension() {
+        let static_icon = named_icon("static-icon");
         let plan = plan_output(
             r#"{"text":"cpu 42%","alt":"missing","icon":"json-icon"}"#,
             "fallback",
             None,
             None,
             &BTreeMap::new(),
-            Some("static-icon"),
+            Some(&static_icon),
             false,
         );
 
-        assert_eq!(plan.icon, Some("static-icon".to_string()));
+        assert_eq!(plan.icon, Some(named_icon("static-icon")));
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/custom.rs
+++ b/crates/vibepanel/src/widgets/custom.rs
@@ -3,59 +3,27 @@
 //! Supports multiple instances via the `custom-` naming prefix.
 //! Each `custom-<name>` entry becomes its own widget with a unique CSS class.
 //!
-//! Two exec modes, both supporting auto-detected Waybar-style JSON output:
-//! - **Poll** (default): `exec` runs every `interval` seconds. First stdout line is processed;
-//!   if it parses as JSON with a supported structured field (`text`, `tooltip`, `class`, `alt`,
-//!   or `percentage`), those fields are applied. Otherwise the line is treated as plain text.
-//! - **Continuous** (`continuous = true`): `exec` spawns a long-running process; each stdout line
-//!   updates the widget in real-time with the same auto-detection.
+//! `exec` can run once/on interval, or as a line-buffered stream with `continuous = true`.
+//! Output is plain text unless it parses as Waybar-style JSON with at least one supported
+//! field: `text`, `tooltip`, `class`, `alt`, or `percentage`. `alt` maps through `icons`,
+//! and `glyph:<value>` renders a literal side icon.
 //!
-//! ## State semantics
+//! VibePanel supports the JSON output format, not Waybar's config surface: use `template`
+//! and `icons` instead of `format`, `format-icons`, `signal`, or `return-type`.
 //!
-//! Each output line fully defines dynamic state:
-//! - Plain text or JSON without `class` clears all previously applied CSS classes.
-//! - JSON without `tooltip` falls back to the static `tooltip` config key, or clears the tooltip.
-//! - JSON `alt` selects an icon from the optional `icons` table; unmatched states fall back to
-//!   the static `icon` config key.
-//! - Empty output hides the custom widget content; `show_if` additionally gates the outer
-//!   widget wrapper. For live gating in streaming widgets, set `show_if_interval`.
+//! For continuous mode, commands must flush stdout per line. Optional `restart_interval`
+//! auto-restarts on exit, with a 5-in-60s crash-loop cap.
 //!
-//! ## Waybar-style JSON output
-//!
-//! A subset of Waybar custom-module JSON fields is supported: `text`, `tooltip`, `class`
-//! (string or array), `alt`, `percentage`.
-//! Auto-detection means no `return-type = "json"` config key is needed.
-//! VibePanel does not implement Waybar config keys such as `format`, percentage-based
-//! `format-icons`, `signal`, or `return-type`; use VibePanel's `template` with
-//! `{output}`/`{text}` and `icons` for exact `alt` -> icon mapping instead.
-//!
-//! ### Compatibility notes
-//!
-//! - JSON must contain at least one supported field (`text`, `tooltip`, `class`, `alt`,
-//!   or `percentage`) for VibePanel to interpret it as structured output.
-//! - `show_if` is evaluated by BaseWidget. In continuous mode, set `show_if_interval`
-//!   if the gate should be re-evaluated while the stream is running.
-//!
-//! For continuous mode, ensure your command flushes stdout per-line (e.g. `stdbuf -oL`).
-//! Optional `restart_interval` (seconds) auto-restarts on exit, with a 5-in-60s crash-loop cap.
-//!
-//! Configuration examples:
+//! Example:
 //! ```toml
-//! [widgets.custom-weather]
-//! exec = "curl -s 'wttr.in/?format=1'"
-//! template = " {output}"
-//! interval = 600
-//! tooltip = "Weather"
-//!
-//! [widgets.custom-json]
-//! exec = "printf '%s\\n' '{\"text\":\"CPU 42%\",\"tooltip\":\"details\",\"class\":\"normal\"}'"
-//! interval = 5
-//! tooltip = "Default tooltip"
-//!
 //! [widgets.custom-monitor]
 //! exec = "stdbuf -oL my-monitor --json"
 //! continuous = true
 //! restart_interval = 5
+//! template = "{text} {percentage}%"
+//!
+//! [widgets.custom-monitor.icons]
+//! warning = "glyph:!"
 //! ```
 
 use std::cell::RefCell;
@@ -68,7 +36,6 @@ use gtk4::gio;
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, GestureClick, Image, Label, Orientation, gdk};
-use parking_lot::Mutex;
 use serde::Deserialize;
 use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
@@ -117,12 +84,6 @@ const CONTINUOUS_KILL_GRACE_MS: u64 = 250;
 enum CustomIconValue {
     Named(String),
     Glyph(String),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CustomIconKind {
-    Named,
-    Glyph,
 }
 
 fn parse_custom_icon_value(custom_id: &str, value: &str) -> Option<CustomIconValue> {
@@ -289,19 +250,17 @@ impl WidgetConfig for CustomConfig {
 #[derive(Clone)]
 struct ExecState {
     cmd: String,
-    label: Option<Label>,
-    fallback_text: String,
-    template: Option<String>,
     custom_id: String,
-    widget: gtk4::Box,
-    visibility: VisibilityHandle,
-    class_target: gtk4::Box,
-    icon_view: Option<CustomIconView>,
-    icons: BTreeMap<String, CustomIconValue>,
-    static_icon: Option<CustomIconValue>,
-    static_tooltip: Option<String>,
+    display: DisplayContext,
     prev_classes: Rc<RefCell<Vec<String>>>,
-    has_static_image: bool,
+}
+
+struct ExecWiring {
+    state: Option<ExecState>,
+    timer_source: Rc<RefCell<Option<SourceId>>>,
+    continuous_stop: Option<Arc<AtomicBool>>,
+    continuous_pid: Arc<AtomicU32>,
+    continuous_restart_source: Rc<RefCell<Option<SourceId>>>,
 }
 
 fn record_restart_attempt(times: &mut Vec<std::time::Instant>, now: std::time::Instant) -> bool {
@@ -317,6 +276,17 @@ fn record_restart_attempt(times: &mut Vec<std::time::Instant>, now: std::time::I
 
 #[derive(Clone)]
 struct ContinuousContext {
+    display: DisplayContext,
+    custom_id: String,
+    restart_interval: Option<u64>,
+    stop_flag: Arc<AtomicBool>,
+    pid_slot: Arc<AtomicU32>,
+    restart_times: Rc<RefCell<Vec<std::time::Instant>>>,
+    restart_source_slot: Rc<RefCell<Option<SourceId>>>,
+}
+
+#[derive(Clone)]
+struct DisplayContext {
     label: Label,
     icon_view: Option<CustomIconView>,
     icons: BTreeMap<String, CustomIconValue>,
@@ -324,25 +294,42 @@ struct ContinuousContext {
     fallback: String,
     static_tooltip: Option<String>,
     template: Option<String>,
-    custom_id: String,
     widget: gtk4::Box,
     visibility: VisibilityHandle,
     class_target: gtk4::Box,
-    restart_interval: Option<u64>,
-    stop_flag: Arc<AtomicBool>,
-    pid_slot: Arc<AtomicU32>,
-    restart_times: Rc<RefCell<Vec<std::time::Instant>>>,
-    restart_source_slot: Rc<RefCell<Option<SourceId>>>,
     has_static_image: bool,
+}
+
+struct DisplayWidgets {
+    label: Option<Label>,
+    icon_view: Option<CustomIconView>,
+    static_icon: Option<CustomIconValue>,
+    has_static_image: bool,
+}
+
+impl DisplayWidgets {
+    fn context(&self, label: &Label, config: &CustomConfig, base: &BaseWidget) -> DisplayContext {
+        DisplayContext {
+            label: label.clone(),
+            icon_view: self.icon_view.clone(),
+            icons: config.icons.clone(),
+            static_icon: self.static_icon.clone(),
+            fallback: config.label.clone(),
+            static_tooltip: config.tooltip.clone(),
+            template: config.template.clone(),
+            widget: base.widget().clone(),
+            visibility: base.visibility_handle(),
+            class_target: base.surface().clone(),
+            has_static_image: self.has_static_image,
+        }
+    }
 }
 
 #[derive(Clone)]
 struct CustomIconView {
     content: gtk4::Box,
     named: Rc<RefCell<Option<IconHandle>>>,
-    glyph_root: Rc<RefCell<Option<gtk4::Box>>>,
-    glyph_label: Rc<RefCell<Option<Label>>>,
-    active: Rc<RefCell<Option<CustomIconKind>>>,
+    glyph: Rc<RefCell<Option<Label>>>,
 }
 
 impl CustomIconView {
@@ -350,9 +337,7 @@ impl CustomIconView {
         Self {
             content: content.clone(),
             named: Rc::new(RefCell::new(None)),
-            glyph_root: Rc::new(RefCell::new(None)),
-            glyph_label: Rc::new(RefCell::new(None)),
-            active: Rc::new(RefCell::new(None)),
+            glyph: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -365,86 +350,55 @@ impl CustomIconView {
     }
 
     fn show_named(&self, name: &str) {
+        self.hide_glyph();
         if self.named.borrow().is_none() {
-            *self.named.borrow_mut() = Some(IconsService::global().create_icon(name, &[]));
+            let handle = IconsService::global().create_icon(name, &[]);
+            let widget = handle.widget();
+            widget.set_visible(false);
+            self.content.prepend(&widget);
+            *self.named.borrow_mut() = Some(handle);
         }
 
-        let widget = {
-            let named = self.named.borrow();
-            let handle = named.as_ref().expect("named icon handle exists");
+        if let Some(handle) = self.named.borrow().as_ref() {
             handle.set_icon(name);
-            handle.widget()
-        };
-
-        self.activate(CustomIconKind::Named, &widget);
+            handle.widget().set_visible(true);
+        }
     }
 
     fn show_glyph(&self, glyph: &str) {
-        if self.glyph_label.borrow().is_none() {
-            let root = GtkBox::new(Orientation::Horizontal, 0);
-            root.add_css_class(icon::ROOT);
-            root.set_halign(gtk4::Align::Center);
-            root.set_hexpand(true);
-
+        self.hide_named();
+        if self.glyph.borrow().is_none() {
             let label = Label::new(None);
+            label.add_css_class(icon::ROOT);
             label.add_css_class(wgt::CUSTOM_ICON_GLYPH);
             label.set_halign(gtk4::Align::Center);
             label.set_hexpand(true);
             label.set_xalign(0.5);
-            root.append(&label);
-
-            *self.glyph_root.borrow_mut() = Some(root);
-            *self.glyph_label.borrow_mut() = Some(label);
+            label.set_visible(false);
+            self.content.prepend(&label);
+            *self.glyph.borrow_mut() = Some(label);
         }
 
-        if let Some(label) = self.glyph_label.borrow().as_ref() {
+        if let Some(label) = self.glyph.borrow().as_ref() {
             label.set_label(glyph);
+            label.set_visible(true);
         }
-        let root = self
-            .glyph_root
-            .borrow()
-            .as_ref()
-            .expect("glyph root exists")
-            .clone()
-            .upcast::<gtk4::Widget>();
-
-        self.activate(CustomIconKind::Glyph, &root);
     }
 
     fn hide(&self) {
-        self.detach_active();
-        *self.active.borrow_mut() = None;
+        self.hide_named();
+        self.hide_glyph();
     }
 
-    fn activate(&self, kind: CustomIconKind, widget: &gtk4::Widget) {
-        if *self.active.borrow() != Some(kind) {
-            self.detach_active();
-            self.content.prepend(widget);
-            *self.active.borrow_mut() = Some(kind);
+    fn hide_named(&self) {
+        if let Some(handle) = self.named.borrow().as_ref() {
+            handle.widget().set_visible(false);
         }
-        widget.set_visible(true);
     }
 
-    fn detach_active(&self) {
-        match *self.active.borrow() {
-            Some(CustomIconKind::Named) => {
-                if let Some(handle) = self.named.borrow().as_ref() {
-                    let widget = handle.widget();
-                    widget.set_visible(false);
-                    if widget.parent().is_some() {
-                        self.content.remove(&widget);
-                    }
-                }
-            }
-            Some(CustomIconKind::Glyph) => {
-                if let Some(root) = self.glyph_root.borrow().as_ref() {
-                    root.set_visible(false);
-                    if root.parent().is_some() {
-                        self.content.remove(root);
-                    }
-                }
-            }
-            None => {}
+    fn hide_glyph(&self) {
+        if let Some(label) = self.glyph.borrow().as_ref() {
+            label.set_visible(false);
         }
     }
 }
@@ -534,9 +488,13 @@ fn plan_output(
         None => line,
     };
 
-    let display = match tmpl {
-        Some(t) => expand_template(t, text, parsed.as_ref()),
-        None => text.to_string(),
+    let display = if !json_present && line.is_empty() {
+        String::new()
+    } else {
+        match tmpl {
+            Some(t) => expand_template(t, text, parsed.as_ref()),
+            None => text.to_string(),
+        }
     };
 
     let tooltip = match parsed.as_ref().and_then(|o| o.tooltip.as_deref()) {
@@ -600,61 +558,46 @@ fn resolve_icon(
 /// State semantics: each output line fully defines dynamic state.
 /// - Plain text or JSON without `class` clears all previously applied CSS classes.
 /// - JSON without `tooltip` falls back to the static `tooltip` config key, or clears the tooltip.
-#[allow(clippy::too_many_arguments)]
-fn apply_output(
-    raw: &str,
-    label: &Label,
-    fallback: &str,
-    tmpl: Option<&str>,
-    icon_view: Option<&CustomIconView>,
-    icons: &BTreeMap<String, CustomIconValue>,
-    static_icon: Option<&CustomIconValue>,
-    static_tooltip: Option<&str>,
-    widget: &gtk4::Box,
-    visibility: &VisibilityHandle,
-    class_target: &gtk4::Box,
-    prev_classes: &mut Vec<String>,
-    has_static_image: bool,
-) {
+fn apply_output(raw: &str, display: &DisplayContext, prev_classes: &mut Vec<String>) {
     let plan = plan_output(
         raw,
-        fallback,
-        tmpl,
-        static_tooltip,
-        icons,
-        static_icon,
-        has_static_image,
+        &display.fallback,
+        display.template.as_deref(),
+        display.static_tooltip.as_deref(),
+        &display.icons,
+        display.static_icon.as_ref(),
+        display.has_static_image,
     );
-    label.set_label(&plan.label);
-    label.set_visible(!plan.label.is_empty());
+    display.label.set_label(&plan.label);
+    display.label.set_visible(!plan.label.is_empty());
 
-    visibility.set_content_visible(plan.should_show);
+    display.visibility.set_content_visible(plan.should_show);
 
     // Tooltip: each update fully defines the tooltip state.
     // JSON tooltip overrides, plain text falls back to static config or clears it.
     if let Some(ref tip) = plan.tooltip {
-        TooltipManager::global().set_styled_tooltip(widget, tip);
+        TooltipManager::global().set_styled_tooltip(&display.widget, tip);
     } else {
-        TooltipManager::global().clear_tooltip(widget);
+        TooltipManager::global().clear_tooltip(&display.widget);
     }
 
     // Waybar-style dynamic icons: JSON `alt` selects from config `icons`.
     // Plain text or unmatched alt falls back to the static `icon`.
-    if let Some(view) = icon_view {
+    if let Some(view) = &display.icon_view {
         view.set_icon(plan.icon.as_ref());
     }
 
     // CSS class rotation: always remove previous classes on every update.
     // Each output line fully defines dynamic state — plain text clears all classes.
     for c in prev_classes.drain(..) {
-        class_target.remove_css_class(&c);
+        display.class_target.remove_css_class(&c);
     }
     for c in plan.classes {
         // Guard against removing static/pre-existing classes: GTK CSS
         // classes are not reference-counted, so blindly tracking and
         // removing a class that was already present would strip it.
-        if !class_target.has_css_class(&c) {
-            class_target.add_css_class(&c);
+        if !display.class_target.has_css_class(&c) {
+            display.class_target.add_css_class(&c);
             prev_classes.push(c);
         }
     }
@@ -689,12 +632,203 @@ fn warn_invalid_custom_icon_value(custom_id: &str, icon_value: &CustomIconValue)
              use the 'image' field for file-based images instead of 'icon'.",
             custom_id, icon_name
         );
-    } else if !has_material_mapping(icon_name) {
+    } else if IconsService::global().uses_material() && !has_material_mapping(icon_name) {
         warn!(
             "Custom widget '{}': icon '{}' has no Material Symbol mapping. \
              Use theme.icons.theme = \"gtk\" or prefix a literal glyph with 'glyph:'.",
             custom_id, icon_name
         );
+    }
+}
+
+fn build_display_widgets(
+    custom_id: &str,
+    config: &CustomConfig,
+    base: &BaseWidget,
+) -> DisplayWidgets {
+    let static_icon = config.icon.clone();
+    let has_static_image = config.image.is_some();
+
+    let icon_view = if let Some(ref image_path) = config.image {
+        if config.icon.is_some() {
+            warn!(
+                "Custom widget '{}': both 'image' and 'icon' are set; using 'image'",
+                custom_id
+            );
+        }
+        if !config.icons.is_empty() {
+            warn!(
+                "Custom widget '{}': both 'image' and 'icons' are set; dynamic icon mapping \
+                 is ignored because 'image' takes precedence",
+                custom_id
+            );
+        }
+
+        let resolved = resolve_image_path(image_path);
+
+        if !resolved.starts_with('/') {
+            warn!(
+                "Custom widget '{}': image path '{}' is not absolute — \
+                 use an absolute path, ~/path, or file:// URI",
+                custom_id, image_path
+            );
+        } else if !std::path::Path::new(&resolved).exists() {
+            warn!(
+                "Custom widget '{}': image file '{}' does not exist",
+                custom_id, resolved
+            );
+        }
+
+        let image = Image::from_file(&resolved);
+        let icon_size = ConfigManager::global().theme_sizes().pixmap_icon_size as i32;
+        image.set_pixel_size(icon_size);
+
+        let icon_root = GtkBox::new(Orientation::Horizontal, 0);
+        icon_root.add_css_class(icon::ROOT);
+        icon_root.set_halign(gtk4::Align::Center);
+        icon_root.set_hexpand(true);
+        image.set_halign(gtk4::Align::Center);
+        icon_root.append(&image);
+        base.content().append(&icon_root);
+
+        None
+    } else if config.icon.is_some() || !config.icons.is_empty() {
+        if let Some(ref icon) = config.icon {
+            warn_invalid_custom_icon_value(custom_id, icon);
+        }
+        for icon in config.icons.values() {
+            warn_invalid_custom_icon_value(custom_id, icon);
+        }
+
+        let view = CustomIconView::new(base.content());
+        view.set_icon(config.icon.as_ref());
+        Some(view)
+    } else {
+        None
+    };
+
+    let label = if !config.label.is_empty() || config.exec.is_some() {
+        let initial_text = if config.label.is_empty() {
+            None
+        } else {
+            Some(config.label.as_str())
+        };
+        let lbl = base.add_label(initial_text, &[]);
+
+        if let Some(max_chars) = config.max_chars {
+            lbl.set_max_width_chars(max_chars);
+            lbl.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        }
+
+        Some(lbl)
+    } else {
+        None
+    };
+
+    if config.exec.is_some()
+        && config.label.is_empty()
+        && config.icon.is_none()
+        && config.image.is_none()
+    {
+        base.visibility_handle().set_content_visible(false);
+    }
+
+    DisplayWidgets {
+        label,
+        icon_view,
+        static_icon,
+        has_static_image,
+    }
+}
+
+fn wire_exec(
+    custom_id: &str,
+    config: &CustomConfig,
+    base: &BaseWidget,
+    display_widgets: &DisplayWidgets,
+) -> ExecWiring {
+    let timer_source = Rc::new(RefCell::new(None));
+    let continuous_pid = Arc::new(AtomicU32::new(0));
+    let continuous_restart_source = Rc::new(RefCell::new(None));
+
+    if config.continuous {
+        let continuous_stop = config
+            .exec
+            .as_ref()
+            .map(|_| Arc::new(AtomicBool::new(false)));
+
+        if let (Some(exec_cmd), Some(lbl), Some(stop)) = (
+            config.exec.clone(),
+            display_widgets.label.clone(),
+            &continuous_stop,
+        ) {
+            let display = display_widgets.context(&lbl, config, base);
+            start_continuous(
+                &exec_cmd,
+                ContinuousContext {
+                    display,
+                    custom_id: custom_id.to_string(),
+                    restart_interval: config.restart_interval,
+                    stop_flag: stop.clone(),
+                    pid_slot: continuous_pid.clone(),
+                    restart_times: Rc::new(RefCell::new(Vec::<std::time::Instant>::new())),
+                    restart_source_slot: continuous_restart_source.clone(),
+                },
+            );
+        }
+
+        return ExecWiring {
+            state: None,
+            timer_source,
+            continuous_stop,
+            continuous_pid,
+            continuous_restart_source,
+        };
+    }
+
+    let continuous_stop = None;
+    let state = config.exec.clone().map(|exec_cmd| {
+        let display = display_widgets.context(
+            display_widgets
+                .label
+                .as_ref()
+                .expect("exec widgets have a label"),
+            config,
+            base,
+        );
+        let state = ExecState {
+            cmd: exec_cmd,
+            custom_id: custom_id.to_string(),
+            display,
+            prev_classes: Rc::new(RefCell::new(Vec::new())),
+        };
+
+        // Run the exec command once immediately.
+        run_exec(&state);
+
+        if config.interval > 0 {
+            let state_for_timer = state.clone();
+
+            let source_id = glib::timeout_add_seconds_local(
+                u32::try_from(config.interval).unwrap_or(u32::MAX),
+                move || {
+                    run_exec(&state_for_timer);
+                    glib::ControlFlow::Continue
+                },
+            );
+
+            *timer_source.borrow_mut() = Some(source_id);
+        }
+
+        state
+    });
+
+    ExecWiring {
+        state,
+        timer_source,
+        continuous_stop,
+        continuous_pid,
+        continuous_restart_source,
     }
 }
 
@@ -705,8 +839,7 @@ pub struct CustomWidget {
     base: BaseWidget,
     /// Kept alive so custom icon handles remain registered for theme changes
     /// even when no exec closure also owns a clone.
-    #[allow(dead_code)]
-    icon_view: Option<CustomIconView>,
+    _icon_view: Option<CustomIconView>,
     /// Active timer source ID for cancellation on drop (poll mode).
     timer_source: Rc<RefCell<Option<SourceId>>>,
     /// Stop flag for the continuous-mode background reader thread.
@@ -758,168 +891,8 @@ impl CustomWidget {
             base.set_tooltip(tip);
         }
 
-        let static_icon = config.icon.clone();
-        let has_static_image = config.image.is_some();
-
-        let icon_view = if let Some(ref image_path) = config.image {
-            if config.icon.is_some() {
-                warn!(
-                    "Custom widget '{}': both 'image' and 'icon' are set; using 'image'",
-                    custom_id
-                );
-            }
-            if !config.icons.is_empty() {
-                warn!(
-                    "Custom widget '{}': both 'image' and 'icons' are set; dynamic icon mapping \
-                     is ignored because 'image' takes precedence",
-                    custom_id
-                );
-            }
-
-            let resolved = resolve_image_path(image_path);
-
-            if !resolved.starts_with('/') {
-                warn!(
-                    "Custom widget '{}': image path '{}' is not absolute — \
-                     use an absolute path, ~/path, or file:// URI",
-                    custom_id, image_path
-                );
-            } else if !std::path::Path::new(&resolved).exists() {
-                warn!(
-                    "Custom widget '{}': image file '{}' does not exist",
-                    custom_id, resolved
-                );
-            }
-
-            let image = Image::from_file(&resolved);
-            let icon_size = ConfigManager::global().theme_sizes().pixmap_icon_size as i32;
-            image.set_pixel_size(icon_size);
-
-            let icon_root = GtkBox::new(Orientation::Horizontal, 0);
-            icon_root.add_css_class(icon::ROOT);
-            icon_root.set_halign(gtk4::Align::Center);
-            icon_root.set_hexpand(true);
-            image.set_halign(gtk4::Align::Center);
-            icon_root.append(&image);
-            base.content().append(&icon_root);
-
-            None
-        } else if config.icon.is_some() || !config.icons.is_empty() {
-            if let Some(ref icon) = config.icon {
-                warn_invalid_custom_icon_value(custom_id, icon);
-            }
-            for icon in config.icons.values() {
-                warn_invalid_custom_icon_value(custom_id, icon);
-            }
-
-            let view = CustomIconView::new(base.content());
-            view.set_icon(config.icon.as_ref());
-            Some(view)
-        } else {
-            None
-        };
-
-        let label = if !config.label.is_empty() || config.exec.is_some() {
-            let initial_text = if config.label.is_empty() {
-                None
-            } else {
-                Some(config.label.as_str())
-            };
-            let lbl = base.add_label(initial_text, &[]);
-
-            if let Some(max_chars) = config.max_chars {
-                lbl.set_max_width_chars(max_chars);
-                lbl.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-            }
-
-            Some(lbl)
-        } else {
-            None
-        };
-
-        let timer_source = Rc::new(RefCell::new(None));
-
-        let continuous_stop: Option<Arc<AtomicBool>>;
-        let continuous_pid = Arc::new(AtomicU32::new(0));
-        let continuous_restart_source = Rc::new(RefCell::new(None));
-
-        // Continuous mode: spawn long-running process, skip poll setup.
-        let exec_state = if config.continuous {
-            continuous_stop = config
-                .exec
-                .as_ref()
-                .map(|_| Arc::new(AtomicBool::new(false)));
-            if let (Some(exec_cmd), Some(lbl), Some(stop)) =
-                (config.exec, label.clone(), &continuous_stop)
-            {
-                start_continuous(
-                    &exec_cmd,
-                    ContinuousContext {
-                        label: lbl,
-                        icon_view: icon_view.clone(),
-                        icons: config.icons.clone(),
-                        static_icon: static_icon.clone(),
-                        fallback: config.label,
-                        static_tooltip: config.tooltip.clone(),
-                        template: config.template,
-                        custom_id: custom_id.to_string(),
-                        widget: base.widget().clone(),
-                        visibility: base.visibility_handle(),
-                        class_target: base.surface().clone(),
-                        restart_interval: config.restart_interval,
-                        stop_flag: stop.clone(),
-                        pid_slot: continuous_pid.clone(),
-                        restart_times: Rc::new(RefCell::new(Vec::<std::time::Instant>::new())),
-                        restart_source_slot: continuous_restart_source.clone(),
-                        has_static_image,
-                    },
-                );
-            }
-            None // no ExecState needed — continuous manages its own updates
-        } else {
-            // Poll mode
-            continuous_stop = None;
-
-            if let Some(exec_cmd) = config.exec {
-                let state = ExecState {
-                    cmd: exec_cmd,
-                    label: label.clone(),
-                    fallback_text: config.label.clone(),
-                    template: config.template.clone(),
-                    custom_id: custom_id.to_string(),
-                    widget: base.widget().clone(),
-                    visibility: base.visibility_handle(),
-                    class_target: base.surface().clone(),
-                    icon_view: icon_view.clone(),
-                    icons: config.icons.clone(),
-                    static_icon: static_icon.clone(),
-                    static_tooltip: config.tooltip.clone(),
-                    prev_classes: Rc::new(RefCell::new(Vec::new())),
-                    has_static_image,
-                };
-
-                // Run the exec command once immediately.
-                run_exec(&state);
-
-                if config.interval > 0 {
-                    let state_for_timer = state.clone();
-
-                    let source_id = glib::timeout_add_seconds_local(
-                        u32::try_from(config.interval).unwrap_or(u32::MAX),
-                        move || {
-                            run_exec(&state_for_timer);
-                            glib::ControlFlow::Continue
-                        },
-                    );
-
-                    *timer_source.borrow_mut() = Some(source_id);
-                }
-
-                Some(state)
-            } else {
-                None
-            }
-        };
+        let display_widgets = build_display_widgets(custom_id, &config, &base);
+        let exec_wiring = wire_exec(custom_id, &config, &base, &display_widgets);
 
         if let Some(on_click) = config.on_click {
             // Custom widget's own left-click handler. Runs the command, then
@@ -931,7 +904,7 @@ impl CustomWidget {
             click.set_button(gdk::BUTTON_PRIMARY);
             click.connect_released(move |_gesture, _n_press, _x, _y| {
                 let cmd = on_click.to_string();
-                let exec_state = exec_state.clone();
+                let exec_state = exec_wiring.state.clone();
                 let widget_name = click_widget_name.clone();
                 debug!("Custom widget executing: sh -c {}", cmd);
 
@@ -984,11 +957,11 @@ impl CustomWidget {
 
         Self {
             base,
-            icon_view,
-            timer_source,
-            continuous_stop,
-            continuous_pid,
-            continuous_restart_source,
+            _icon_view: display_widgets.icon_view,
+            timer_source: exec_wiring.timer_source,
+            continuous_stop: exec_wiring.continuous_stop,
+            continuous_pid: exec_wiring.continuous_pid,
+            continuous_restart_source: exec_wiring.continuous_restart_source,
         }
     }
 
@@ -1003,12 +976,12 @@ impl Drop for CustomWidget {
         if let Some(source_id) = self.timer_source.borrow_mut().take() {
             source_id.remove();
         }
-        if let Some(source_id) = self.continuous_restart_source.borrow_mut().take() {
-            source_id.remove();
-        }
         // Stop continuous-mode process group (shell + descendants).
         if let Some(ref flag) = self.continuous_stop {
             flag.store(true, Ordering::Relaxed);
+        }
+        if let Some(source_id) = self.continuous_restart_source.borrow_mut().take() {
+            source_id.remove();
         }
         let pid = self.continuous_pid.load(Ordering::Relaxed);
         if pid != 0 {
@@ -1052,24 +1025,10 @@ impl Drop for CustomWidget {
 /// supported field (`text`, `tooltip`, `class`, `alt`, `percentage`) are
 /// auto-detected and applied. Plain text lines work as before.
 fn run_exec(state: &ExecState) {
-    let Some(label) = state.label.as_ref() else {
-        return;
-    };
-
-    let label = label.clone();
-    let fallback_text = state.fallback_text.clone();
-    let template = state.template.clone();
+    let display = state.display.clone();
     let custom_id = state.custom_id.clone();
-    let widget = state.widget.clone();
-    let visibility = state.visibility.clone();
-    let class_target = state.class_target.clone();
     let exec_cmd = state.cmd.clone();
-    let icon_view = state.icon_view.clone();
-    let icons = state.icons.clone();
-    let static_icon = state.static_icon.clone();
-    let static_tooltip = state.static_tooltip.clone();
     let prev_classes = Rc::clone(&state.prev_classes);
-    let has_static_image = state.has_static_image;
 
     glib::spawn_future_local(async move {
         let result = gio::spawn_blocking(move || {
@@ -1145,21 +1104,7 @@ fn run_exec(state: &ExecState) {
 
         match result {
             Ok(Ok(output)) => {
-                apply_output(
-                    &output,
-                    &label,
-                    &fallback_text,
-                    template.as_deref(),
-                    icon_view.as_ref(),
-                    &icons,
-                    static_icon.as_ref(),
-                    static_tooltip.as_deref(),
-                    &widget,
-                    &visibility,
-                    &class_target,
-                    &mut prev_classes.borrow_mut(),
-                    has_static_image,
-                );
+                apply_output(&output, &display, &mut prev_classes.borrow_mut());
             }
             Ok(Err(err)) => {
                 warn!("'custom-{}' exec failed: {}", custom_id, err);
@@ -1180,6 +1125,10 @@ fn run_exec(state: &ExecState) {
 /// Schedule a bounded restart after process exit or spawn failure.
 /// Enforces crash-loop cap ([`MAX_RESTARTS`] per [`RESTART_WINDOW_SECS`]).
 fn schedule_restart(ctx: &ContinuousContext, cmd: &str, reason: &str) {
+    if ctx.stop_flag.load(Ordering::Relaxed) {
+        return;
+    }
+
     let delay = match ctx.restart_interval {
         Some(d) => d,
         None => return,
@@ -1244,7 +1193,7 @@ fn start_continuous(cmd: &str, ctx: ContinuousContext) {
         ctx.custom_id, pid
     );
 
-    let (tx, rx) = std::sync::mpsc::channel::<Option<String>>();
+    let (tx, rx) = async_channel::bounded::<Option<String>>(64);
     let thread_stop = ctx.stop_flag.clone();
     let thread_id = ctx.custom_id.clone();
 
@@ -1254,7 +1203,6 @@ fn start_continuous(cmd: &str, ctx: ContinuousContext) {
         continuous_reader(child, thread_stop, thread_id, tx, reader_pid_slot);
     });
 
-    let rx = Arc::new(Mutex::new(rx));
     let stop = ctx.stop_flag.clone();
     let cmd = cmd.to_string();
 
@@ -1264,36 +1212,21 @@ fn start_continuous(cmd: &str, ctx: ContinuousContext) {
             if stop.load(Ordering::Relaxed) {
                 break;
             }
-            let rx2 = rx.clone();
-            let msg = gio::spawn_blocking(move || rx2.lock().recv().ok().flatten()).await;
+            let msg = rx.recv().await.ok().flatten();
             if stop.load(Ordering::Relaxed) {
                 break;
             }
 
             match msg {
-                Ok(Some(line)) => {
-                    apply_output(
-                        &line,
-                        &ctx.label,
-                        &ctx.fallback,
-                        ctx.template.as_deref(),
-                        ctx.icon_view.as_ref(),
-                        &ctx.icons,
-                        ctx.static_icon.as_ref(),
-                        ctx.static_tooltip.as_deref(),
-                        &ctx.widget,
-                        &ctx.visibility,
-                        &ctx.class_target,
-                        &mut prev_classes,
-                        ctx.has_static_image,
-                    );
+                Some(line) => {
+                    apply_output(&line, &ctx.display, &mut prev_classes);
                 }
                 _ => {
                     // Channel closed — process exited.
                     // Clear CSS classes from the old process so the next
                     // incarnation starts with a clean slate.
                     for c in prev_classes.drain(..) {
-                        ctx.class_target.remove_css_class(&c);
+                        ctx.display.class_target.remove_css_class(&c);
                     }
                     schedule_restart(&ctx, &cmd, "after exit");
                     break;
@@ -1309,7 +1242,7 @@ fn continuous_reader(
     mut child: std::process::Child,
     stop: Arc<AtomicBool>,
     id: String,
-    tx: std::sync::mpsc::Sender<Option<String>>,
+    tx: async_channel::Sender<Option<String>>,
     pid_slot: Arc<AtomicU32>,
 ) {
     use std::io::BufRead;
@@ -1340,7 +1273,7 @@ fn continuous_reader(
             }
             match line {
                 Ok(l) => {
-                    if tx.send(Some(l)).is_err() {
+                    if tx.send_blocking(Some(l)).is_err() {
                         break;
                     }
                 }
@@ -1369,7 +1302,7 @@ fn continuous_reader(
             warn!("'custom-{}' continuous process wait failed: {}", id, e);
         }
     }
-    let _ = tx.send(None); // signal exit before joining stderr
+    let _ = tx.send_blocking(None); // signal exit before joining stderr
     // Drop stderr reader without joining; if a background descendant
     // inherits stderr, the join could block and prevent restart signaling.
     drop(stderr_handle);
@@ -1502,33 +1435,6 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_config_negative_interval_clamped() {
-        let mut options = HashMap::new();
-        options.insert("interval".to_string(), Value::Integer(-5));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert_eq!(config.interval, 0);
-    }
-
-    #[test]
-    fn test_custom_config_max_chars_min_one() {
-        let mut options = HashMap::new();
-        options.insert("max_chars".to_string(), Value::Integer(0));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert_eq!(config.max_chars, Some(1));
-    }
-
-    #[test]
-    fn test_custom_config_ignores_non_string_icon() {
-        let mut options = HashMap::new();
-        options.insert("icon".to_string(), Value::Integer(42));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert!(config.icon.is_none());
-    }
-
-    #[test]
     fn test_custom_config_icon_glyph_parsed() {
         let mut options = HashMap::new();
         options.insert("icon".to_string(), Value::String("glyph:🔋".to_string()));
@@ -1556,21 +1462,6 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_config_icons_ignores_non_string_values() {
-        let mut icons = toml::map::Map::new();
-        icons.insert("dnd".to_string(), Value::String("disabled".to_string()));
-        icons.insert("count".to_string(), Value::Integer(3));
-
-        let mut options = HashMap::new();
-        options.insert("icons".to_string(), Value::Table(icons));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-
-        assert_eq!(config.icons.len(), 1);
-        assert_eq!(config.icons.get("dnd"), Some(&named_icon("disabled")));
-    }
-
-    #[test]
     fn test_custom_config_icons_glyph_value_parsed() {
         let mut icons = toml::map::Map::new();
         icons.insert("unknown".to_string(), Value::String("glyph:?".to_string()));
@@ -1583,60 +1474,6 @@ mod tests {
 
         assert_eq!(config.icons.get("unknown"), Some(&glyph_icon("?")));
         assert_eq!(config.icons.get("dnd"), Some(&named_icon("disabled")));
-    }
-
-    #[test]
-    fn test_custom_config_template_parsed() {
-        let mut options = HashMap::new();
-        options.insert(
-            "template".to_string(),
-            Value::String(" {output}".to_string()),
-        );
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert_eq!(config.template, Some(" {output}".to_string()));
-    }
-
-    #[test]
-    fn test_custom_config_template_ignores_non_string() {
-        let mut options = HashMap::new();
-        options.insert("template".to_string(), Value::Integer(42));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert!(config.template.is_none());
-    }
-
-    #[test]
-    fn test_custom_config_image_parsed() {
-        let mut options = HashMap::new();
-        options.insert(
-            "image".to_string(),
-            Value::String("/usr/share/pixmaps/logo.svg".to_string()),
-        );
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert_eq!(
-            config.image,
-            Some("/usr/share/pixmaps/logo.svg".to_string())
-        );
-    }
-
-    #[test]
-    fn test_custom_config_image_ignores_non_string() {
-        let mut options = HashMap::new();
-        options.insert("image".to_string(), Value::Integer(42));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert!(config.image.is_none());
-    }
-
-    #[test]
-    fn test_custom_config_image_empty_string_is_none() {
-        let mut options = HashMap::new();
-        options.insert("image".to_string(), Value::String("".to_string()));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert!(config.image.is_none());
     }
 
     #[test]
@@ -1656,40 +1493,15 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_image_path_home_tilde() {
-        let result = resolve_image_path("~/icons/logo.png");
-        assert!(!result.starts_with('~'));
-        assert!(result.ends_with("/icons/logo.png"));
-    }
-
-    // --- show_if command tests ---
-
-    #[test]
-    fn test_run_show_if_command_true() {
-        assert!(BaseWidget::run_show_if_command_with_timeout("true"));
-    }
-
-    #[test]
-    fn test_run_show_if_command_false() {
-        assert!(!BaseWidget::run_show_if_command_with_timeout("false"));
-    }
-
-    #[test]
-    fn test_run_show_if_command_nonexistent_binary() {
-        assert!(!BaseWidget::run_show_if_command_with_timeout(
-            "/nonexistent/binary/that/does/not/exist"
-        ));
+    fn test_resolve_image_path_home_relative() {
+        let resolved = resolve_image_path("~/icon.png");
+        match std::env::var("HOME") {
+            Ok(home) => assert_eq!(resolved, format!("{home}/icon.png")),
+            Err(_) => assert_eq!(resolved, "~/icon.png"),
+        }
     }
 
     // --- continuous mode config tests ---
-
-    #[test]
-    fn test_custom_config_continuous_defaults_false() {
-        let entry = make_entry(HashMap::new());
-        let config = CustomConfig::from_entry(&entry);
-        assert!(!config.continuous);
-        assert!(config.restart_interval.is_none());
-    }
 
     #[test]
     fn test_custom_config_continuous_true() {
@@ -1703,18 +1515,9 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_config_restart_interval_zero_is_none() {
+    fn test_custom_config_negative_restart_interval_is_none() {
         let mut options = HashMap::new();
-        options.insert("restart_interval".to_string(), Value::Integer(0));
-        let entry = make_entry(options);
-        let config = CustomConfig::from_entry(&entry);
-        assert!(config.restart_interval.is_none());
-    }
-
-    #[test]
-    fn test_custom_config_restart_interval_negative_is_none() {
-        let mut options = HashMap::new();
-        options.insert("restart_interval".to_string(), Value::Integer(-3));
+        options.insert("restart_interval".to_string(), Value::Integer(-1));
         let entry = make_entry(options);
         let config = CustomConfig::from_entry(&entry);
         assert!(config.restart_interval.is_none());
@@ -1755,12 +1558,6 @@ mod tests {
             try_parse_json(r#"{"percentage":80}"#).unwrap().percentage,
             Some(80.0)
         );
-    }
-
-    #[test]
-    fn test_try_parse_json_with_text() {
-        let out = try_parse_json(r#"{"text":"hello"}"#).unwrap();
-        assert_eq!(out.text.as_deref(), Some("hello"));
     }
 
     #[test]
@@ -1806,28 +1603,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_resolve_icon_exact_match_can_return_glyph() {
-        let icons = BTreeMap::from([("unknown".to_string(), glyph_icon("?"))]);
-        let static_icon = named_icon("static");
-        assert_eq!(
-            resolve_icon(Some("unknown"), &icons, Some(&static_icon)),
-            Some(glyph_icon("?"))
-        );
-    }
-
-    #[test]
-    fn test_try_parse_json_class_single() {
-        let out = try_parse_json(r#"{"text":"x","class":"warning"}"#).unwrap();
-        assert_eq!(out.class.unwrap().into_vec(), vec!["warning"]);
-    }
-
-    #[test]
-    fn test_try_parse_json_class_array() {
-        let out = try_parse_json(r#"{"text":"x","class":["a","b"]}"#).unwrap();
-        assert_eq!(out.class.unwrap().into_vec(), vec!["a", "b"]);
-    }
-
     // --- StringOrVec tests ---
 
     #[test]
@@ -1848,16 +1623,6 @@ mod tests {
     }
 
     // --- expand_template tests ---
-
-    #[test]
-    fn test_expand_template_output() {
-        assert_eq!(expand_template("{output}!", "hello", None), "hello!");
-    }
-
-    #[test]
-    fn test_expand_template_text_alias() {
-        assert_eq!(expand_template("{text}!", "hello", None), "hello!");
-    }
 
     #[test]
     fn test_expand_template_with_exec_output() {
@@ -2047,28 +1812,44 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_output_json_missing_tooltip_clears_when_no_static() {
-        let plan = plan_output(
-            r#"{"text":"x"}"#,
-            "fallback",
-            None,
-            None,
-            &BTreeMap::new(),
-            None,
-            false,
-        );
-
-        assert_eq!(plan.tooltip, None);
-        assert_eq!(plan.classes, Vec::<String>::new());
-    }
-
-    #[test]
     fn test_output_should_show_plain_text_uses_fallback() {
         let with_fallback = plan_output("", "fallback", None, None, &BTreeMap::new(), None, false);
         assert_eq!(with_fallback.label, "fallback");
         assert!(with_fallback.should_show);
         let without_fallback = plan_output("", "", None, None, &BTreeMap::new(), None, false);
         assert!(!without_fallback.should_show);
+    }
+
+    #[test]
+    fn test_output_should_show_empty_plain_text_template_uses_fallback() {
+        let plan = plan_output(
+            "",
+            "fallback",
+            Some("[{output}]"),
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.label, "fallback");
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_output_should_hide_empty_plain_text_template_without_fallback() {
+        let plan = plan_output(
+            "",
+            "",
+            Some("[{output}]"),
+            None,
+            &BTreeMap::new(),
+            None,
+            false,
+        );
+
+        assert_eq!(plan.label, "");
+        assert!(!plan.should_show);
     }
 
     #[test]
@@ -2106,6 +1887,24 @@ mod tests {
         );
 
         assert_eq!(plan.label, "");
+        assert!(plan.should_show);
+    }
+
+    #[test]
+    fn test_output_should_show_json_empty_text_with_static_icon() {
+        let static_icon = named_icon("static-icon");
+        let plan = plan_output(
+            r#"{"text":""}"#,
+            "fallback",
+            None,
+            None,
+            &BTreeMap::new(),
+            Some(&static_icon),
+            false,
+        );
+
+        assert_eq!(plan.label, "");
+        assert_eq!(plan.icon, Some(named_icon("static-icon")));
         assert!(plan.should_show);
     }
 }


### PR DESCRIPTION
Adds Waybar-style JSON output support to custom widgets so Waybar custom scripts can be reused in VibePanel.

Supported JSON fields: `text`, `tooltip`, `class`, `alt`, `percentage`.
`alt` maps through the widget `icons` table. A configured `icon` is used as the fallback when the script does not output `alt`.
```toml
[widgets.custom-weather]
exec = "weather-script --json"
interval = 60
template = "{text} {percentage}%"
icon = "name"

[widgets.custom-weather.icons]
warning = "glyph:󰀦" # prefix with glyph: to use nerd fonts etc, otherwise it resolves a named icon
```

Continuous/streaming scripts are also supported:
```toml
[widgets.custom-monitor]
exec = "stdbuf -oL monitor-script --json"
continuous = true
restart_interval = 5
```

`show_if` no longer re-runs on every exec tick. Set `show_if_interval` if you need periodic re-evaluation.