### PR TITLE
feat(quick_settings): add options to override commands for power actions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,6 +44,13 @@ background_opacity = 1.0
 #   [widgets.battery]
 #   disabled = true
 #
+#   [widgets.quick_settings]
+#   # shutdown_command = "loginctl poweroff"
+#   # reboot_command = "loginctl reboot"
+#   # suspend_command = "loginctl suspend"
+#   # lock_command = "loginctl lock-session"
+#   # logout_command = "niri msg action quit"  # unset/empty = compositor IPC logout
+#
 #   [widgets.media]
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)
 #
@@ -51,14 +58,7 @@ background_opacity = 1.0
 #   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
 #
 # Custom widgets use the "custom-" prefix for user-defined buttons:
-#   right = ["custom-power", "custom-os", "tray", "clock"]
-#
-#   [widgets.custom-power]
-#   icon = "system-shutdown-symbolic"
-#   label = "Power"
-#   tooltip = "Power menu"
-#   on_click = "wlogout"
-#   on_click_right = "systemctl suspend"
+#   right = ["custom-os", "tray", "clock"]
 #
 #   [widgets.custom-os]
 #   image = "/usr/share/pixmaps/distro-logo.svg"  # file path (PNG, SVG, etc.)

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -29,6 +29,29 @@ use crate::widgets::layer_shell_popover::PopoverAnchor;
 use crate::widgets::warn_unknown_options;
 use vibepanel_core::config::WidgetEntry;
 
+/// Configurable shell commands used by the Quick Settings power card.
+#[derive(Debug, Clone)]
+pub struct PowerCommandsConfig {
+    pub shutdown: String,
+    pub reboot: String,
+    pub suspend: String,
+    pub lock: String,
+    /// Empty means use the compositor-aware logout implementation.
+    pub logout: String,
+}
+
+impl Default for PowerCommandsConfig {
+    fn default() -> Self {
+        Self {
+            shutdown: "systemctl poweroff".to_string(),
+            reboot: "systemctl reboot".to_string(),
+            suspend: "systemctl suspend".to_string(),
+            lock: "loginctl lock-session".to_string(),
+            logout: String::new(),
+        }
+    }
+}
+
 /// Configuration for which cards are shown in Quick Settings.
 ///
 /// These options are set in the `[widgets.quick_settings]` TOML section
@@ -88,6 +111,8 @@ pub struct QuickSettingsConfig {
     pub cards: QuickSettingsCardsConfig,
     /// Volume delta (percentage points) for scroll on QS widget/window.
     pub audio_scroll_percentage: i32,
+    /// Shell commands used by the power card.
+    pub power_commands: PowerCommandsConfig,
 }
 
 impl WidgetConfig for QuickSettingsConfig {
@@ -104,6 +129,11 @@ impl WidgetConfig for QuickSettingsConfig {
             "power",
             "vpn_close_on_connect",
             "audio_scroll_percentage",
+            "shutdown_command",
+            "reboot_command",
+            "suspend_command",
+            "lock_command",
+            "logout_command",
         ];
         warn_unknown_options("quick_settings", entry, known_options);
 
@@ -133,6 +163,16 @@ impl WidgetConfig for QuickSettingsConfig {
                 .unwrap_or(true) // default to true (shown)
         };
 
+        let default_commands = PowerCommandsConfig::default();
+        let get_command = |key: &str, default: &str| -> String {
+            entry
+                .options
+                .get(key)
+                .and_then(|v| v.as_str())
+                .unwrap_or(default)
+                .to_string()
+        };
+
         Self {
             cards: QuickSettingsCardsConfig {
                 network: get_bool("network"),
@@ -147,6 +187,13 @@ impl WidgetConfig for QuickSettingsConfig {
                 vpn_close_on_connect: get_bool("vpn_close_on_connect"),
             },
             audio_scroll_percentage,
+            power_commands: PowerCommandsConfig {
+                shutdown: get_command("shutdown_command", &default_commands.shutdown),
+                reboot: get_command("reboot_command", &default_commands.reboot),
+                suspend: get_command("suspend_command", &default_commands.suspend),
+                lock: get_command("lock_command", &default_commands.lock),
+                logout: get_command("logout_command", &default_commands.logout),
+            },
         }
     }
 }
@@ -156,6 +203,7 @@ impl Default for QuickSettingsConfig {
         Self {
             cards: QuickSettingsCardsConfig::default(),
             audio_scroll_percentage: Self::DEFAULT_AUDIO_SCROLL_PERCENTAGE,
+            power_commands: PowerCommandsConfig::default(),
         }
     }
 }
@@ -630,5 +678,61 @@ impl Drop for QuickSettingsWidget {
         if let Some(id) = self.vpn_callback_id.take() {
             VpnService::global().disconnect(id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widgets::WidgetConfig;
+    use std::collections::HashMap;
+    use toml::Value;
+
+    #[test]
+    fn quick_settings_power_commands_default_to_existing_behavior() {
+        let config = QuickSettingsConfig::from_entry(&WidgetEntry::new("quick_settings"));
+
+        assert_eq!(config.power_commands.shutdown, "systemctl poweroff");
+        assert_eq!(config.power_commands.reboot, "systemctl reboot");
+        assert_eq!(config.power_commands.suspend, "systemctl suspend");
+        assert_eq!(config.power_commands.lock, "loginctl lock-session");
+        assert_eq!(config.power_commands.logout, "");
+    }
+
+    #[test]
+    fn quick_settings_power_commands_parse_overrides() {
+        let mut options = HashMap::new();
+        options.insert(
+            "shutdown_command".to_string(),
+            Value::String("loginctl poweroff".to_string()),
+        );
+        options.insert(
+            "reboot_command".to_string(),
+            Value::String("loginctl reboot".to_string()),
+        );
+        options.insert(
+            "suspend_command".to_string(),
+            Value::String("loginctl suspend".to_string()),
+        );
+        options.insert(
+            "lock_command".to_string(),
+            Value::String("swaylock".to_string()),
+        );
+        options.insert(
+            "logout_command".to_string(),
+            Value::String("niri msg action quit".to_string()),
+        );
+
+        let entry = WidgetEntry {
+            name: "quick_settings".to_string(),
+            options,
+        };
+        let config = QuickSettingsConfig::from_entry(&entry);
+
+        assert_eq!(config.power_commands.shutdown, "loginctl poweroff");
+        assert_eq!(config.power_commands.reboot, "loginctl reboot");
+        assert_eq!(config.power_commands.suspend, "loginctl suspend");
+        assert_eq!(config.power_commands.lock, "swaylock");
+        assert_eq!(config.power_commands.logout, "niri msg action quit");
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/power_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/power_card.rs
@@ -11,7 +11,7 @@
 //! - Expander: Actions appear as ListRows in accordion
 
 use std::cell::{Cell, RefCell};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -30,6 +30,7 @@ use crate::services::icons::{IconHandle, IconsService};
 use crate::styles::{button, card, color, qs, row, surface};
 use crate::widgets::base::configure_popover;
 
+use super::bar_widget::PowerCommandsConfig;
 use super::components::{CardLabel, ToggleCard};
 use super::ui_helpers::{ExpandableCard, ExpandableCardBase, create_qs_list_box};
 
@@ -48,9 +49,6 @@ struct PowerAction {
     label: &'static str,
     /// Icon name (GTK/Material mapped).
     icon: &'static str,
-    /// Command to execute (first element is program, rest are args).
-    /// Empty slice means special handling (e.g., logout via compositor IPC).
-    command: &'static [&'static str],
 }
 
 /// Available power actions.
@@ -59,57 +57,97 @@ const POWER_ACTIONS: &[PowerAction] = &[
         id: "shutdown",
         label: "Shut Down",
         icon: "system-shutdown-symbolic",
-        command: &["systemctl", "poweroff"],
     },
     PowerAction {
         id: "reboot",
         label: "Reboot",
         icon: "system-reboot-symbolic",
-        command: &["systemctl", "reboot"],
     },
     PowerAction {
         id: "suspend",
         label: "Suspend",
         icon: "system-suspend-symbolic",
-        command: &["systemctl", "suspend"],
     },
     PowerAction {
         id: "lock",
         label: "Lock",
         icon: "system-lock-screen-symbolic",
-        command: &["loginctl", "lock-session"],
     },
     PowerAction {
         id: "logout",
         label: "Log Out",
         icon: "system-log-out-symbolic",
-        // Empty command - handled specially via compositor IPC
-        command: &[],
     },
 ];
 
+fn command_for_action<'a>(action: &PowerAction, commands: &'a PowerCommandsConfig) -> &'a str {
+    match action.id {
+        "shutdown" => &commands.shutdown,
+        "reboot" => &commands.reboot,
+        "suspend" => &commands.suspend,
+        "lock" => &commands.lock,
+        "logout" => &commands.logout,
+        _ => "",
+    }
+}
+
 /// Execute a power action command.
-fn execute_power_action(action: &PowerAction) {
-    // Special handling for logout - use compositor IPC
-    if action.id == "logout" {
+fn execute_power_action(action: &PowerAction, command: &str) {
+    let command = command.trim();
+
+    // Special handling for logout - use compositor IPC unless overridden.
+    if action.id == "logout" && command.is_empty() {
         debug!("Executing logout via compositor IPC");
         CompositorManager::global().quit_compositor();
         return;
     }
 
-    if action.command.is_empty() {
+    if command.is_empty() {
         warn!("Power action {} has no command", action.id);
         return;
     }
 
-    debug!("Executing power action {}: {:?}", action.id, action.command);
+    debug!("Executing power action {}: sh -c {}", action.id, command);
 
-    match Command::new(action.command[0])
-        .args(&action.command[1..])
+    let action_id = action.id;
+    let command = command.to_string();
+    match Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
     {
-        Ok(_) => debug!("Power action {} spawned successfully", action.id),
-        Err(e) => warn!("Failed to execute power action {}: {}", action.id, e),
+        Ok(child) => {
+            debug!("Power action {} spawned successfully", action_id);
+            std::thread::spawn(move || match child.wait_with_output() {
+                Ok(output) if output.status.success() => {}
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let stderr = stderr.trim();
+                    if stderr.is_empty() {
+                        warn!(
+                            "Power action {} command {:?} exited with {}",
+                            action_id, command, output.status
+                        );
+                    } else {
+                        warn!(
+                            "Power action {} command {:?} exited with {}: {}",
+                            action_id, command, output.status, stderr
+                        );
+                    }
+                }
+                Err(e) => warn!(
+                    "Failed to wait for power action {} command {:?}: {}",
+                    action_id, command, e
+                ),
+            });
+        }
+        Err(e) => warn!(
+            "Failed to execute power action {} with command {:?}: {}",
+            action_id, command, e
+        ),
     }
 }
 
@@ -449,7 +487,9 @@ impl ExpandableCard for PowerCardExpanderState {
 }
 
 /// Build power card with popover menu (hold-to-open).
-pub fn build_power_card_popover() -> (gtk4::Widget, Rc<PowerCardState>) {
+pub fn build_power_card_popover(
+    commands: PowerCommandsConfig,
+) -> (gtk4::Widget, Rc<PowerCardState>) {
     let state = Rc::new(PowerCardState::new());
 
     // Create the card wrapper box
@@ -466,11 +506,12 @@ pub fn build_power_card_popover() -> (gtk4::Widget, Rc<PowerCardState>) {
 
     // Set up hold-to-confirm that opens popover
     let button_weak = button.downgrade();
+    let commands_for_popover = commands.clone();
     setup_hold_to_confirm(&button, &button, &progress, move || {
         let Some(btn) = button_weak.upgrade() else {
             return;
         };
-        show_power_popover(&btn);
+        show_power_popover(&btn, commands_for_popover.clone());
     });
 
     card_box.append(&overlay);
@@ -478,7 +519,7 @@ pub fn build_power_card_popover() -> (gtk4::Widget, Rc<PowerCardState>) {
 }
 
 /// Show the power actions popover.
-fn show_power_popover(parent: &Button) {
+fn show_power_popover(parent: &Button, commands: PowerCommandsConfig) {
     let popover = Popover::new();
     configure_popover(&popover);
 
@@ -494,7 +535,8 @@ fn show_power_popover(parent: &Button) {
 
     // Add a hold-to-confirm button for each power action
     for action in POWER_ACTIONS {
-        let action_widget = create_power_popover_action(action);
+        let command = command_for_action(action, &commands).to_string();
+        let action_widget = create_power_popover_action(action, command);
         content.append(&action_widget);
     }
 
@@ -509,7 +551,7 @@ fn show_power_popover(parent: &Button) {
 }
 
 /// Create a power action button for the popover (with hold-to-confirm).
-fn create_power_popover_action(action: &'static PowerAction) -> Overlay {
+fn create_power_popover_action(action: &'static PowerAction, command: String) -> Overlay {
     let overlay = Overlay::new();
     overlay.add_css_class(qs::POWER_ROW);
 
@@ -548,7 +590,7 @@ fn create_power_popover_action(action: &'static PowerAction) -> Overlay {
 
     // Set up hold-to-confirm
     setup_hold_to_confirm(&btn, &btn, &progress, move || {
-        execute_power_action(action);
+        execute_power_action(action, &command);
     });
 
     overlay
@@ -564,7 +606,9 @@ fn create_power_popover_action(action: &'static PowerAction) -> Overlay {
 /// setting up the expander button click handler via `AccordionManager::setup_expander_with_callback`,
 /// which handles accordion behavior, revealer toggling, and arrow CSS updates.
 /// The caller can provide an `on_toggle` callback to update the subtitle text.
-pub fn build_power_card_expander() -> (
+pub fn build_power_card_expander(
+    commands: PowerCommandsConfig,
+) -> (
     gtk4::Widget,
     Revealer,
     Rc<PowerCardExpanderState>,
@@ -595,7 +639,7 @@ pub fn build_power_card_expander() -> (
     revealer.set_transition_type(RevealerTransitionType::SlideDown);
     revealer.set_transition_duration(ConfigManager::global().animation_duration(250));
 
-    let details = build_power_details();
+    let details = build_power_details_with_commands(&commands);
     revealer.set_child(Some(&details.container));
 
     *state.base.revealer.borrow_mut() = Some(revealer.clone());
@@ -622,8 +666,9 @@ pub fn build_power_card_expander() -> (
     // Gesture on toggle button, but width calculated from card_overlay (full card width)
     {
         let shutdown_action = &POWER_ACTIONS[0]; // Shutdown action (index 0)
+        let shutdown_command = command_for_action(shutdown_action, &commands).to_string();
         setup_hold_to_confirm(&card.toggle, &card_overlay, &progress, move || {
-            execute_power_action(shutdown_action);
+            execute_power_action(shutdown_action, &shutdown_command);
         });
     }
 
@@ -645,8 +690,7 @@ struct PowerDetailsResult {
     list_box: ListBox,
 }
 
-/// Build the power details section with action rows.
-fn build_power_details() -> PowerDetailsResult {
+fn build_power_details_with_commands(commands: &PowerCommandsConfig) -> PowerDetailsResult {
     let container = GtkBox::new(Orientation::Vertical, 0);
     container.add_css_class(qs::POWER_DETAILS);
 
@@ -654,7 +698,8 @@ fn build_power_details() -> PowerDetailsResult {
 
     // Add a row for each power action
     for action in POWER_ACTIONS {
-        let row = build_power_action_row(action);
+        let command = command_for_action(action, commands).to_string();
+        let row = build_power_action_row_with_command(action, command);
         list_box.append(&row);
     }
 
@@ -667,7 +712,10 @@ fn build_power_details() -> PowerDetailsResult {
 }
 
 /// Build a power action row with hold-to-confirm.
-fn build_power_action_row(action: &'static PowerAction) -> ListBoxRow {
+fn build_power_action_row_with_command(
+    action: &'static PowerAction,
+    command: String,
+) -> ListBoxRow {
     let list_row = ListBoxRow::new();
     list_row.add_css_class(row::QS);
     list_row.add_css_class(row::BASE);
@@ -714,7 +762,7 @@ fn build_power_action_row(action: &'static PowerAction) -> ListBoxRow {
 
     // Set up hold-to-confirm on the row
     setup_hold_to_confirm(&list_row, &list_row, &progress, move || {
-        execute_power_action(action);
+        execute_power_action(action, &command);
     });
 
     list_row
@@ -744,12 +792,12 @@ pub enum PowerCardBuildResult {
 /// accordion behavior. Note that the Power card already handles its own expand/collapse
 /// with subtitle updates, so the caller should use a custom accordion setup that
 /// calls `accordion.collapse_others()` before the card's built-in handler runs.
-pub fn build_power_card() -> PowerCardBuildResult {
+pub fn build_power_card(commands: PowerCommandsConfig) -> PowerCardBuildResult {
     if USE_POPOVER_VARIANT {
-        let (card, state) = build_power_card_popover();
+        let (card, state) = build_power_card_popover(commands);
         PowerCardBuildResult::Popover { card, state }
     } else {
-        let (card, revealer, state, expander_button) = build_power_card_expander();
+        let (card, revealer, state, expander_button) = build_power_card_expander(commands);
         PowerCardBuildResult::Expander {
             card,
             revealer,

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -41,7 +41,7 @@ use crate::widgets::scale_box::ScaleBox;
 use super::audio_card::{
     self, AudioCardState, build_audio_details, build_audio_hint_label, build_audio_row,
 };
-use super::bar_widget::{QuickSettingsCardsConfig, QuickSettingsConfig};
+use super::bar_widget::{PowerCommandsConfig, QuickSettingsCardsConfig, QuickSettingsConfig};
 use super::bluetooth_card::{self, BluetoothCardState, bt_icon_name, build_bluetooth_details};
 use super::brightness_card::{self, BrightnessCardState, build_brightness_row};
 use super::components::ToggleCard;
@@ -162,6 +162,7 @@ pub struct QuickSettingsWindow {
     /// tick callbacks and idle callbacks.
     anim_generation: Rc<Cell<u32>>,
     cards_config: QuickSettingsCardsConfig,
+    power_commands: PowerCommandsConfig,
     audio_scroll_percentage: i32,
     scroll_container: ScrolledWindow,
     /// Service callback IDs, used to disconnect/unsubscribe on close.
@@ -255,6 +256,7 @@ impl QuickSettingsWindow {
             anim_state: Rc::new(RefCell::new(AnimState::new_idle())),
             anim_generation: Rc::new(Cell::new(0)),
             cards_config: config.cards,
+            power_commands: config.power_commands,
             audio_scroll_percentage: config.audio_scroll_percentage,
             scroll_container,
             network_callback_id: Cell::new(None),
@@ -536,7 +538,7 @@ impl QuickSettingsWindow {
         }
         // Power card (always last in the grid)
         if cfg.power {
-            match power_card::build_power_card() {
+            match power_card::build_power_card(qs.power_commands.clone()) {
                 PowerCardBuildResult::Popover { card, state: _ } => {
                     toggle_cards.push(ToggleCardInfo {
                         card,


### PR DESCRIPTION
The commands in the quick settings power actions can now be overriden:
```toml
[widgets.quick_settings]
shutdown_command = "notify-send shutdown"
reboot_command = "notify-send reboot"
suspend_command = "notify-send suspend"
lock_command = "notify-send lock"
logout_command = "notify-send logout"
```

Fixes #155 