### PR TITLE
feat(notifications): add configurable notificiations toast position

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,9 @@ background_opacity = 1.0
 #   [widgets.media]
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)
 #
+#   [widgets.notifications]
+#   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
+#
 # Custom widgets use the "custom-" prefix for user-defined buttons:
 #   right = ["custom-power", "custom-os", "tray", "clock"]
 #

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -4,7 +4,7 @@
 //! - Bell icon with unread notification badge
 //! - CSS states: has-notifications, has-critical, backend-unavailable
 //! - Popover with scrollable notification list and dismiss controls
-//! - Toast overlay windows for new notifications (top-right stacked)
+//! - Toast overlay windows for new notifications (configurable screen position)
 //!
 //! This module is split into several files for maintainability:
 //! - `notifications.rs` (this file): Widget implementation and badge logic
@@ -19,7 +19,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::debug;
+use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
@@ -28,18 +28,38 @@ use crate::services::notification::{NotificationService, URGENCY_CRITICAL};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::widget;
 use crate::widgets::base::MenuHandle;
-use crate::widgets::{BaseWidget, WidgetConfig};
+use crate::widgets::{BaseWidget, WidgetConfig, warn_unknown_options};
 
 use super::notifications_popover::{ClosePopoverCallback, build_popover_content};
-use super::notifications_toast::NotificationToastManager;
+use super::notifications_toast::{NotificationToastManager, ToastPosition};
 
 /// Configuration for the notification widget.
 #[derive(Debug, Clone, Default)]
-pub struct NotificationsConfig {}
+pub struct NotificationsConfig {
+    toast_position: ToastPosition,
+}
 
 impl WidgetConfig for NotificationsConfig {
-    fn from_entry(_entry: &WidgetEntry) -> Self {
-        Self {}
+    fn from_entry(entry: &WidgetEntry) -> Self {
+        warn_unknown_options("notifications", entry, &["toast_position"]);
+
+        let toast_position = entry
+            .options
+            .get("toast_position")
+            .and_then(|v| v.as_str())
+            .and_then(|value| {
+                let position = ToastPosition::parse(value);
+                if position.is_none() {
+                    warn!(
+                        "Invalid toast_position '{}' for widget 'notifications' - expected one of: top-right, top-center, top-left, bottom-right, bottom-center, bottom-left; using top-right",
+                        value
+                    );
+                }
+                position
+            })
+            .unwrap_or_default();
+
+        Self { toast_position }
     }
 }
 
@@ -262,9 +282,10 @@ impl NotificationsWidgetInner {
             // proper initialization with callbacks.
 
             if let (Some(toast_manager), Some(app)) = (&*self.toast_manager.borrow(), app) {
+                let monitor = self.toast_monitor();
                 for id in &to_toast {
                     if let Some(notification) = service.get(*id) {
-                        toast_manager.show(&app, &notification);
+                        toast_manager.show(&app, monitor.as_ref(), &notification);
                     }
                 }
             }
@@ -291,6 +312,17 @@ impl NotificationsWidgetInner {
         Some(app)
     }
 
+    fn toast_monitor(&self) -> Option<gtk4::gdk::Monitor> {
+        self.container
+            .root()
+            .and_then(|root| root.downcast_ref::<gtk4::Window>().cloned())
+            .and_then(|window| window.surface())
+            .and_then(|surface| {
+                gtk4::gdk::Display::default()
+                    .and_then(|display| display.monitor_at_surface(&surface))
+            })
+    }
+
     /// Mark notifications as seen (called when popover opens).
     fn mark_as_seen(&self) {
         let now = SystemTime::now()
@@ -314,7 +346,7 @@ pub struct NotificationsWidget {
 
 impl NotificationsWidget {
     /// Create a new notification widget.
-    pub fn new(_config: NotificationsConfig) -> Self {
+    pub fn new(config: NotificationsConfig) -> Self {
         let base = BaseWidget::new(&[widget::NOTIFICATIONS]);
 
         // Create an overlay for badge on top of icon
@@ -409,7 +441,8 @@ impl NotificationsWidget {
                 });
             };
 
-            let manager = NotificationToastManager::new(on_action, on_toast_removed);
+            let manager =
+                NotificationToastManager::new(on_action, on_toast_removed, config.toast_position);
             *inner.toast_manager.borrow_mut() = Some(manager);
         }
 

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -19,8 +19,8 @@ pub const TOAST_TIMEOUT_CRITICAL_MS: u32 = 0;
 /// Estimated height per toast (including padding/margins) for stack positioning
 pub const TOAST_ESTIMATED_HEIGHT: i32 = 85;
 pub const TOAST_GAP: i32 = 4;
-pub const TOAST_BAR_MARGIN: i32 = 10;
-pub const TOAST_MARGIN_RIGHT: i32 = 10;
+pub const TOAST_EDGE_MARGIN: i32 = 10;
+pub const TOAST_SIDE_MARGIN: i32 = 10;
 
 /// Popover dimensions
 pub const POPOVER_WIDTH: i32 = 400;

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -81,6 +81,25 @@ fn calculate_center_margin(monitor_width: i32, window_width: i32) -> i32 {
     ((monitor_width - window_width) / 2).max(0)
 }
 
+fn toast_horizontal_layout(
+    position: ToastPosition,
+    monitor_width: Option<i32>,
+    side_margin: i32,
+) -> (Option<Edge>, i32) {
+    if position.is_centered() {
+        return monitor_width
+            .map(|width| {
+                (
+                    Some(Edge::Left),
+                    calculate_center_margin(width, POPOVER_WIDTH),
+                )
+            })
+            .unwrap_or((None, 0));
+    }
+
+    (position.horizontal_edge(), side_margin)
+}
+
 struct ToastWindowContext<'a> {
     app: &'a Application,
     monitor: Option<&'a gdk::Monitor>,
@@ -130,11 +149,6 @@ impl NotificationToast {
 
         let layout = context.layout;
         let vertical_edge = layout.position.vertical_edge();
-        let horizontal_edge = if layout.position.is_centered() && context.monitor.is_some() {
-            Some(Edge::Left)
-        } else {
-            layout.position.horizontal_edge()
-        };
 
         // Initialize layer shell
         window.init_layer_shell();
@@ -149,22 +163,20 @@ impl NotificationToast {
 
         window.set_anchor(Edge::Top, vertical_edge == Edge::Top);
         window.set_anchor(Edge::Bottom, vertical_edge == Edge::Bottom);
+        let side_margin = (TOAST_MARGIN_RIGHT
+            - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
+        .max(0);
+        let (horizontal_edge, horizontal_margin) = toast_horizontal_layout(
+            layout.position,
+            context.monitor.map(|m| m.geometry().width()),
+            side_margin,
+        );
+
         window.set_anchor(Edge::Left, horizontal_edge == Some(Edge::Left));
         window.set_anchor(Edge::Right, horizontal_edge == Some(Edge::Right));
-
         window.set_margin(vertical_edge, layout.initial_margin);
         if let Some(horizontal_edge) = horizontal_edge {
-            let side_margin = if layout.position.is_centered() {
-                context
-                    .monitor
-                    .map(|m| calculate_center_margin(m.geometry().width(), POPOVER_WIDTH))
-                    .unwrap_or(0)
-            } else {
-                (TOAST_MARGIN_RIGHT
-                    - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
-                .max(0)
-            };
-            window.set_margin(horizontal_edge, side_margin);
+            window.set_margin(horizontal_edge, horizontal_margin);
         }
 
         let notification_id = notification.id;

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -27,8 +27,8 @@ use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{button, color, notification as notif};
 
 use super::notifications_common::{
-    POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_BAR_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
-    TOAST_MARGIN_RIGHT, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
+    POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_EDGE_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
+    TOAST_SIDE_MARGIN, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
     create_notification_image_widget, sanitize_body_markup,
 };
 
@@ -163,7 +163,7 @@ impl NotificationToast {
 
         window.set_anchor(Edge::Top, vertical_edge == Edge::Top);
         window.set_anchor(Edge::Bottom, vertical_edge == Edge::Bottom);
-        let side_margin = (TOAST_MARGIN_RIGHT
+        let side_margin = (TOAST_SIDE_MARGIN
             - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
         .max(0);
         let (horizontal_edge, horizontal_margin) = toast_horizontal_layout(
@@ -659,7 +659,7 @@ impl NotificationToastManager {
         let initial_margin = {
             let order = self.toast_order.borrow();
             let toasts = self.toasts.borrow();
-            let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
+            let mut y_offset = (TOAST_EDGE_MARGIN - sm).max(0);
             for &id in order.iter() {
                 if let Some(toast) = toasts.get(&id) {
                     y_offset += (toast.height() - 2 * sm).max(0) + TOAST_GAP;
@@ -713,7 +713,7 @@ impl NotificationToastManager {
         let order = self.toast_order.borrow();
         let toasts = self.toasts.borrow();
         let sm = SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN);
-        let mut y_offset = (TOAST_BAR_MARGIN - sm).max(0);
+        let mut y_offset = (TOAST_EDGE_MARGIN - sm).max(0);
         for &id in order.iter() {
             if let Some(toast) = toasts.get(&id) {
                 toast.update_bar_margin(y_offset, ConfigManager::global().animations_enabled());

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -1,13 +1,12 @@
 //! Notification toast windows for displaying new notifications.
 //!
 //! This module handles floating toast windows that appear when new notifications
-//! arrive. Toasts stack vertically on the bar-adjacent edge (top-right when bar
-//! is at top, bottom-right when bar is at bottom) and auto-dismiss after a
-//! timeout (except for critical notifications).
+//! arrive. Toasts stack vertically from the configured screen edge and
+//! auto-dismiss after a timeout (except for critical notifications).
 
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
-use gtk4::{Align, Application, Box as GtkBox, Button, Image, Label, Orientation, Window};
+use gtk4::{Align, Application, Box as GtkBox, Button, Image, Label, Orientation, Window, gdk};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -17,7 +16,6 @@ use tracing::debug;
 use crate::services::notification::{
     Notification, NotificationService, URGENCY_CRITICAL, URGENCY_LOW,
 };
-use vibepanel_core::config::BarPosition;
 
 /// Type alias for toast notification callbacks.
 type ToastCallback = Rc<dyn Fn(u32)>;
@@ -33,6 +31,67 @@ use super::notifications_common::{
     TOAST_MARGIN_RIGHT, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
     create_notification_image_widget, sanitize_body_markup,
 };
+
+/// Configurable screen position for notification toasts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum ToastPosition {
+    #[default]
+    TopRight,
+    TopCenter,
+    TopLeft,
+    BottomRight,
+    BottomCenter,
+    BottomLeft,
+}
+
+impl ToastPosition {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "top-right" => Some(Self::TopRight),
+            "top-center" => Some(Self::TopCenter),
+            "top-left" => Some(Self::TopLeft),
+            "bottom-right" => Some(Self::BottomRight),
+            "bottom-center" => Some(Self::BottomCenter),
+            "bottom-left" => Some(Self::BottomLeft),
+            _ => None,
+        }
+    }
+
+    fn vertical_edge(self) -> Edge {
+        match self {
+            Self::TopRight | Self::TopCenter | Self::TopLeft => Edge::Top,
+            Self::BottomRight | Self::BottomCenter | Self::BottomLeft => Edge::Bottom,
+        }
+    }
+
+    fn horizontal_edge(self) -> Option<Edge> {
+        match self {
+            Self::TopRight | Self::BottomRight => Some(Edge::Right),
+            Self::TopLeft | Self::BottomLeft => Some(Edge::Left),
+            Self::TopCenter | Self::BottomCenter => None,
+        }
+    }
+
+    fn is_centered(self) -> bool {
+        matches!(self, Self::TopCenter | Self::BottomCenter)
+    }
+}
+
+fn calculate_center_margin(monitor_width: i32, window_width: i32) -> i32 {
+    ((monitor_width - window_width) / 2).max(0)
+}
+
+struct ToastWindowContext<'a> {
+    app: &'a Application,
+    monitor: Option<&'a gdk::Monitor>,
+    layout: ToastLayout,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ToastLayout {
+    position: ToastPosition,
+    initial_margin: i32,
+}
 
 /// Floating toast window for displaying a single notification.
 pub(super) struct NotificationToast {
@@ -52,17 +111,16 @@ impl NotificationToast {
     const ANIMATION_DURATION_MS: i32 = 150;
     const ANIMATION_STEP_MS: u32 = 16; // ~60fps
 
-    pub fn new(
-        app: &Application,
+    fn new(
+        context: ToastWindowContext<'_>,
         notification: &Notification,
         on_dismiss: ToastCallback,
         on_action: ToastActionCallback,
         on_timeout: ToastCallback,
         on_height_measured: ToastCallback,
-        initial_margin: i32,
     ) -> Rc<Self> {
         let window = Window::builder()
-            .application(app)
+            .application(context.app)
             .decorated(false)
             .resizable(false)
             .default_width(POPOVER_WIDTH)
@@ -70,9 +128,13 @@ impl NotificationToast {
 
         window.add_css_class(notif::TOAST_WRAPPER);
 
-        // Determine bar position for toast anchoring
-        let is_bottom = ConfigManager::global().bar_position() == BarPosition::Bottom;
-        let bar_edge = if is_bottom { Edge::Bottom } else { Edge::Top };
+        let layout = context.layout;
+        let vertical_edge = layout.position.vertical_edge();
+        let horizontal_edge = if layout.position.is_centered() && context.monitor.is_some() {
+            Some(Edge::Left)
+        } else {
+            layout.position.horizontal_edge()
+        };
 
         // Initialize layer shell
         window.init_layer_shell();
@@ -81,28 +143,38 @@ impl NotificationToast {
         window.set_exclusive_zone(0);
         window.set_keyboard_mode(KeyboardMode::None);
 
-        // Anchor to bar-edge + right
-        window.set_anchor(bar_edge, true);
-        window.set_anchor(Edge::Right, true);
-        window.set_anchor(Edge::Left, false);
-        // Ensure opposite edge is unanchored
-        let opposite_edge = if is_bottom { Edge::Top } else { Edge::Bottom };
-        window.set_anchor(opposite_edge, false);
+        if let Some(monitor) = context.monitor {
+            window.set_monitor(Some(monitor));
+        }
 
-        window.set_margin(bar_edge, initial_margin);
-        let right_margin = (TOAST_MARGIN_RIGHT
-            - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
-        .max(0);
-        window.set_margin(Edge::Right, right_margin);
+        window.set_anchor(Edge::Top, vertical_edge == Edge::Top);
+        window.set_anchor(Edge::Bottom, vertical_edge == Edge::Bottom);
+        window.set_anchor(Edge::Left, horizontal_edge == Some(Edge::Left));
+        window.set_anchor(Edge::Right, horizontal_edge == Some(Edge::Right));
+
+        window.set_margin(vertical_edge, layout.initial_margin);
+        if let Some(horizontal_edge) = horizontal_edge {
+            let side_margin = if layout.position.is_centered() {
+                context
+                    .monitor
+                    .map(|m| calculate_center_margin(m.geometry().width(), POPOVER_WIDTH))
+                    .unwrap_or(0)
+            } else {
+                (TOAST_MARGIN_RIGHT
+                    - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
+                .max(0)
+            };
+            window.set_margin(horizontal_edge, side_margin);
+        }
 
         let notification_id = notification.id;
         let toast = Rc::new(Self {
             window,
             notification_id,
             timeout_source: RefCell::new(None),
-            current_bar_margin: Cell::new(initial_margin),
+            current_bar_margin: Cell::new(layout.initial_margin),
             animation_source: RefCell::new(None),
-            bar_edge,
+            bar_edge: vertical_edge,
             height: Cell::new(TOAST_ESTIMATED_HEIGHT),
             theme_callback_guard: RefCell::new(None),
         });
@@ -495,22 +567,30 @@ pub(super) struct NotificationToastManager {
     toast_order: RefCell<Vec<u32>>,
     on_action: ToastActionCallback,
     on_toast_removed: Rc<dyn Fn()>,
+    position: ToastPosition,
 }
 
 impl NotificationToastManager {
     pub fn new(
         on_action: impl Fn(u32, &str) + 'static,
         on_toast_removed: impl Fn() + 'static,
+        position: ToastPosition,
     ) -> Rc<Self> {
         Rc::new(Self {
             toasts: RefCell::new(HashMap::new()),
             toast_order: RefCell::new(Vec::new()),
             on_action: Rc::new(on_action),
             on_toast_removed: Rc::new(on_toast_removed),
+            position,
         })
     }
 
-    pub fn show(self: &Rc<Self>, app: &Application, notification: &Notification) {
+    pub fn show(
+        self: &Rc<Self>,
+        app: &Application,
+        monitor: Option<&gdk::Monitor>,
+        notification: &Notification,
+    ) {
         // Transient notifications must be removed from the service when their toast
         // disappears (dismiss or timeout) so they never leak into the popover
         // history. Close the service entry *before* tearing down the toast so the
@@ -577,13 +657,19 @@ impl NotificationToastManager {
         };
 
         let toast = NotificationToast::new(
-            app,
+            ToastWindowContext {
+                app,
+                monitor,
+                layout: ToastLayout {
+                    position: self.position,
+                    initial_margin,
+                },
+            },
             notification,
             on_dismiss,
             Rc::clone(&self.on_action),
             on_timeout,
             on_height_measured,
-            initial_margin,
         );
 
         self.toasts

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -77,6 +77,73 @@ fn test_calculate_center_margin_contract() {
 }
 
 #[test]
+fn test_toast_horizontal_layout_contract() {
+    let side_margin = 8;
+    let cases = [
+        (
+            ToastPosition::TopRight,
+            None,
+            Some(Edge::Right),
+            side_margin,
+        ),
+        (
+            ToastPosition::TopRight,
+            Some(1920),
+            Some(Edge::Right),
+            side_margin,
+        ),
+        (ToastPosition::TopLeft, None, Some(Edge::Left), side_margin),
+        (
+            ToastPosition::TopLeft,
+            Some(1920),
+            Some(Edge::Left),
+            side_margin,
+        ),
+        (
+            ToastPosition::BottomRight,
+            None,
+            Some(Edge::Right),
+            side_margin,
+        ),
+        (
+            ToastPosition::BottomRight,
+            Some(1920),
+            Some(Edge::Right),
+            side_margin,
+        ),
+        (
+            ToastPosition::BottomLeft,
+            None,
+            Some(Edge::Left),
+            side_margin,
+        ),
+        (
+            ToastPosition::BottomLeft,
+            Some(1920),
+            Some(Edge::Left),
+            side_margin,
+        ),
+        (ToastPosition::TopCenter, None, None, 0),
+        (ToastPosition::TopCenter, Some(1920), Some(Edge::Left), 760),
+        (ToastPosition::BottomCenter, None, None, 0),
+        (
+            ToastPosition::BottomCenter,
+            Some(1920),
+            Some(Edge::Left),
+            760,
+        ),
+    ];
+
+    for (position, monitor_width, expected_edge, expected_margin) in cases {
+        assert_eq!(
+            toast_horizontal_layout(position, monitor_width, side_margin),
+            (expected_edge, expected_margin),
+            "unexpected horizontal layout for {position:?} with monitor_width={monitor_width:?}"
+        );
+    }
+}
+
+#[test]
 fn test_notification_toast_critical_class_does_not_apply_visual_tokens() {
     let css = crate::widgets::css::widget_css(&Config::default());
 

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -40,6 +40,43 @@ fn run_toast_ui_regression_subprocess(test_case: &str) {
 }
 
 #[test]
+fn test_toast_position_parse_contract() {
+    assert_eq!(
+        ToastPosition::parse("top-right"),
+        Some(ToastPosition::TopRight)
+    );
+    assert_eq!(
+        ToastPosition::parse("top-center"),
+        Some(ToastPosition::TopCenter)
+    );
+    assert_eq!(
+        ToastPosition::parse("top-left"),
+        Some(ToastPosition::TopLeft)
+    );
+    assert_eq!(
+        ToastPosition::parse("bottom-right"),
+        Some(ToastPosition::BottomRight)
+    );
+    assert_eq!(
+        ToastPosition::parse("bottom-center"),
+        Some(ToastPosition::BottomCenter)
+    );
+    assert_eq!(
+        ToastPosition::parse("bottom-left"),
+        Some(ToastPosition::BottomLeft)
+    );
+    assert_eq!(ToastPosition::parse("auto"), None);
+    assert_eq!(ToastPosition::default(), ToastPosition::TopRight);
+}
+
+#[test]
+fn test_calculate_center_margin_contract() {
+    assert_eq!(calculate_center_margin(1920, POPOVER_WIDTH), 760);
+    assert_eq!(calculate_center_margin(400, POPOVER_WIDTH), 0);
+    assert_eq!(calculate_center_margin(320, POPOVER_WIDTH), 0);
+}
+
+#[test]
 fn test_notification_toast_critical_class_does_not_apply_visual_tokens() {
     let css = crate::widgets::css::widget_css(&Config::default());
 
@@ -266,10 +303,18 @@ fn test_notification_toast_structure_contract() {
     }
 
     let app = test_app();
-    for position in ["top", "bottom"] {
+    let cases = [
+        (ToastPosition::TopRight, Edge::Top, Some(Edge::Right)),
+        (ToastPosition::TopCenter, Edge::Top, None),
+        (ToastPosition::TopLeft, Edge::Top, Some(Edge::Left)),
+        (ToastPosition::BottomRight, Edge::Bottom, Some(Edge::Right)),
+        (ToastPosition::BottomCenter, Edge::Bottom, None),
+        (ToastPosition::BottomLeft, Edge::Bottom, Some(Edge::Left)),
+    ];
+
+    for (position, vertical_edge, horizontal_edge) in cases {
         let mut config = Config::default();
         config.theme.mode = "dark".to_string();
-        config.bar.position = position.to_string();
         config.advanced.compositor = "mango".to_string();
         ConfigManager::replace_global_for_test(config.clone());
         let _css_provider =
@@ -286,13 +331,19 @@ fn test_notification_toast_structure_contract() {
         let noop_timeout: ToastCallback = Rc::new(|_| {});
         let noop_height: ToastCallback = Rc::new(|_| {});
         let toast = NotificationToast::new(
-            &app,
+            ToastWindowContext {
+                app: &app,
+                monitor: None,
+                layout: ToastLayout {
+                    position,
+                    initial_margin: TOAST_BAR_MARGIN,
+                },
+            },
             &notification,
             noop_dismiss,
             noop_action,
             noop_timeout,
             noop_height,
-            TOAST_BAR_MARGIN,
         );
         toast.present();
         flush_gtk();
@@ -303,17 +354,7 @@ fn test_notification_toast_structure_contract() {
             .expect("toast window should contain a styled surface");
         let container = find_descendant_with_class(&child, notif::TOAST_CONTAINER)
             .expect("toast should render a styled notification container");
-        let bar_edge = if position == "bottom" {
-            Edge::Bottom
-        } else {
-            Edge::Top
-        };
-        let opposite_edge = if position == "bottom" {
-            Edge::Top
-        } else {
-            Edge::Bottom
-        };
-        let right_margin = (TOAST_MARGIN_RIGHT
+        let side_margin = (TOAST_MARGIN_RIGHT
             - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
         .max(0);
 
@@ -322,12 +363,39 @@ fn test_notification_toast_structure_contract() {
         assert_eq!(toast.window.layer(), Layer::Overlay);
         assert_eq!(toast.window.keyboard_mode(), KeyboardMode::None);
         assert_eq!(toast.window.exclusive_zone(), 0);
-        assert!(toast.window.is_anchor(bar_edge));
-        assert!(toast.window.is_anchor(Edge::Right));
-        assert!(!toast.window.is_anchor(Edge::Left));
-        assert!(!toast.window.is_anchor(opposite_edge));
-        assert_eq!(toast.window.margin(bar_edge), TOAST_BAR_MARGIN);
-        assert_eq!(toast.window.margin(Edge::Right), right_margin);
+        assert_eq!(
+            toast.window.is_anchor(Edge::Top),
+            vertical_edge == Edge::Top
+        );
+        assert_eq!(
+            toast.window.is_anchor(Edge::Bottom),
+            vertical_edge == Edge::Bottom
+        );
+        assert_eq!(
+            toast.window.is_anchor(Edge::Left),
+            horizontal_edge == Some(Edge::Left)
+        );
+        assert_eq!(
+            toast.window.is_anchor(Edge::Right),
+            horizontal_edge == Some(Edge::Right)
+        );
+        assert_eq!(toast.window.margin(vertical_edge), TOAST_BAR_MARGIN);
+        assert_eq!(
+            toast.window.margin(Edge::Left),
+            if horizontal_edge == Some(Edge::Left) {
+                side_margin
+            } else {
+                0
+            }
+        );
+        assert_eq!(
+            toast.window.margin(Edge::Right),
+            if horizontal_edge == Some(Edge::Right) {
+                side_margin
+            } else {
+                0
+            }
+        );
 
         assert!(toast.window.has_css_class(notif::TOAST_WRAPPER));
         assert!(container.has_css_class(notif::TOAST));

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -403,7 +403,7 @@ fn test_notification_toast_structure_contract() {
                 monitor: None,
                 layout: ToastLayout {
                     position,
-                    initial_margin: TOAST_BAR_MARGIN,
+                    initial_margin: TOAST_EDGE_MARGIN,
                 },
             },
             &notification,
@@ -421,7 +421,7 @@ fn test_notification_toast_structure_contract() {
             .expect("toast window should contain a styled surface");
         let container = find_descendant_with_class(&child, notif::TOAST_CONTAINER)
             .expect("toast should render a styled notification container");
-        let side_margin = (TOAST_MARGIN_RIGHT
+        let side_margin = (TOAST_SIDE_MARGIN
             - SurfaceStyleManager::global().shadow_margin(SURFACE_SHADOW_MARGIN))
         .max(0);
 
@@ -446,7 +446,7 @@ fn test_notification_toast_structure_contract() {
             toast.window.is_anchor(Edge::Right),
             horizontal_edge == Some(Edge::Right)
         );
-        assert_eq!(toast.window.margin(vertical_edge), TOAST_BAR_MARGIN);
+        assert_eq!(toast.window.margin(vertical_edge), TOAST_EDGE_MARGIN);
         assert_eq!(
             toast.window.margin(Edge::Left),
             if horizontal_edge == Some(Edge::Left) {


### PR DESCRIPTION
Adds configurable notification toast positioning via `toast_position`, supporting top/bottom + left/center/right placements. Toast placement is now independent of bar position, and `top-right` is the default for all modes.

```toml
[widgets.notifications]
toast_position = "top-right"
```

The options are `top-left`, `top-center`, `top-right`, `bottom-left`, bottom-center`, `bottom-right`

Fixes #143 