### PR TITLE
feat: set font scale from toml and widget scoped vars

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -91,6 +91,10 @@ mode = "dark" # "auto", "dark", "light", "gtk"
 #outline_color = "accent"    # "subtle" | "accent" | "foreground" | "#rrggbb"
 #outline_opacity = 1.0        # 0.0 = transparent, 1.0 = opaque
 
+[theme.typography]
+# font_family = "monospace" # Empty string inherits the system font
+# font_scale = 0.6          # Text size as a multiplier of widget height
+
 [theme.icons]
 theme = "material" # "material" or "gtk"
 weight = 400       # Material icon stroke weight (100-700)

--- a/crates/vibepanel-core/src/config.rs
+++ b/crates/vibepanel-core/src/config.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use toml::Table;
 
 use crate::error::{Error, Result};
+use crate::theme::DEFAULT_FONT_SCALE;
 
 /// Known valid values for advanced.compositor.
 const VALID_COMPOSITORS: &[&str] = &[
@@ -55,6 +56,10 @@ const VALID_OUTLINE_COLOR_SYMBOLS: &[&str] = &["subtle", "accent", "foreground"]
 /// Outlines are intended for visual edge definition (1px is the typical case);
 /// thicker decorative borders should be done via user CSS.
 const MAX_OUTLINE_WIDTH: u32 = 4;
+
+/// Supported typography scale range.
+const MIN_FONT_SCALE: f64 = 0.1;
+const MAX_FONT_SCALE: f64 = 1.0;
 
 /// Validate an outline color value against the symbolic + hex contract.
 ///
@@ -428,6 +433,13 @@ impl Config {
             ));
         }
 
+        if !(MIN_FONT_SCALE..=MAX_FONT_SCALE).contains(&self.theme.typography.font_scale) {
+            errors.push(format!(
+                "theme.typography.font_scale: invalid value '{}', must be between {} and {}",
+                self.theme.typography.font_scale, MIN_FONT_SCALE, MAX_FONT_SCALE
+            ));
+        }
+
         // Per-widget outline_color validation
         for (name, opts) in &self.widgets.widget_configs {
             if let Some(ref color) = opts.outline_color
@@ -604,6 +616,10 @@ impl Config {
         lines.push(format!(
             "  font_family: {}",
             self.theme.typography.font_family
+        ));
+        lines.push(format!(
+            "  font_scale: {}",
+            self.theme.typography.font_scale
         ));
         lines.push(format!("  icon_theme: {}", self.theme.icons.theme));
         lines.push(format!("  icon_weight: {}", self.theme.icons.weight));
@@ -1439,12 +1455,16 @@ impl Default for ThemeStates {
 pub struct ThemeTypography {
     /// Base font family.
     pub font_family: String,
+
+    /// Font size as a multiplier of widget height.
+    pub font_scale: f64,
 }
 
 impl Default for ThemeTypography {
     fn default() -> Self {
         Self {
             font_family: "monospace".to_string(),
+            font_scale: DEFAULT_FONT_SCALE,
         }
     }
 }
@@ -1537,6 +1557,7 @@ mod tests {
         assert_eq!(config.theme.mode, "auto");
         assert!(config.theme.accent.is_none());
         assert_eq!(config.theme.typography.font_family, "monospace");
+        assert_eq!(config.theme.typography.font_scale, DEFAULT_FONT_SCALE);
         assert_eq!(config.theme.icons.theme, "material");
         assert_eq!(config.theme.icons.weight, 400);
     }
@@ -2678,6 +2699,7 @@ mod tests {
                 &|c| c.theme.outline_color = "rebeccapurple".to_string(),
                 "outline_color",
             ),
+            (&|c| c.theme.typography.font_scale = 1.1, "font_scale"),
         ];
         for (mutate, field) in cases {
             let mut config = Config::default();

--- a/crates/vibepanel-core/src/theme.rs
+++ b/crates/vibepanel-core/src/theme.rs
@@ -70,7 +70,7 @@ const DEFAULT_FONT_FAMILY: &str = "monospace";
 const WIDGET_HOVER_BG_VALUE: &str = "color-mix(in srgb, color-mix(in srgb, var(--widget-background-color) var(--widget-background-opacity), transparent) 92%, var(--widget-hover-tint))";
 
 // Size scaling factors (empirically tuned for visual balance at bar sizes 28-60px)
-const FONT_SCALE: f64 = 0.6;
+pub const DEFAULT_FONT_SCALE: f64 = 0.6;
 const TEXT_ICON_SCALE: f64 = 0.50;
 const PIXMAP_ICON_SCALE: f64 = 0.50;
 const PADDING_SCALE: f64 = 0.14;
@@ -387,6 +387,7 @@ pub struct ThemePalette {
 
     // Typography
     pub font_family: String,
+    pub font_scale: f64,
 
     // Opacities
     pub bar_opacity: f64,
@@ -860,7 +861,7 @@ impl ThemePalette {
             widget_content_gap_vertical = self.sizes.widget_content_gap_vertical,
             widget_opacity = self.widget_opacity,
             font_family = self.font_family,
-            font_scale = FONT_SCALE,
+            font_scale = self.font_scale,
             text_icon_size = self.sizes.text_icon_size,
             pixmap_icon_size = self.sizes.pixmap_icon_size,
         )
@@ -1131,6 +1132,7 @@ impl ThemePalette {
         } else {
             config.theme.typography.font_family.clone()
         };
+        self.font_scale = config.theme.typography.font_scale;
 
         // Radii percentages (now directly on bar/widgets)
         self.bar_radius_percent = config.bar.border_radius;
@@ -1467,7 +1469,7 @@ impl ThemePalette {
 
         // Sizes - ensure vertical-related sizes are even for proper centering
         let internal_spacing = (bar_size as f64 * SPACING_SCALE) as u32;
-        let font_size = round_to_even((widget_height as f64 * FONT_SCALE) as u32);
+        let font_size = round_to_even((widget_height as f64 * self.font_scale) as u32);
         let text_icon_size = round_to_even((bar_size as f64 * TEXT_ICON_SCALE) as u32);
         let pixmap_icon_size = round_to_even((bar_size as f64 * PIXMAP_ICON_SCALE) as u32);
 
@@ -1532,6 +1534,7 @@ impl Default for ThemePalette {
             slider_track_disabled: String::new(),
             row_critical_background: String::new(),
             font_family: DEFAULT_FONT_FAMILY.to_string(),
+            font_scale: DEFAULT_FONT_SCALE,
             bar_opacity: 0.0,
             widget_opacity: 1.0,
             popover_opacity: None,
@@ -1679,6 +1682,23 @@ mod tests {
         assert!(css.contains("--radius-bar:"));
         assert!(css.contains("--widget-height:"));
         assert!(css.contains("--font-family:"));
+    }
+
+    #[test]
+    fn test_configured_font_scale_controls_font_size() {
+        let mut config = Config::default();
+        config.bar.size = 40;
+        config.theme.typography.font_scale = 0.5;
+
+        let palette = ThemePalette::from_config(&config, None, None);
+        let css = palette.css_vars_block();
+
+        assert_eq!(palette.font_scale, 0.5);
+        assert_eq!(
+            palette.sizes.font_size,
+            round_to_even((palette.sizes.widget_height as f64 * 0.5) as u32)
+        );
+        assert_eq!(css_var_value(&css, "--font-scale"), Some("0.5"));
     }
 
     #[test]

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1437,6 +1437,51 @@ fn run_test_widgets_scoped_content_spacing_contract() {
     );
 }
 
+fn custom_widget_surface_widths(override_css: Option<&str>) -> (i32, i32) {
+    let mut config = test_config();
+    for widget_name in ["custom-a", "custom-b"] {
+        config
+            .widgets
+            .widget_configs
+            .entry(widget_name.to_string())
+            .or_default()
+            .options
+            .insert(
+                "label".to_string(),
+                toml::Value::String("MMMMMMMMMMMM".to_string()),
+            );
+    }
+
+    let fixture = painted_bar_fixture_with_override_css(&config, override_css);
+    let first_bounds = bounds_in_window(&fixture.first_surface, &fixture.window);
+    let second_bounds = bounds_in_window(&fixture.second_surface, &fixture.window);
+
+    fixture.window.close();
+    flush_gtk();
+
+    (first_bounds.2, second_bounds.2)
+}
+
+fn run_test_widgets_scoped_font_scale_contract() {
+    let (baseline_first, baseline_second) = custom_widget_surface_widths(None);
+    assert_eq!(
+        baseline_first, baseline_second,
+        "same-label custom widgets should start with matching widths"
+    );
+
+    let (scaled_first, scaled_second) =
+        custom_widget_surface_widths(Some(".custom-a { --font-scale: 0.1; }"));
+
+    assert!(
+        scaled_first < baseline_first / 2,
+        "widget-scoped --font-scale should shrink only the targeted widget width"
+    );
+    assert_eq!(
+        scaled_second, baseline_second,
+        "widget-scoped --font-scale should not affect adjacent widgets"
+    );
+}
+
 fn run_test_widgets_background_color_pixel() {
     let color = "#445566";
     let mut config = test_config();
@@ -2143,6 +2188,11 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_scoped_content_spacing,
         "widgets.scoped-content-spacing",
         run_test_widgets_scoped_content_spacing_contract
+    ),
+    (
+        test_ui_regression_widgets_scoped_font_scale,
+        "widgets.scoped-font-scale",
+        run_test_widgets_scoped_font_scale_contract
     ),
     (
         test_ui_regression_widgets_background_color_pixel,

--- a/crates/vibepanel/src/widgets/css/bar.rs
+++ b/crates/vibepanel/src/widgets/css/bar.rs
@@ -123,6 +123,8 @@ sectioned-bar.bar.bar--vertical {{
 .widget:not(.widget-group) > overlay > .content {{
     --vp-widget-content-padding: max(0px, calc(var(--vp-widget-content-padding-h) + var(--widget-content-padding-offset, 0px)));
     --vp-widget-content-gap: max(0px, calc(var(--vp-widget-content-gap-h) + var(--widget-content-gap-offset, 0px)));
+    --font-size: calc(var(--widget-height) * var(--font-scale));
+    font-size: var(--font-size);
 }}
 
 .bar--vertical .widget:not(.widget-group) > overlay > .content {{
@@ -154,6 +156,8 @@ sectioned-bar.bar.bar--vertical {{
 .widget-group > .content > .widget-item .content,
 .widget-item.passive > .content {{
     padding: var(--widget-padding-y) var(--vp-widget-content-padding);
+    --font-size: calc(var(--widget-height) * var(--font-scale));
+    font-size: var(--font-size);
 }}
 
 .bar--vertical .widget-group > .content > .widget-item .content,


### PR DESCRIPTION
Add a setting to adjust font scale from tom:
```toml
[theme.typography]
font_scale = 1.0 # 0.0-0.1
```

<img width="83" height="41" alt="image" src="https://github.com/user-attachments/assets/e898eac9-3a0d-40b5-8755-1430163fbd77" />
<img width="61" height="38" alt="image" src="https://github.com/user-attachments/assets/e06288f3-c476-4621-a98e-3812985afff2" />

Also fixes so the `--font-scale` CSS variables can be set on widget scoped classes, i.e:
```css
.clock {
  --font-scale: 0.1;
}
```

To just adjust font scale for the clock