### PR TITLE
Refactor GPU widget to support multiple devices and improve tooltip f…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -56,15 +56,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -158,7 +158,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -183,9 +183,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -256,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -442,13 +442,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -718,7 +717,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -848,7 +847,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1d422cce9367945916b7a5083eedf67b0a5380d326af1943a0b5cef9afb6e48"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "gdk4",
  "glib",
  "glib-sys",
@@ -903,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -977,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1024,16 +1023,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1046,9 +1047,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1056,11 +1057,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -1072,9 +1073,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1092,7 +1093,7 @@ version = "2.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "libc",
  "libpulse-sys",
  "num-derive",
@@ -1111,18 +1112,6 @@ dependencies = [
  "num-traits",
  "pkg-config",
  "winapi",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1152,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matchers"
@@ -1178,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -1240,7 +1229,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1304,11 +1293,11 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9e6eebc1fe424d24c864e40092072618169bd0130f103919aaf615f153e4d0"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -1318,18 +1307,18 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1385,7 +1374,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1398,15 +1387,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1414,7 +1397,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1423,11 +1406,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1441,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -1453,18 +1436,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1481,16 +1464,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -1539,7 +1513,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1607,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1643,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1665,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1694,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1754,22 +1728,22 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -1814,17 +1788,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1838,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1856,28 +1830,28 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1888,9 +1862,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1937,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1955,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "udev"
@@ -2073,18 +2047,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2095,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2105,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2118,18 +2092,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2141,11 +2115,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2153,11 +2127,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2165,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2176,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -2484,18 +2458,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wrapcenum-derive"
@@ -2517,18 +2500,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -56,15 +56,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -158,7 +158,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -183,9 +183,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.8"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -256,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "concurrent-queue"
@@ -442,12 +442,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -717,7 +718,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -847,7 +848,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1d422cce9367945916b7a5083eedf67b0a5380d326af1943a0b5cef9afb6e48"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "gdk4",
  "glib",
  "glib-sys",
@@ -902,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -976,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1023,18 +1024,16 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1047,9 +1046,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1057,11 +1056,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1073,9 +1072,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -1093,7 +1092,7 @@ version = "2.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "libc",
  "libpulse-sys",
  "num-derive",
@@ -1112,6 +1111,18 @@ dependencies = [
  "num-traits",
  "pkg-config",
  "winapi",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1141,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -1167,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -1229,7 +1240,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1293,11 +1304,11 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
+checksum = "7d9e6eebc1fe424d24c864e40092072618169bd0130f103919aaf615f153e4d0"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -1307,18 +1318,18 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
+checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1374,7 +1385,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1387,9 +1398,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -1397,7 +1414,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1406,11 +1423,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1424,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"
@@ -1436,18 +1453,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1464,7 +1481,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1513,7 +1539,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1581,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1617,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -1639,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -1668,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "2.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -1728,22 +1754,22 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.8"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 1.1.2+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.5"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "thiserror"
@@ -1788,17 +1814,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -1812,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
@@ -1830,28 +1856,28 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -1862,9 +1888,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -1911,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1929,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "udev"
@@ -2045,18 +2071,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2067,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2077,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2090,18 +2116,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2113,11 +2139,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2125,11 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2137,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2148,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.11"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
  "dlib",
  "log",
@@ -2456,27 +2482,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.57.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wrapcenum-derive"
@@ -2498,18 +2515,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -56,15 +56,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -158,7 +158,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -183,9 +183,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -256,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -442,13 +442,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -718,7 +717,7 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -848,7 +847,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1d422cce9367945916b7a5083eedf67b0a5380d326af1943a0b5cef9afb6e48"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "gdk4",
  "glib",
  "glib-sys",
@@ -903,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -977,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1024,16 +1023,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1046,9 +1047,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1056,11 +1057,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -1072,9 +1073,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1092,7 +1093,7 @@ version = "2.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "libc",
  "libpulse-sys",
  "num-derive",
@@ -1111,18 +1112,6 @@ dependencies = [
  "num-traits",
  "pkg-config",
  "winapi",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1152,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matchers"
@@ -1178,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -1240,7 +1229,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1304,11 +1293,11 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9e6eebc1fe424d24c864e40092072618169bd0130f103919aaf615f153e4d0"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -1318,18 +1307,18 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1385,7 +1374,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1398,15 +1387,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1414,7 +1397,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1423,11 +1406,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1441,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -1453,18 +1436,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1481,16 +1464,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -1539,7 +1513,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1607,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1643,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1665,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1694,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1754,22 +1728,22 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -1814,17 +1788,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1838,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1856,28 +1830,28 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1888,9 +1862,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1937,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1955,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "udev"
@@ -2071,18 +2045,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2093,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2103,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2116,18 +2090,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2139,11 +2113,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2151,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2163,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2174,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -2482,18 +2456,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wrapcenum-derive"
@@ -2515,18 +2498,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/config.toml
+++ b/config.toml
@@ -54,6 +54,9 @@ background_opacity = 1.0
 #   [widgets.media]
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)
 #
+#   [widgets.gpu]
+#   devices = "auto"  # "auto" (default) shows the preferred GPU only; "all" shows every detected GPU; [1, 2] shows explicit GPU indices
+#
 #   [widgets.notifications]
 #   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
 #

--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,9 @@ background_opacity = 1.0
 #   stable_width = false # Disable width stabilization; default stabilizes common 2-digit metric values
 #   # Also supported by [widgets.memory] and [widgets.gpu]
 #
+#   [widgets.gpu]
+#   devices = "auto"  # "auto" (default) shows the preferred GPU only; "all" shows every detected GPU; [1, 2] shows explicit GPU indices
+#
 #   [widgets.notifications]
 #   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
 #

--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,9 @@ background_opacity = 1.0
 #   # Also supported by [widgets.memory] and [widgets.gpu]
 #
 #   [widgets.gpu]
-#   devices = "auto"  # "auto" (default) shows the preferred GPU only; "all" shows every detected GPU; [1, 2] shows explicit GPU indices
+#   devices = "auto"  # "auto" (default), "all", or zero-based indices such as [0, 1]
+#   # "all" checks every GPU while the GPU widget or system popover is active. Runtime-suspended
+#   # GPUs skip vendor polling, but active secondary GPUs are queried and may use more power than "auto".
 #
 #   [widgets.notifications]
 #   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -52,6 +52,7 @@ const GTK_COLOR_SCHEME_KEY: &str = "color-scheme";
 use crate::bar;
 use crate::services::audio::AudioService;
 use crate::services::bar_manager::BarManager;
+use crate::services::gpu::GpuService;
 use crate::services::icons::IconsService;
 use crate::services::network::NetworkService;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -946,6 +947,10 @@ impl ConfigManager {
         // Store the new config AFTER theme/CSS update but BEFORE widget rebuild,
         // so widgets see the new values when notified
         *self.config.borrow_mut() = new_config.clone();
+
+        if old_config.widgets.get_options("gpu") != new_config.widgets.get_options("gpu") {
+            GpuService::global().reconfigure();
+        }
 
         // Restart or stop wallpaper polling if auto mode or wallpaper config changed
         if old_config.theme.mode != new_config.theme.mode

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -56,6 +56,7 @@ const CSS_IMPORT_SCAN_LIMIT: usize = 256;
 use crate::bar;
 use crate::services::audio::AudioService;
 use crate::services::bar_manager::BarManager;
+use crate::services::gpu::GpuService;
 use crate::services::icons::IconsService;
 use crate::services::network::NetworkService;
 use crate::services::surfaces::SurfaceStyleManager;
@@ -1116,6 +1117,10 @@ impl ConfigManager {
         if old_config.battery_alert_config() != new_config.battery_alert_config() {
             crate::services::battery_alert::BatteryAlertController::global()
                 .configure(new_config.battery_alert_config());
+        }
+
+        if old_config.widgets.get_options("gpu") != new_config.widgets.get_options("gpu") {
+            GpuService::global().reconfigure();
         }
 
         // Restart or stop wallpaper polling if auto mode or wallpaper config changed

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -282,7 +282,7 @@ pub struct GpuService {
     devices: Vec<GpuDevice>,
 
     /// GPU indices currently configured for display and polling.
-    display_indices: Vec<usize>,
+    display_indices: RefCell<Vec<usize>>,
 
     /// Polling interval in seconds.
     poll_interval: Cell<u32>,
@@ -299,19 +299,7 @@ impl GpuService {
         let display_selection = Self::read_display_config();
         let display_indices = Self::resolve_display_indices(&devices, &display_selection);
 
-        if let Some(idx) = display_indices.first().copied() {
-            debug!(
-                "GpuService: selected GPU {} ({:?}) via {}",
-                idx,
-                devices[idx].name().unwrap_or("unknown"),
-                Self::display_selection_description(&display_selection),
-            );
-            if display_indices.len() > 1 {
-                debug!("GpuService: displaying GPU indices {:?}", display_indices);
-            }
-        } else {
-            debug!("GpuService: no GPU selected");
-        }
+        Self::log_display_selection(&devices, &display_selection, &display_indices);
 
         let initial_snapshot = if !display_indices.is_empty() {
             GpuSnapshot {
@@ -327,7 +315,7 @@ impl GpuService {
             callbacks: Callbacks::new(),
             timer_source: RefCell::new(None),
             devices,
-            display_indices,
+            display_indices: RefCell::new(display_indices),
             poll_interval: Cell::new(DEFAULT_POLL_INTERVAL_SECS),
             poll_requests: Cell::new(0),
         })
@@ -359,6 +347,29 @@ impl GpuService {
 
     pub fn snapshot(&self) -> GpuSnapshot {
         self.snapshot.borrow().clone()
+    }
+
+    pub fn reconfigure(&self) {
+        if !self.refresh_display_selection() {
+            return;
+        }
+
+        if self.poll_requests.get() > 0 {
+            self.poll();
+            return;
+        }
+
+        let snapshot = if self.display_indices.borrow().is_empty() {
+            GpuSnapshot::unknown()
+        } else {
+            GpuSnapshot {
+                available: true,
+                ..Default::default()
+            }
+        };
+
+        *self.snapshot.borrow_mut() = snapshot;
+        self.callbacks.notify(&self.snapshot.borrow());
     }
 
     fn start_polling(this: &Rc<Self>) {
@@ -421,19 +432,22 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        if self.display_indices.is_empty() {
-            return;
-        }
+        let display_indices = self.display_indices.borrow();
+        let snapshot = if display_indices.is_empty() {
+            GpuSnapshot::unknown()
+        } else {
+            let mut snapshots = Vec::with_capacity(display_indices.len());
 
-        let mut snapshots = Vec::with_capacity(self.display_indices.len());
-
-        for &idx in &self.display_indices {
-            if let Some(device) = self.devices.get(idx) {
-                snapshots.push(Self::poll_device(idx, device));
+            for &idx in display_indices.iter() {
+                if let Some(device) = self.devices.get(idx) {
+                    snapshots.push(Self::poll_device(idx, device));
+                }
             }
-        }
 
-        let snapshot = GpuSnapshot::from_devices(snapshots);
+            GpuSnapshot::from_devices(snapshots)
+        };
+        drop(display_indices);
+
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
     }
@@ -797,6 +811,39 @@ impl GpuService {
                 format!("config (devices = {:?})", indices)
             }
         }
+    }
+
+    fn log_display_selection(
+        devices: &[GpuDevice],
+        selection: &GpuDisplaySelection,
+        display_indices: &[usize],
+    ) {
+        if let Some(idx) = display_indices.first().copied() {
+            debug!(
+                "GpuService: selected GPU {} ({:?}) via {}",
+                idx,
+                devices[idx].name().unwrap_or("unknown"),
+                Self::display_selection_description(selection),
+            );
+            if display_indices.len() > 1 {
+                debug!("GpuService: displaying GPU indices {:?}", display_indices);
+            }
+        } else {
+            debug!("GpuService: no GPU selected");
+        }
+    }
+
+    fn refresh_display_selection(&self) -> bool {
+        let display_selection = Self::read_display_config();
+        let display_indices = Self::resolve_display_indices(&self.devices, &display_selection);
+        let changed = *self.display_indices.borrow() != display_indices;
+
+        if changed {
+            Self::log_display_selection(&self.devices, &display_selection, &display_indices);
+            *self.display_indices.borrow_mut() = display_indices;
+        }
+
+        changed
     }
 
     fn resolve_display_indices(

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -6,16 +6,22 @@
 //! - **AMD**: sysfs files under `/sys/class/drm/cardN/device/`
 //! - **NVIDIA**: NVML via the `nvml-wrapper` crate (runtime-loaded `libnvidia-ml.so`)
 //!
-//! All GPUs are discovered at startup and polled while the widget or popover is
-//! visible. One preferred GPU is selected only to order the displayed list and
-//! populate the compact summary fields based on:
+//! All GPUs are discovered at startup, but only the configured display set is
+//! polled while the widget or popover is visible.
 //!
-//! 1. **Explicit config**: `device = N` in `[widgets.gpu]` selects a specific index.
-//! 2. **Auto heuristic** (default): Prefers the primary discrete GPU, then any
-//!    discrete GPU, then the primary GPU.
-//!    AMD primary/discrete detection uses `boot_vga` sysfs.
-//!    NVIDIA GPUs are always treated as discrete.
-//!    Falls back to index 0 if no better match is found.
+//! 1. **`devices = "auto"`** (default): shows only the preferred GPU.
+//! 2. **`devices = "all"`**: shows all detected GPUs, ordered with the
+//!    preferred GPU first.
+//! 3. **`devices = [N, M]`** or **`devices = N`**: shows explicit GPU indices
+//!    in the configured order.
+//! 4. **Legacy compatibility**: `device = N` remains accepted as an alias for a
+//!    single explicit GPU selection.
+//!
+//! Preferred GPU auto-selection uses the existing heuristic: prefer the primary
+//! discrete GPU, then any discrete GPU, then the primary GPU.
+//! AMD primary/discrete detection uses `boot_vga` sysfs.
+//! NVIDIA GPUs are always treated as discrete.
+//! Falls back to index 0 if no better match is found.
 //!
 //! ## Usage
 //!
@@ -247,6 +253,14 @@ impl GpuDevice {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+enum GpuDisplaySelection {
+    #[default]
+    Auto,
+    All,
+    Explicit(Vec<usize>),
+}
+
 /// Shared, process-wide GPU monitoring service.
 ///
 /// Discovers all available GPUs at startup and polls them at regular intervals
@@ -267,8 +281,8 @@ pub struct GpuService {
     /// All discovered GPU devices.
     devices: Vec<GpuDevice>,
 
-    /// Preferred GPU index used for display ordering and summary fields.
-    selected_index: Cell<Option<usize>>,
+    /// GPU indices currently configured for display and polling.
+    display_indices: Vec<usize>,
 
     /// Polling interval in seconds.
     poll_interval: Cell<u32>,
@@ -282,26 +296,24 @@ impl GpuService {
         debug!("GpuService: initializing");
 
         let devices = Self::discover_all_gpus();
-        let device_selection = Self::read_device_config();
+        let display_selection = Self::read_display_config();
+        let display_indices = Self::resolve_display_indices(&devices, &display_selection);
 
-        let selected_index = Self::select_gpu(&devices, &device_selection);
-
-        if let Some(idx) = selected_index {
-            let method = match device_selection {
-                Some(i) => format!("config (device = {})", i),
-                None => "auto".to_string(),
-            };
+        if let Some(idx) = display_indices.first().copied() {
             debug!(
                 "GpuService: selected GPU {} ({:?}) via {}",
                 idx,
                 devices[idx].name().unwrap_or("unknown"),
-                method,
+                Self::display_selection_description(&display_selection),
             );
+            if display_indices.len() > 1 {
+                debug!("GpuService: displaying GPU indices {:?}", display_indices);
+            }
         } else {
             debug!("GpuService: no GPU selected");
         }
 
-        let initial_snapshot = if selected_index.is_some() {
+        let initial_snapshot = if !display_indices.is_empty() {
             GpuSnapshot {
                 available: true,
                 ..Default::default()
@@ -315,7 +327,7 @@ impl GpuService {
             callbacks: Callbacks::new(),
             timer_source: RefCell::new(None),
             devices,
-            selected_index: Cell::new(selected_index),
+            display_indices,
             poll_interval: Cell::new(DEFAULT_POLL_INTERVAL_SECS),
             poll_requests: Cell::new(0),
         })
@@ -409,23 +421,16 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        if self.devices.is_empty() {
+        if self.display_indices.is_empty() {
             return;
         }
 
-        let mut snapshots = Vec::with_capacity(self.devices.len());
+        let mut snapshots = Vec::with_capacity(self.display_indices.len());
 
-        if let Some(selected_index) = self.selected_index.get()
-            && let Some(device) = self.devices.get(selected_index)
-        {
-            snapshots.push(Self::poll_device(selected_index, device));
-        }
-
-        for (idx, device) in self.devices.iter().enumerate() {
-            if Some(idx) == self.selected_index.get() {
-                continue;
+        for &idx in &self.display_indices {
+            if let Some(device) = self.devices.get(idx) {
+                snapshots.push(Self::poll_device(idx, device));
             }
-            snapshots.push(Self::poll_device(idx, device));
         }
 
         let snapshot = GpuSnapshot::from_devices(snapshots);
@@ -700,21 +705,148 @@ impl GpuService {
         devices
     }
 
-    /// Read the `device` config option from `[widgets.gpu]`.
-    fn read_device_config() -> Option<u32> {
-        ConfigManager::global()
-            .get_widget_option("gpu", "device")
-            .and_then(|v| match v {
-                toml::Value::Integer(i) if i >= 0 => Some(i as u32),
-                toml::Value::String(ref s) if s == "auto" => None,
-                other => {
-                    warn!("GpuService: invalid 'device' config value: {other}, using auto");
+    /// Read the `devices` config option from `[widgets.gpu]`.
+    fn read_display_config() -> GpuDisplaySelection {
+        let config = ConfigManager::global();
+
+        if let Some(value) = config.get_widget_option("gpu", "devices") {
+            return Self::parse_display_selection_value(&value, "devices").unwrap_or_default();
+        }
+
+        if let Some(value) = config.get_widget_option("gpu", "device") {
+            debug!("GpuService: using legacy 'device' option; prefer 'devices'");
+            return Self::parse_display_selection_value(&value, "device").unwrap_or_default();
+        }
+
+        GpuDisplaySelection::Auto
+    }
+
+    fn parse_display_selection_value(
+        value: &toml::Value,
+        option_name: &str,
+    ) -> Option<GpuDisplaySelection> {
+        match value {
+            toml::Value::Integer(index) if *index >= 0 => {
+                Some(GpuDisplaySelection::Explicit(vec![*index as usize]))
+            }
+            toml::Value::Integer(index) => {
+                warn!(
+                    "GpuService: invalid '{}' config value {} (must be >= 0), using auto",
+                    option_name, index,
+                );
+                None
+            }
+            toml::Value::String(mode) => match mode.to_lowercase().as_str() {
+                "auto" => Some(GpuDisplaySelection::Auto),
+                "all" => Some(GpuDisplaySelection::All),
+                _ => {
+                    warn!(
+                        "GpuService: invalid '{}' config value {:?}, expected 'auto', 'all', an integer, or an array of integers; using auto",
+                        option_name, mode,
+                    );
                     None
                 }
-            })
+            },
+            toml::Value::Array(entries) => {
+                let mut indices = Vec::new();
+                for entry in entries {
+                    match entry {
+                        toml::Value::Integer(index) if *index >= 0 => {
+                            let index = *index as usize;
+                            if !indices.contains(&index) {
+                                indices.push(index);
+                            }
+                        }
+                        other => {
+                            warn!(
+                                "GpuService: ignoring invalid '{}' array entry {other}; expected non-negative integers",
+                                option_name,
+                            );
+                        }
+                    }
+                }
+
+                if indices.is_empty() {
+                    warn!(
+                        "GpuService: '{}' array contained no valid GPU indices, using auto",
+                        option_name,
+                    );
+                    None
+                } else {
+                    Some(GpuDisplaySelection::Explicit(indices))
+                }
+            }
+            other => {
+                warn!(
+                    "GpuService: invalid '{}' config value: {other}, expected 'auto', 'all', an integer, or an array of integers; using auto",
+                    option_name,
+                );
+                None
+            }
+        }
+    }
+
+    fn display_selection_description(selection: &GpuDisplaySelection) -> String {
+        match selection {
+            GpuDisplaySelection::Auto => "auto".to_string(),
+            GpuDisplaySelection::All => "config (devices = all)".to_string(),
+            GpuDisplaySelection::Explicit(indices) if indices.len() == 1 => {
+                format!("config (devices = {})", indices[0])
+            }
+            GpuDisplaySelection::Explicit(indices) => {
+                format!("config (devices = {:?})", indices)
+            }
+        }
+    }
+
+    fn resolve_display_indices(
+        devices: &[GpuDevice],
+        selection: &GpuDisplaySelection,
+    ) -> Vec<usize> {
+        match selection {
+            GpuDisplaySelection::Auto => Self::auto_select(devices).into_iter().collect(),
+            GpuDisplaySelection::All => {
+                let Some(selected_index) = Self::auto_select(devices) else {
+                    return Vec::new();
+                };
+
+                let mut display_indices = Vec::with_capacity(devices.len());
+                display_indices.push(selected_index);
+                display_indices.extend((0..devices.len()).filter(|idx| *idx != selected_index));
+                display_indices
+            }
+            GpuDisplaySelection::Explicit(indices) => {
+                let mut valid_indices = Vec::with_capacity(indices.len());
+                for &idx in indices {
+                    if idx < devices.len() {
+                        if !valid_indices.contains(&idx) {
+                            valid_indices.push(idx);
+                        }
+                    } else {
+                        warn!(
+                            "GpuService: configured GPU index {} out of range (have {} GPU(s)), ignoring it",
+                            idx,
+                            devices.len(),
+                        );
+                    }
+                }
+
+                if valid_indices.is_empty() {
+                    warn!(
+                        "GpuService: configured GPU list {:?} contains no valid indices (have {} GPU(s)), falling back to auto",
+                        indices,
+                        devices.len(),
+                    );
+                    Self::auto_select(devices).into_iter().collect()
+                } else {
+                    valid_indices
+                }
+            }
+        }
     }
 
     /// Select GPU: explicit config index > first discrete > index 0.
+    #[cfg(test)]
     fn select_gpu(devices: &[GpuDevice], selection: &Option<u32>) -> Option<usize> {
         if devices.is_empty() {
             return None;
@@ -1105,6 +1237,96 @@ mod tests {
             dummy_amd("dGPU", true, false),
         ];
         assert_eq!(GpuService::select_gpu(&devices, &None), Some(1));
+    }
+
+    #[test]
+    fn test_parse_display_selection_accepts_strings() {
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::String("auto".to_string()),
+                "devices"
+            ),
+            Some(GpuDisplaySelection::Auto)
+        );
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::String("all".to_string()),
+                "devices"
+            ),
+            Some(GpuDisplaySelection::All)
+        );
+    }
+
+    #[test]
+    fn test_parse_display_selection_accepts_integer_and_array() {
+        assert_eq!(
+            GpuService::parse_display_selection_value(&toml::Value::Integer(2), "devices"),
+            Some(GpuDisplaySelection::Explicit(vec![2]))
+        );
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::Array(vec![toml::Value::Integer(2), toml::Value::Integer(1)]),
+                "devices",
+            ),
+            Some(GpuDisplaySelection::Explicit(vec![2, 1]))
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_auto_shows_selected_only() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::Auto),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_all_orders_selected_first() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+            dummy_amd("dGPU-2", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::All),
+            vec![1, 0, 2]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_explicit_preserves_order() {
+        let devices = vec![
+            dummy_amd("gpu-0", false, true),
+            dummy_amd("gpu-1", true, false),
+            dummy_amd("gpu-2", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(
+                &devices,
+                &GpuDisplaySelection::Explicit(vec![2, 1]),
+            ),
+            vec![2, 1]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_invalid_list_falls_back_to_auto() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::Explicit(vec![9]),),
+            vec![1]
+        );
     }
 
     #[test]

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -6,13 +6,16 @@
 //! - **AMD**: sysfs files under `/sys/class/drm/cardN/device/`
 //! - **NVIDIA**: NVML via the `nvml-wrapper` crate (runtime-loaded `libnvidia-ml.so`)
 //!
-//! All GPUs are discovered at startup. One is selected for active polling based on:
+//! All GPUs are discovered at startup and polled while the widget or popover is
+//! visible. One preferred GPU is selected only to order the displayed list and
+//! populate the compact summary fields based on:
 //!
 //! 1. **Explicit config**: `device = N` in `[widgets.gpu]` selects a specific index.
-//! 2. **Auto heuristic** (default): Prefers discrete GPUs over integrated.
-//!    AMD discrete detection uses `boot_vga` sysfs (0 = discrete).
+//! 2. **Auto heuristic** (default): Prefers the primary discrete GPU, then any
+//!    discrete GPU, then the primary GPU.
+//!    AMD primary/discrete detection uses `boot_vga` sysfs.
 //!    NVIDIA GPUs are always treated as discrete.
-//!    Falls back to index 0 if no discrete GPU is found.
+//!    Falls back to index 0 if no better match is found.
 //!
 //! ## Usage
 //!
@@ -62,8 +65,7 @@ pub enum GpuPowerState {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct GpuSnapshot {
-    pub available: bool,
+pub struct GpuDeviceSnapshot {
     /// Hardware power state (active, suspended, or unknown).
     pub power_state: GpuPowerState,
     /// GPU utilization percentage (0.0 - 100.0).
@@ -82,6 +84,37 @@ pub struct GpuSnapshot {
     pub device_name: Option<String>,
 }
 
+impl GpuDeviceSnapshot {
+    fn is_gpu_high(&self) -> bool {
+        self.gpu_usage
+            .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
+            .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GpuSnapshot {
+    pub available: bool,
+    /// Hardware power state (active, suspended, or unknown).
+    pub power_state: GpuPowerState,
+    /// GPU utilization percentage (0.0 - 100.0).
+    pub gpu_usage: Option<f32>,
+    /// Used VRAM in bytes.
+    pub vram_used: Option<u64>,
+    /// Total VRAM in bytes.
+    pub vram_total: Option<u64>,
+    /// GPU temperature in degrees Celsius.
+    pub temperature: Option<f32>,
+    /// GPU clock speed in MHz.
+    pub clock_mhz: Option<u64>,
+    /// GPU power draw in watts.
+    pub power_watts: Option<f32>,
+    /// Device name (product name, or `vendor:device` PCI ID fallback).
+    pub device_name: Option<String>,
+    /// Per-device snapshots in display order (preferred GPU first).
+    pub devices: Vec<GpuDeviceSnapshot>,
+}
+
 impl GpuSnapshot {
     /// Returns a snapshot representing an unknown/unavailable GPU.
     pub fn unknown() -> Self {
@@ -90,16 +123,62 @@ impl GpuSnapshot {
 
     /// Returns true if GPU usage is above the high threshold.
     pub fn is_gpu_high(&self) -> bool {
-        self.gpu_usage
-            .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
-            .unwrap_or(false)
+        if self.devices.is_empty() {
+            self.gpu_usage
+                .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
+                .unwrap_or(false)
+        } else {
+            self.devices.iter().any(GpuDeviceSnapshot::is_gpu_high)
+        }
     }
 
-    /// VRAM usage as a percentage (0.0 - 100.0), if both used and total are known.
-    pub fn vram_percent(&self) -> Option<f32> {
-        match (self.vram_used, self.vram_total) {
-            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
-            _ => None,
+    /// Returns the per-device GPU snapshots, falling back to the summary fields
+    /// for older callers when the service has not yet populated the device list.
+    pub fn devices_for_display(&self) -> Vec<GpuDeviceSnapshot> {
+        if !self.devices.is_empty() {
+            return self.devices.clone();
+        }
+
+        if !self.available {
+            return Vec::new();
+        }
+
+        vec![GpuDeviceSnapshot {
+            power_state: self.power_state,
+            gpu_usage: self.gpu_usage,
+            vram_used: self.vram_used,
+            vram_total: self.vram_total,
+            temperature: self.temperature,
+            clock_mhz: self.clock_mhz,
+            power_watts: self.power_watts,
+            device_name: self.device_name.clone(),
+        }]
+    }
+
+    pub fn all_devices_suspended(&self) -> bool {
+        let devices = self.devices_for_display();
+        !devices.is_empty()
+            && devices
+                .iter()
+                .all(|device| device.power_state == GpuPowerState::Suspended)
+    }
+
+    fn from_devices(devices: Vec<GpuDeviceSnapshot>) -> Self {
+        let Some(summary) = devices.first().cloned() else {
+            return Self::unknown();
+        };
+
+        Self {
+            available: true,
+            power_state: summary.power_state,
+            gpu_usage: summary.gpu_usage,
+            vram_used: summary.vram_used,
+            vram_total: summary.vram_total,
+            temperature: summary.temperature,
+            clock_mhz: summary.clock_mhz,
+            power_watts: summary.power_watts,
+            device_name: summary.device_name.clone(),
+            devices,
         }
     }
 }
@@ -119,6 +198,9 @@ struct AmdGpuDevice {
 
     /// Whether this is a discrete GPU (determined via `boot_vga` sysfs attribute).
     is_discrete: bool,
+
+    /// Whether this is the primary GPU (`boot_vga == 1`).
+    is_primary: bool,
 }
 
 struct NvidiaGpuDevice {
@@ -131,6 +213,9 @@ struct NvidiaGpuDevice {
 
     /// Sysfs `power/runtime_status` path for checking hardware power state.
     runtime_status_path: Option<PathBuf>,
+
+    /// Whether this is the primary GPU (`boot_vga == 1`).
+    is_primary: bool,
 }
 
 enum GpuDevice {
@@ -153,12 +238,19 @@ impl GpuDevice {
             GpuDevice::Nvidia(_) => true,
         }
     }
+
+    fn is_primary(&self) -> bool {
+        match self {
+            GpuDevice::Amd(d) => d.is_primary,
+            GpuDevice::Nvidia(d) => d.is_primary,
+        }
+    }
 }
 
 /// Shared, process-wide GPU monitoring service.
 ///
-/// Discovers all available GPUs at startup and polls one selected device
-/// at regular intervals via vendor-specific backends (AMD sysfs, NVIDIA NVML).
+/// Discovers all available GPUs at startup and polls them at regular intervals
+/// via vendor-specific backends (AMD sysfs, NVIDIA NVML).
 /// Notifies registered callbacks whenever the snapshot updates.
 ///
 /// Unlike other services, GPU polling is demand-driven: callers must use
@@ -175,7 +267,7 @@ pub struct GpuService {
     /// All discovered GPU devices.
     devices: Vec<GpuDevice>,
 
-    /// Index into `devices` of the currently polled GPU, or `None` if no GPU.
+    /// Preferred GPU index used for display ordering and summary fields.
     selected_index: Cell<Option<usize>>,
 
     /// Polling interval in seconds.
@@ -290,7 +382,7 @@ impl GpuService {
     /// Requires `&Rc<Self>` because `start_polling` creates a weak reference
     /// for the timer closure.
     pub fn request_polling(this: &Rc<Self>) {
-        if this.selected_index.get().is_none() {
+        if this.devices.is_empty() {
             return;
         }
         let prev = this.poll_requests.get();
@@ -317,17 +409,33 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        let Some(idx) = self.selected_index.get() else {
+        if self.devices.is_empty() {
             return;
-        };
-        let Some(device) = self.devices.get(idx) else {
-            return;
-        };
+        }
 
+        let mut snapshots = Vec::with_capacity(self.devices.len());
+
+        if let Some(selected_index) = self.selected_index.get()
+            && let Some(device) = self.devices.get(selected_index)
+        {
+            snapshots.push(Self::poll_device(selected_index, device));
+        }
+
+        for (idx, device) in self.devices.iter().enumerate() {
+            if Some(idx) == self.selected_index.get() {
+                continue;
+            }
+            snapshots.push(Self::poll_device(idx, device));
+        }
+
+        let snapshot = GpuSnapshot::from_devices(snapshots);
+        *self.snapshot.borrow_mut() = snapshot;
+        self.callbacks.notify(&self.snapshot.borrow());
+    }
+
+    fn poll_device(idx: usize, device: &GpuDevice) -> GpuDeviceSnapshot {
         trace!("GpuService: polling GPU {} metrics", idx);
 
-        // Check hardware power state before touching vendor APIs.
-        // NVML calls prevent NVIDIA GPUs from entering D3cold sleep.
         let runtime_path = match device {
             GpuDevice::Amd(d) => d.runtime_status_path.as_deref(),
             GpuDevice::Nvidia(d) => d.runtime_status_path.as_deref(),
@@ -338,15 +446,11 @@ impl GpuService {
 
         if power_state == GpuPowerState::Suspended {
             trace!("GpuService: GPU {} is suspended, skipping vendor poll", idx);
-            let snapshot = GpuSnapshot {
-                available: true,
+            return GpuDeviceSnapshot {
                 power_state: GpuPowerState::Suspended,
                 device_name: device.name().map(str::to_string),
                 ..Default::default()
             };
-            *self.snapshot.borrow_mut() = snapshot;
-            self.callbacks.notify(&self.snapshot.borrow());
-            return;
         }
 
         let mut snapshot = match device {
@@ -354,12 +458,10 @@ impl GpuService {
             GpuDevice::Nvidia(nvidia) => Self::poll_nvidia(nvidia),
         };
         snapshot.power_state = power_state;
-
-        *self.snapshot.borrow_mut() = snapshot;
-        self.callbacks.notify(&self.snapshot.borrow());
+        snapshot
     }
 
-    fn poll_amd(device: &AmdGpuDevice) -> GpuSnapshot {
+    fn poll_amd(device: &AmdGpuDevice) -> GpuDeviceSnapshot {
         let gpu_usage =
             read_sysfs_u32(&device.device_path.join("gpu_busy_percent")).map(|v| v.min(100) as f32);
 
@@ -379,8 +481,7 @@ impl GpuService {
             (None, None, None)
         };
 
-        GpuSnapshot {
-            available: true,
+        GpuDeviceSnapshot {
             gpu_usage,
             vram_used,
             vram_total,
@@ -392,13 +493,12 @@ impl GpuService {
         }
     }
 
-    fn poll_nvidia(nvidia: &NvidiaGpuDevice) -> GpuSnapshot {
+    fn poll_nvidia(nvidia: &NvidiaGpuDevice) -> GpuDeviceSnapshot {
         let device = match nvidia.nvml.device_by_index(nvidia.device_index) {
             Ok(d) => d,
             Err(e) => {
                 warn!("GpuService: failed to acquire NVIDIA device handle: {e}");
-                return GpuSnapshot {
-                    available: true,
+                return GpuDeviceSnapshot {
                     device_name: nvidia.device_name.clone(),
                     ..Default::default()
                 };
@@ -425,8 +525,7 @@ impl GpuService {
 
         let power_watts = device.power_usage().ok().map(|mw| mw as f32 / 1000.0);
 
-        GpuSnapshot {
-            available: true,
+        GpuDeviceSnapshot {
             gpu_usage,
             vram_used,
             vram_total,
@@ -504,9 +603,10 @@ impl GpuService {
                     let hwmon_path = discover_hwmon(&device_path);
                     let device_name = read_device_name(&device_path);
 
-                    // boot_vga: 1 = primary (typically integrated), 0 = secondary (typically discrete).
+                    // boot_vga: 1 = primary VGA device, 0 = non-primary.
                     let boot_vga = read_sysfs_u32(&device_path.join("boot_vga"));
-                    let is_discrete = boot_vga.map(|v| v == 0).unwrap_or(false);
+                    let is_discrete = boot_vga == Some(0);
+                    let is_primary = boot_vga == Some(1);
 
                     // Resolve the PCI device path for runtime_status.
                     // device_path is a symlink like /sys/class/drm/card1/device ->
@@ -527,6 +627,7 @@ impl GpuService {
                         runtime_status_path,
                         device_name,
                         is_discrete,
+                        is_primary,
                     });
                 }
             }
@@ -567,21 +668,20 @@ impl GpuService {
 
             let device_name = device.name().ok();
 
-            // Get PCI bus ID for runtime_status path.
-            // NVML uses an 8-char domain ("00000000:06:00.0") while sysfs uses
-            // 4-char ("0000:06:00.0"). Normalize by stripping leading zeros and
-            // re-adding a 4-char prefix.
-            let runtime_status_path = device
+            let pci_device_path = device
                 .pci_info()
                 .ok()
-                .map(|pci| {
-                    let bus_id = pci.bus_id.trim_start_matches('0');
-                    let bus_id = format!("0000{bus_id}").to_lowercase();
-                    PathBuf::from(format!(
-                        "/sys/bus/pci/devices/{bus_id}/power/runtime_status",
-                    ))
-                })
+                .and_then(|pci| sysfs_pci_device_path_from_nvml_bus_id(&pci.bus_id));
+
+            let runtime_status_path = pci_device_path
+                .as_ref()
+                .map(|path| path.join("power/runtime_status"))
                 .filter(|p| p.exists());
+
+            let is_primary = pci_device_path
+                .as_ref()
+                .and_then(|path| read_sysfs_u32(&path.join("boot_vga")))
+                == Some(1);
 
             debug!(
                 "GpuService: found NVIDIA GPU {:?} (nvml_index: {})",
@@ -593,6 +693,7 @@ impl GpuService {
                 device_index,
                 device_name,
                 runtime_status_path,
+                is_primary,
             });
         }
 
@@ -634,10 +735,22 @@ impl GpuService {
         Self::auto_select(devices)
     }
 
-    /// Auto-select a GPU: prefer discrete, then index 0.
+    /// Auto-select a GPU: prefer the primary discrete GPU, then any discrete
+    /// GPU, then the primary GPU, then index 0.
     fn auto_select(devices: &[GpuDevice]) -> Option<usize> {
         if devices.is_empty() {
             return None;
+        }
+
+        if let Some(idx) = devices
+            .iter()
+            .position(|d| d.is_discrete() && d.is_primary())
+        {
+            debug!(
+                "GpuService: auto-selected primary discrete GPU at index {}",
+                idx
+            );
+            return Some(idx);
         }
 
         // Prefer the first discrete GPU.
@@ -646,8 +759,13 @@ impl GpuService {
             return Some(idx);
         }
 
+        if let Some(idx) = devices.iter().position(|d| d.is_primary()) {
+            debug!("GpuService: auto-selected primary GPU at index {}", idx);
+            return Some(idx);
+        }
+
         // Fall back to the first GPU.
-        debug!("GpuService: no discrete GPU found, defaulting to index 0");
+        debug!("GpuService: no primary/discrete GPU found, defaulting to index 0");
         Some(0)
     }
 }
@@ -686,12 +804,41 @@ fn discover_hwmon(device_path: &Path) -> Option<PathBuf> {
 /// Tries `product_name` first (available on some AMD GPUs), then falls back
 /// to reading `vendor` + `device` IDs.
 fn read_device_name(device_path: &Path) -> Option<String> {
-    if let Some(name) = read_sysfs_string(&device_path.join("product_name")) {
+    choose_device_name(
+        read_sysfs_string(&device_path.join("product_name")),
+        read_udev_model_name(device_path),
+        read_sysfs_string(&device_path.join("vendor")),
+        read_sysfs_string(&device_path.join("device")),
+    )
+}
+
+fn read_udev_model_name(device_path: &Path) -> Option<String> {
+    let syspath = fs::canonicalize(device_path).ok()?;
+    let device = udev::Device::from_syspath(&syspath).ok()?;
+    device
+        .property_value("ID_MODEL_FROM_DATABASE")
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn choose_device_name(
+    product_name: Option<String>,
+    udev_model_name: Option<String>,
+    vendor_id: Option<String>,
+    device_id: Option<String>,
+) -> Option<String> {
+    if let Some(name) = product_name.filter(|name| !name.trim().is_empty()) {
         return Some(name);
     }
 
-    let vendor = read_sysfs_string(&device_path.join("vendor"))?;
-    let device = read_sysfs_string(&device_path.join("device"))?;
+    if let Some(name) = udev_model_name.filter(|name| !name.trim().is_empty()) {
+        return Some(name);
+    }
+
+    let vendor = vendor_id?;
+    let device = device_id?;
     Some(format!(
         "GPU [{}:{}]",
         vendor.trim_start_matches("0x"),
@@ -731,14 +878,37 @@ fn read_runtime_status(path: &Path) -> GpuPowerState {
     }
 }
 
+fn sysfs_pci_device_path_from_nvml_bus_id(bus_id: &str) -> Option<PathBuf> {
+    let trimmed = bus_id.trim().trim_end_matches('\0');
+    let (domain_hex, bus_slot) = trimmed.split_once(':')?;
+    let domain = u32::from_str_radix(domain_hex, 16).ok()?;
+    if domain > u16::MAX as u32 {
+        return None;
+    }
+
+    Some(PathBuf::from(format!(
+        "/sys/bus/pci/devices/{:04x}:{}",
+        domain,
+        bus_slot.to_lowercase()
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn device_vram_percent(snapshot: &GpuDeviceSnapshot) -> Option<f32> {
+        match (snapshot.vram_used, snapshot.vram_total) {
+            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
+            _ => None,
+        }
+    }
 
     #[test]
     fn test_gpu_snapshot_defaults() {
         let snap = GpuSnapshot::default();
         assert!(!snap.available);
+        assert!(snap.devices.is_empty());
         assert!(snap.gpu_usage.is_none());
         assert!(snap.vram_used.is_none());
         assert!(snap.vram_total.is_none());
@@ -765,33 +935,120 @@ mod tests {
 
     #[test]
     fn test_vram_percent() {
-        let mut snap = GpuSnapshot::default();
-        assert!(snap.vram_percent().is_none());
+        let mut snap = GpuDeviceSnapshot::default();
+        assert!(device_vram_percent(&snap).is_none());
 
         snap.vram_used = Some(4 * 1024 * 1024 * 1024); // 4 GB
         snap.vram_total = Some(8 * 1024 * 1024 * 1024); // 8 GB
-        let pct = snap.vram_percent().unwrap();
+        let pct = device_vram_percent(&snap).unwrap();
         assert!((pct - 50.0).abs() < 0.01);
     }
 
     #[test]
     fn test_vram_percent_zero_total() {
-        let snap = GpuSnapshot {
+        let snap = GpuDeviceSnapshot {
             vram_used: Some(0),
             vram_total: Some(0),
             ..Default::default()
         };
-        assert!(snap.vram_percent().is_none());
+        assert!(device_vram_percent(&snap).is_none());
+    }
+
+    #[test]
+    fn test_choose_device_name_prefers_product_name_then_udev_then_ids() {
+        assert_eq!(
+            choose_device_name(
+                Some("AMD Radeon 780M".to_string()),
+                Some("Granite Ridge [Radeon Graphics]".to_string()),
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("AMD Radeon 780M".to_string())
+        );
+
+        assert_eq!(
+            choose_device_name(
+                None,
+                Some("Granite Ridge [Radeon Graphics]".to_string()),
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("Granite Ridge [Radeon Graphics]".to_string())
+        );
+
+        assert_eq!(
+            choose_device_name(
+                None,
+                None,
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("GPU [1002:13c0]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_snapshot_from_devices_uses_first_device_as_summary() {
+        let snap = GpuSnapshot::from_devices(vec![
+            GpuDeviceSnapshot {
+                gpu_usage: Some(75.0),
+                device_name: Some("Primary GPU".to_string()),
+                ..Default::default()
+            },
+            GpuDeviceSnapshot {
+                gpu_usage: Some(35.0),
+                device_name: Some("Secondary GPU".to_string()),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(snap.available);
+        assert_eq!(snap.gpu_usage, Some(75.0));
+        assert_eq!(snap.device_name.as_deref(), Some("Primary GPU"));
+        assert_eq!(snap.devices.len(), 2);
+    }
+
+    #[test]
+    fn test_is_gpu_high_checks_all_devices() {
+        let snap = GpuSnapshot::from_devices(vec![
+            GpuDeviceSnapshot {
+                gpu_usage: Some(10.0),
+                ..Default::default()
+            },
+            GpuDeviceSnapshot {
+                gpu_usage: Some(95.0),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(snap.is_gpu_high());
+    }
+
+    #[test]
+    fn test_devices_for_display_falls_back_to_summary_fields() {
+        let snap = GpuSnapshot {
+            available: true,
+            power_state: GpuPowerState::Active,
+            gpu_usage: Some(64.0),
+            device_name: Some("Fallback GPU".to_string()),
+            ..Default::default()
+        };
+
+        let devices = snap.devices_for_display();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].gpu_usage, Some(64.0));
+        assert_eq!(devices[0].device_name.as_deref(), Some("Fallback GPU"));
     }
 
     /// Helper to create a dummy AMD GPU device for selection tests.
-    fn dummy_amd(name: &str, is_discrete: bool) -> GpuDevice {
+    fn dummy_amd(name: &str, is_discrete: bool, is_primary: bool) -> GpuDevice {
         GpuDevice::Amd(AmdGpuDevice {
             device_path: PathBuf::from("/dev/null"),
             hwmon_path: None,
             runtime_status_path: None,
             device_name: Some(name.to_string()),
             is_discrete,
+            is_primary,
         })
     }
 
@@ -802,33 +1059,63 @@ mod tests {
 
     #[test]
     fn test_auto_select_single_integrated() {
-        let devices = vec![dummy_amd("iGPU", false)];
+        let devices = vec![dummy_amd("iGPU", false, true)];
         assert_eq!(GpuService::auto_select(&devices), Some(0));
     }
 
     #[test]
     fn test_auto_select_prefers_discrete() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+        assert_eq!(GpuService::auto_select(&devices), Some(1));
+    }
+
+    #[test]
+    fn test_auto_select_prefers_primary_discrete() {
+        let devices = vec![
+            dummy_amd("secondary-dgpu", true, false),
+            dummy_amd("primary-dgpu", true, true),
+        ];
         assert_eq!(GpuService::auto_select(&devices), Some(1));
     }
 
     #[test]
     fn test_select_gpu_explicit_index() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
         // Explicit config overrides auto-selection.
         assert_eq!(GpuService::select_gpu(&devices, &Some(0)), Some(0));
     }
 
     #[test]
     fn test_select_gpu_out_of_range_falls_back() {
-        let devices = vec![dummy_amd("dGPU", true)];
+        let devices = vec![dummy_amd("dGPU", true, true)];
         // Out-of-range index falls back to auto (which picks discrete at 0).
         assert_eq!(GpuService::select_gpu(&devices, &Some(5)), Some(0));
     }
 
     #[test]
     fn test_select_gpu_none_config_uses_auto() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
         assert_eq!(GpuService::select_gpu(&devices, &None), Some(1));
+    }
+
+    #[test]
+    fn test_nvml_bus_id_to_sysfs_path_normalizes_domain() {
+        assert_eq!(
+            sysfs_pci_device_path_from_nvml_bus_id("00000000:01:00.0"),
+            Some(PathBuf::from("/sys/bus/pci/devices/0000:01:00.0"))
+        );
+        assert_eq!(
+            sysfs_pci_device_path_from_nvml_bus_id("00000080:3B:00.0"),
+            Some(PathBuf::from("/sys/bus/pci/devices/0080:3b:00.0"))
+        );
     }
 }

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -359,7 +359,7 @@ pub struct GpuService {
     devices: Vec<GpuDevice>,
 
     /// GPU indices currently configured for display and polling.
-    display_indices: Vec<usize>,
+    display_indices: RefCell<Vec<usize>>,
 
     /// Polling interval in seconds.
     poll_interval: Cell<u32>,
@@ -376,19 +376,7 @@ impl GpuService {
         let display_selection = Self::read_display_config();
         let display_indices = Self::resolve_display_indices(&devices, &display_selection);
 
-        if let Some(idx) = display_indices.first().copied() {
-            debug!(
-                "GpuService: selected GPU {} ({:?}) via {}",
-                idx,
-                devices[idx].name().unwrap_or("unknown"),
-                Self::display_selection_description(&display_selection),
-            );
-            if display_indices.len() > 1 {
-                debug!("GpuService: displaying GPU indices {:?}", display_indices);
-            }
-        } else {
-            debug!("GpuService: no GPU selected");
-        }
+        Self::log_display_selection(&devices, &display_selection, &display_indices);
 
         let initial_snapshot = if !display_indices.is_empty() {
             GpuSnapshot {
@@ -404,7 +392,7 @@ impl GpuService {
             callbacks: Callbacks::new(),
             timer_source: RefCell::new(None),
             devices,
-            display_indices,
+            display_indices: RefCell::new(display_indices),
             poll_interval: Cell::new(DEFAULT_POLL_INTERVAL_SECS),
             poll_requests: Cell::new(0),
         })
@@ -436,6 +424,29 @@ impl GpuService {
 
     pub fn snapshot(&self) -> GpuSnapshot {
         self.snapshot.borrow().clone()
+    }
+
+    pub fn reconfigure(&self) {
+        if !self.refresh_display_selection() {
+            return;
+        }
+
+        if self.poll_requests.get() > 0 {
+            self.poll();
+            return;
+        }
+
+        let snapshot = if self.display_indices.borrow().is_empty() {
+            GpuSnapshot::unknown()
+        } else {
+            GpuSnapshot {
+                available: true,
+                ..Default::default()
+            }
+        };
+
+        *self.snapshot.borrow_mut() = snapshot;
+        self.callbacks.notify(&self.snapshot.borrow());
     }
 
     fn start_polling(this: &Rc<Self>) {
@@ -498,19 +509,22 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        if self.display_indices.is_empty() {
-            return;
-        }
+        let display_indices = self.display_indices.borrow();
+        let snapshot = if display_indices.is_empty() {
+            GpuSnapshot::unknown()
+        } else {
+            let mut snapshots = Vec::with_capacity(display_indices.len());
 
-        let mut snapshots = Vec::with_capacity(self.display_indices.len());
-
-        for &idx in &self.display_indices {
-            if let Some(device) = self.devices.get(idx) {
-                snapshots.push(Self::poll_device(idx, device));
+            for &idx in display_indices.iter() {
+                if let Some(device) = self.devices.get(idx) {
+                    snapshots.push(Self::poll_device(idx, device));
+                }
             }
-        }
 
-        let snapshot = GpuSnapshot::from_devices(snapshots);
+            GpuSnapshot::from_devices(snapshots)
+        };
+        drop(display_indices);
+
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
     }
@@ -871,6 +885,39 @@ impl GpuService {
                 format!("config (devices = {:?})", indices)
             }
         }
+    }
+
+    fn log_display_selection(
+        devices: &[GpuDevice],
+        selection: &GpuDisplaySelection,
+        display_indices: &[usize],
+    ) {
+        if let Some(idx) = display_indices.first().copied() {
+            debug!(
+                "GpuService: selected GPU {} ({:?}) via {}",
+                idx,
+                devices[idx].name().unwrap_or("unknown"),
+                Self::display_selection_description(selection),
+            );
+            if display_indices.len() > 1 {
+                debug!("GpuService: displaying GPU indices {:?}", display_indices);
+            }
+        } else {
+            debug!("GpuService: no GPU selected");
+        }
+    }
+
+    fn refresh_display_selection(&self) -> bool {
+        let display_selection = Self::read_display_config();
+        let display_indices = Self::resolve_display_indices(&self.devices, &display_selection);
+        let changed = *self.display_indices.borrow() != display_indices;
+
+        if changed {
+            Self::log_display_selection(&self.devices, &display_selection, &display_indices);
+            *self.display_indices.borrow_mut() = display_indices;
+        }
+
+        changed
     }
 
     fn resolve_display_indices(

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -39,11 +39,13 @@
 //! ```
 
 use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, VecDeque};
 use std::fs::{self, OpenOptions};
 use std::mem;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use gtk4::glib::{self, SourceId};
 use nvml_wrapper::Nvml;
@@ -54,6 +56,20 @@ use super::callbacks::{CallbackId, Callbacks};
 use super::config_manager::ConfigManager;
 
 const DEFAULT_POLL_INTERVAL_SECS: u32 = 3;
+
+/// Number of utilization samples retained per device.
+pub const GPU_HISTORY_SAMPLES: usize = 60;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct GpuHistorySample {
+    pub usage: Option<f32>,
+}
+
+impl GpuHistorySample {
+    fn is_gap(&self) -> bool {
+        self.usage.is_none()
+    }
+}
 
 /// Threshold above which GPU usage is considered "high" (higher than CPU since sustained GPU load is normal).
 pub(crate) const GPU_HIGH_USAGE_THRESHOLD: f32 = 90.0;
@@ -163,15 +179,26 @@ pub struct GpuDeviceSnapshot {
     pub vram_total: Option<u64>,
     /// GPU temperature in degrees Celsius.
     pub temperature: Option<f32>,
-    /// GPU clock speed in MHz.
+    /// Current GPU graphics clock in MHz.
     pub clock_mhz: Option<u64>,
+    /// Maximum GPU graphics clock in MHz.
+    pub max_clock_mhz: Option<u64>,
     /// GPU power draw in watts.
     pub power_watts: Option<f32>,
+    /// Enforced GPU power limit in watts.
+    pub power_limit_watts: Option<f32>,
     /// Device name (product name, or `vendor:device` PCI ID fallback).
     pub device_name: Option<String>,
 }
 
 impl GpuDeviceSnapshot {
+    pub fn vram_percent(&self) -> Option<f32> {
+        match (self.vram_used, self.vram_total) {
+            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
+            _ => None,
+        }
+    }
+
     fn is_gpu_high(&self) -> bool {
         self.gpu_usage
             .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
@@ -181,7 +208,7 @@ impl GpuDeviceSnapshot {
 
 #[derive(Debug, Clone, Default)]
 pub struct GpuSnapshot {
-    /// Per-device snapshots in display order (preferred GPU first).
+    /// Per-device snapshots in configured display order.
     pub devices: Vec<GpuDeviceSnapshot>,
 }
 
@@ -222,6 +249,8 @@ struct AmdGpuDevice {
 
     device_name: Option<String>,
 
+    max_clock_mhz: Option<u64>,
+
     /// Whether this is a discrete GPU (determined via AMDGPU FUSION flag or fallback markers).
     is_discrete: bool,
 
@@ -236,6 +265,7 @@ struct NvidiaGpuDevice {
 
     device_index: u32,
     device_name: Option<String>,
+    max_clock_mhz: Option<u64>,
 
     /// Sysfs `power/runtime_status` path for checking hardware power state.
     runtime_status_path: Option<PathBuf>,
@@ -271,6 +301,20 @@ impl GpuDevice {
             GpuDevice::Nvidia(d) => d.is_primary,
         }
     }
+
+    fn max_clock_mhz(&self) -> Option<u64> {
+        match self {
+            GpuDevice::Amd(d) => d.max_clock_mhz,
+            GpuDevice::Nvidia(d) => d.max_clock_mhz,
+        }
+    }
+
+    fn runtime_status_path(&self) -> Option<&Path> {
+        match self {
+            GpuDevice::Amd(d) => d.runtime_status_path.as_deref(),
+            GpuDevice::Nvidia(d) => d.runtime_status_path.as_deref(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -279,6 +323,127 @@ enum GpuDisplaySelection {
     Auto,
     All,
     Explicit(Vec<usize>),
+}
+
+#[cfg(debug_assertions)]
+const MAX_MOCK_GPUS: usize = 4;
+#[cfg(debug_assertions)]
+const MOCK_GPU_NAMES: [&str; MAX_MOCK_GPUS] = [
+    "NVIDIA GeForce RTX 4070 Laptop GPU",
+    "Intel(R) UHD Graphics 620",
+    "Navi 31 [Radeon RX 7900 XT]",
+    "AMD Radeon 780M",
+];
+#[cfg(debug_assertions)]
+const MOCK_GPU_POWER_LIMITS: [f32; MAX_MOCK_GPUS] = [140.0, 28.0, 355.0, 65.0];
+#[cfg(debug_assertions)]
+const MOCK_GPU_MAX_CLOCKS: [u64; MAX_MOCK_GPUS] = [2475, 1150, 2500, 2900];
+#[cfg(debug_assertions)]
+const MOCK_GPU_VRAM_TOTALS: [u64; MAX_MOCK_GPUS] = [
+    8 * 1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+    20 * 1024 * 1024 * 1024,
+    4 * 1024 * 1024 * 1024,
+];
+
+/// Debug-only synthetic GPUs for evaluating multi-device layouts.
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone, Default)]
+struct MockGpuConfig {
+    count: usize,
+    suspended: Vec<usize>,
+}
+
+#[cfg(debug_assertions)]
+impl MockGpuConfig {
+    fn from_env() -> Self {
+        Self::parse(
+            std::env::var("VIBEPANEL_MOCK_GPUS").ok().as_deref(),
+            std::env::var("VIBEPANEL_MOCK_GPU_SUSPEND").ok().as_deref(),
+        )
+    }
+
+    fn parse(count: Option<&str>, suspended: Option<&str>) -> Self {
+        let count = count
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(0)
+            .min(MAX_MOCK_GPUS);
+        let suspended = suspended
+            .map(|value| {
+                value
+                    .split(',')
+                    .filter_map(|part| part.trim().parse::<usize>().ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self { count, suspended }
+    }
+
+    fn enabled(&self) -> bool {
+        self.count > 0
+    }
+
+    fn devices(&self, first_index: usize, seconds: f64) -> Vec<GpuDeviceSnapshot> {
+        (0..self.count)
+            .map(|slot| {
+                let device_index = first_index + slot;
+                let device_name = Some(MOCK_GPU_NAMES[slot].to_string());
+                if self.suspended.contains(&slot) {
+                    return GpuDeviceSnapshot {
+                        device_index,
+                        power_state: GpuPowerState::Suspended,
+                        device_name,
+                        ..Default::default()
+                    };
+                }
+
+                let phase = slot as f64 * 2.1;
+                let usage = mock_wave(seconds, phase);
+                let vram_total = MOCK_GPU_VRAM_TOTALS[slot];
+                let vram_fraction = 0.32 + 0.34 * mock_wave(seconds * 0.18, phase + 1.3);
+                let power_limit = MOCK_GPU_POWER_LIMITS[slot];
+                let max_clock = MOCK_GPU_MAX_CLOCKS[slot];
+
+                GpuDeviceSnapshot {
+                    device_index,
+                    power_state: GpuPowerState::Active,
+                    gpu_usage: Some((usage * 100.0) as f32),
+                    vram_used: Some((vram_total as f64 * vram_fraction) as u64),
+                    vram_total: Some(vram_total),
+                    temperature: Some((42.0 + usage * 42.0) as f32),
+                    clock_mhz: Some((300.0 + usage * (max_clock as f64 - 300.0)) as u64),
+                    max_clock_mhz: Some(max_clock),
+                    power_watts: Some((f64::from(power_limit) * (0.12 + 0.78 * usage)) as f32),
+                    power_limit_watts: Some(power_limit),
+                    device_name,
+                }
+            })
+            .collect()
+    }
+}
+
+fn push_history_sample(samples: &mut VecDeque<GpuHistorySample>, value: GpuHistorySample) {
+    if samples.len() == GPU_HISTORY_SAMPLES {
+        samples.pop_front();
+    }
+    samples.push_back(value);
+}
+
+#[cfg(debug_assertions)]
+fn mock_wave(seconds: f64, phase: f64) -> f64 {
+    (0.48
+        + 0.30 * ((seconds / 13.0) + phase).sin()
+        + 0.14 * ((seconds / 4.3) + phase * 2.0).sin()
+        + 0.06 * ((seconds / 1.7) + phase * 3.0).sin())
+    .clamp(0.0, 1.0)
+}
+
+#[cfg(debug_assertions)]
+fn mock_seconds() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs_f64())
+        .unwrap_or(0.0)
 }
 
 /// Shared, process-wide GPU monitoring service.
@@ -309,6 +474,12 @@ pub struct GpuService {
 
     /// Reference count for polling requests. Polling runs only while > 0.
     poll_requests: Cell<u32>,
+
+    history: RefCell<HashMap<usize, VecDeque<GpuHistorySample>>>,
+    last_sample_at: Cell<Option<Instant>>,
+
+    #[cfg(debug_assertions)]
+    mock: MockGpuConfig,
 }
 
 impl GpuService {
@@ -323,6 +494,21 @@ impl GpuService {
 
         let initial_snapshot = Self::placeholder_snapshot(&devices, &display_indices);
 
+        #[cfg(debug_assertions)]
+        let mock = MockGpuConfig::from_env();
+        #[cfg(debug_assertions)]
+        let initial_snapshot = if mock.enabled() {
+            warn!(
+                "GpuService: VIBEPANEL_MOCK_GPUS is set, appending {} synthetic GPU(s)",
+                mock.count
+            );
+            let mut snapshots = initial_snapshot.devices;
+            snapshots.extend(mock.devices(devices.len(), mock_seconds()));
+            GpuSnapshot::from_devices(snapshots)
+        } else {
+            initial_snapshot
+        };
+
         Rc::new(Self {
             snapshot: RefCell::new(initial_snapshot),
             callbacks: Callbacks::new(),
@@ -331,6 +517,10 @@ impl GpuService {
             display_indices: RefCell::new(display_indices),
             poll_interval: Cell::new(DEFAULT_POLL_INTERVAL_SECS),
             poll_requests: Cell::new(0),
+            history: RefCell::new(HashMap::new()),
+            last_sample_at: Cell::new(None),
+            #[cfg(debug_assertions)]
+            mock,
         })
     }
 
@@ -363,19 +553,9 @@ impl GpuService {
     }
 
     pub fn reconfigure(&self) {
-        if !self.refresh_display_selection() {
-            return;
-        }
-
-        if self.poll_requests.get() > 0 {
+        if self.refresh_display_selection() && self.poll_requests.get() > 0 {
             self.poll();
-            return;
         }
-
-        let snapshot = Self::placeholder_snapshot(&self.devices, &self.display_indices.borrow());
-
-        *self.snapshot.borrow_mut() = snapshot;
-        self.callbacks.notify(&self.snapshot.borrow());
     }
 
     fn start_polling(this: &Rc<Self>) {
@@ -411,7 +591,12 @@ impl GpuService {
     /// Requires `&Rc<Self>` because `start_polling` creates a weak reference
     /// for the timer closure.
     pub fn request_polling(this: &Rc<Self>) {
-        if this.devices.is_empty() {
+        #[cfg(debug_assertions)]
+        let has_mock = this.mock.enabled();
+        #[cfg(not(debug_assertions))]
+        let has_mock = false;
+
+        if this.devices.is_empty() && !has_mock {
             return;
         }
         let prev = this.poll_requests.get();
@@ -434,34 +619,79 @@ impl GpuService {
         if prev == 1 {
             debug!("GpuService: last poll request released, stopping polling");
             self.stop_polling();
+            self.record_history_break();
         }
     }
 
     fn poll(&self) {
-        let snapshot = GpuSnapshot::from_devices(
-            self.display_indices
-                .borrow()
-                .iter()
-                .filter_map(|&idx| {
-                    self.devices
-                        .get(idx)
-                        .map(|device| Self::poll_device(idx, device))
-                })
-                .collect(),
-        );
+        #[allow(unused_mut)]
+        let mut devices: Vec<GpuDeviceSnapshot> = self
+            .display_indices
+            .borrow()
+            .iter()
+            .filter_map(|&idx| {
+                self.devices
+                    .get(idx)
+                    .map(|device| Self::poll_device(idx, device))
+            })
+            .collect();
+
+        #[cfg(debug_assertions)]
+        if self.mock.enabled() {
+            devices.extend(self.mock.devices(self.devices.len(), mock_seconds()));
+        }
+
+        self.record_history(&devices);
+        let snapshot = GpuSnapshot::from_devices(devices);
 
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
     }
 
+    fn record_history(&self, devices: &[GpuDeviceSnapshot]) {
+        let now = Instant::now();
+        let history_window =
+            Duration::from_secs(u64::from(self.poll_interval.get()) * GPU_HISTORY_SAMPLES as u64);
+        let mut history = self.history.borrow_mut();
+        if self
+            .last_sample_at
+            .replace(Some(now))
+            .is_some_and(|previous| now.duration_since(previous) > history_window)
+        {
+            history.clear();
+        }
+
+        for device in devices {
+            push_history_sample(
+                history.entry(device.device_index).or_default(),
+                GpuHistorySample {
+                    usage: device.gpu_usage,
+                },
+            );
+        }
+    }
+
+    fn record_history_break(&self) {
+        for samples in self.history.borrow_mut().values_mut() {
+            if !samples.back().is_some_and(GpuHistorySample::is_gap) {
+                push_history_sample(samples, GpuHistorySample::default());
+            }
+        }
+    }
+
+    pub fn history(&self, device_index: usize) -> Vec<GpuHistorySample> {
+        self.history
+            .borrow()
+            .get(&device_index)
+            .map(|samples| samples.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
     fn poll_device(idx: usize, device: &GpuDevice) -> GpuDeviceSnapshot {
         trace!("GpuService: polling GPU {} metrics", idx);
 
-        let runtime_path = match device {
-            GpuDevice::Amd(d) => d.runtime_status_path.as_deref(),
-            GpuDevice::Nvidia(d) => d.runtime_status_path.as_deref(),
-        };
-        let power_state = runtime_path
+        let power_state = device
+            .runtime_status_path()
             .map(read_runtime_status)
             .unwrap_or(GpuPowerState::Unknown);
 
@@ -471,6 +701,7 @@ impl GpuService {
                 device_index: idx,
                 power_state: GpuPowerState::Suspended,
                 device_name: device.name().map(str::to_string),
+                max_clock_mhz: device.max_clock_mhz(),
                 ..Default::default()
             };
         }
@@ -492,6 +723,7 @@ impl GpuService {
                     devices.get(device_index).map(|device| GpuDeviceSnapshot {
                         device_index,
                         device_name: device.name().map(str::to_string),
+                        max_clock_mhz: device.max_clock_mhz(),
                         ..Default::default()
                     })
                 })
@@ -506,18 +738,23 @@ impl GpuService {
         let vram_used = read_sysfs_u64(&device.device_path.join("mem_info_vram_used"));
         let vram_total = read_sysfs_u64(&device.device_path.join("mem_info_vram_total"));
 
-        let (temperature, clock_mhz, power_watts) = if let Some(ref hwmon) = device.hwmon_path {
-            let temp = read_sysfs_u32(&hwmon.join("temp1_input")).map(|v| v as f32 / 1000.0);
+        let (temperature, clock_mhz, power_watts, power_limit_watts) =
+            if let Some(ref hwmon) = device.hwmon_path {
+                let temp = read_sysfs_u32(&hwmon.join("temp1_input")).map(|v| v as f32 / 1000.0);
 
-            let clock = read_sysfs_u64(&hwmon.join("freq1_input")).map(|v| v / 1_000_000);
+                let clock = read_sysfs_u64(&hwmon.join("freq1_input")).map(|v| v / 1_000_000);
 
-            let power =
-                read_sysfs_u64(&hwmon.join("power1_average")).map(|v| v as f32 / 1_000_000.0);
+                let power = read_sysfs_u64(&hwmon.join("power1_average"))
+                    .or_else(|| read_sysfs_u64(&hwmon.join("power1_input")))
+                    .map(|v| v as f32 / 1_000_000.0);
 
-            (temp, clock, power)
-        } else {
-            (None, None, None)
-        };
+                let power_limit =
+                    read_sysfs_u64(&hwmon.join("power1_cap")).map(|v| v as f32 / 1_000_000.0);
+
+                (temp, clock, power, power_limit)
+            } else {
+                (None, None, None, None)
+            };
 
         GpuDeviceSnapshot {
             gpu_usage,
@@ -525,7 +762,9 @@ impl GpuService {
             vram_total,
             temperature,
             clock_mhz,
+            max_clock_mhz: device.max_clock_mhz,
             power_watts,
+            power_limit_watts,
             device_name: device.device_name.clone(),
             ..Default::default()
         }
@@ -562,6 +801,10 @@ impl GpuService {
         let clock_mhz = device.clock_info(Clock::Graphics).ok().map(|c| c as u64);
 
         let power_watts = device.power_usage().ok().map(|mw| mw as f32 / 1000.0);
+        let power_limit_watts = device
+            .enforced_power_limit()
+            .ok()
+            .map(|mw| mw as f32 / 1000.0);
 
         GpuDeviceSnapshot {
             gpu_usage,
@@ -569,7 +812,9 @@ impl GpuService {
             vram_total,
             temperature,
             clock_mhz,
+            max_clock_mhz: nvidia.max_clock_mhz,
             power_watts,
+            power_limit_watts,
             device_name: nvidia.device_name.clone(),
             ..Default::default()
         }
@@ -640,8 +885,15 @@ impl GpuService {
                 if driver_name == "amdgpu" {
                     let hwmon_path = discover_hwmon(&device_path);
                     let device_name = read_device_name(&device_path);
+                    let device_info = query_amd_device_info(&device_path);
 
-                    let is_discrete = is_amd_discrete_gpu(&device_path);
+                    let is_discrete = device_info
+                        .as_ref()
+                        .map(|info| info.ids_flags & AMDGPU_IDS_FLAGS_FUSION == 0)
+                        .unwrap_or_else(|| is_amd_discrete_gpu_sysfs_fallback(&device_path));
+                    let max_clock_mhz = device_info
+                        .as_ref()
+                        .and_then(|info| amd_max_clock_mhz(info.max_engine_clock));
                     // boot_vga: 1 = primary VGA device, 0 = non-primary.
                     let boot_vga = read_sysfs_u32(&device_path.join("boot_vga"));
                     let is_primary = boot_vga == Some(1);
@@ -664,6 +916,7 @@ impl GpuService {
                         hwmon_path,
                         runtime_status_path,
                         device_name,
+                        max_clock_mhz,
                         is_discrete,
                         is_primary,
                     });
@@ -701,7 +954,8 @@ impl GpuService {
                 }
             };
 
-            let device_name = device.name().ok();
+            let device_name = device.name().ok().filter(|name| !name.trim().is_empty());
+            let max_clock_mhz = device.max_clock_info(Clock::Graphics).ok().map(u64::from);
 
             let pci_device_path = device
                 .pci_info()
@@ -712,6 +966,13 @@ impl GpuService {
                 .as_ref()
                 .map(|path| path.join("power/runtime_status"))
                 .filter(|p| p.exists());
+
+            if runtime_status_path.is_none() {
+                debug!(
+                    "GpuService: could not resolve runtime power status path for NVIDIA GPU {}",
+                    device_index
+                );
+            }
 
             let is_primary = pci_device_path
                 .as_ref()
@@ -727,6 +988,7 @@ impl GpuService {
                 nvml: nvml.clone(),
                 device_index,
                 device_name,
+                max_clock_mhz,
                 runtime_status_path,
                 is_primary,
             });
@@ -864,6 +1126,9 @@ impl GpuService {
 
         if changed {
             Self::log_display_selection(&self.devices, &display_selection, &display_indices);
+            self.history
+                .borrow_mut()
+                .retain(|idx, _| display_indices.contains(idx));
             *self.display_indices.borrow_mut() = display_indices;
         }
 
@@ -1064,16 +1329,11 @@ fn choose_device_name(
     ))
 }
 
-/// Prefer the AMDGPU kernel driver's FUSION flag for integrated/discrete
-/// classification and fall back to sysfs files exposed for dedicated AMD GPUs.
-fn is_amd_discrete_gpu(device_path: &Path) -> bool {
-    match query_amd_fusion_flag(device_path) {
-        Some(is_fusion) => !is_fusion,
-        None => is_amd_discrete_gpu_sysfs_fallback(device_path),
-    }
+fn amd_max_clock_mhz(max_engine_clock_khz: u64) -> Option<u64> {
+    (max_engine_clock_khz > 0).then_some(max_engine_clock_khz / 1_000)
 }
 
-fn query_amd_fusion_flag(device_path: &Path) -> Option<bool> {
+fn query_amd_device_info(device_path: &Path) -> Option<DrmAmdgpuInfoDeviceIds> {
     let render_node = render_node_for_device(device_path)?;
     let file = OpenOptions::new().read(true).open(&render_node).ok()?;
 
@@ -1101,7 +1361,7 @@ fn query_amd_fusion_flag(device_path: &Path) -> Option<bool> {
         return None;
     }
 
-    Some(device_info.ids_flags & AMDGPU_IDS_FLAGS_FUSION != 0)
+    Some(device_info)
 }
 
 fn render_node_for_device(device_path: &Path) -> Option<PathBuf> {
@@ -1205,18 +1465,63 @@ mod tests {
         }
     }
 
-    fn device_vram_percent(snapshot: &GpuDeviceSnapshot) -> Option<f32> {
-        match (snapshot.vram_used, snapshot.vram_total) {
-            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
-            _ => None,
-        }
-    }
-
     #[test]
     fn test_gpu_snapshot_defaults() {
         let snap = GpuSnapshot::default();
         assert!(!snap.available());
         assert!(snap.devices.is_empty());
+    }
+
+    #[test]
+    fn test_vram_percent() {
+        let snapshot = GpuDeviceSnapshot {
+            vram_used: Some(4),
+            vram_total: Some(8),
+            ..Default::default()
+        };
+        assert_eq!(snapshot.vram_percent(), Some(50.0));
+
+        let zero_total = GpuDeviceSnapshot {
+            vram_used: Some(4),
+            vram_total: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(zero_total.vram_percent(), None);
+    }
+
+    #[test]
+    fn test_history_discards_oldest_samples_beyond_the_cap() {
+        let mut samples = VecDeque::new();
+        for value in 0..=GPU_HISTORY_SAMPLES {
+            push_history_sample(
+                &mut samples,
+                GpuHistorySample {
+                    usage: Some(value as f32),
+                },
+            );
+        }
+        assert_eq!(samples.len(), GPU_HISTORY_SAMPLES);
+        assert_eq!(samples.front().and_then(|sample| sample.usage), Some(1.0));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_mock_gpu_config_requires_explicit_positive_count() {
+        assert!(!MockGpuConfig::parse(None, None).enabled());
+        assert!(!MockGpuConfig::parse(Some("0"), None).enabled());
+        assert!(!MockGpuConfig::parse(Some("invalid"), None).enabled());
+        assert_eq!(MockGpuConfig::parse(Some("99"), None).count, MAX_MOCK_GPUS);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_mock_gpu_devices_include_current_and_max_clock() {
+        let devices = MockGpuConfig::parse(Some("2"), None).devices(3, 1234.0);
+        assert_eq!(devices[0].device_index, 3);
+        for device in devices {
+            assert!(device.clock_mhz.is_some());
+            assert!(device.max_clock_mhz >= device.clock_mhz);
+        }
     }
 
     #[test]
@@ -1314,6 +1619,7 @@ mod tests {
             hwmon_path: None,
             runtime_status_path: None,
             device_name: Some(name.to_string()),
+            max_clock_mhz: None,
             is_discrete,
             is_primary,
         })
@@ -1469,8 +1775,12 @@ mod tests {
 
         let device_info = DrmAmdgpuInfoDeviceIds::default();
         let base = &device_info as *const _ as usize;
+        let max_engine_clock = &device_info.max_engine_clock as *const _ as usize;
         let ids_flags = &device_info.ids_flags as *const _ as usize;
+        assert_eq!(max_engine_clock - base, 32);
         assert_eq!(ids_flags - base, 136);
+        assert_eq!(amd_max_clock_mhz(2_430_000), Some(2430));
+        assert_eq!(amd_max_clock_mhz(0), None);
     }
 
     #[test]

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -20,8 +20,8 @@
 //!
 //! Preferred GPU auto-selection uses the existing heuristic: prefer the primary
 //! discrete GPU, then any discrete GPU, then the primary GPU.
-//! AMD discrete detection queries the kernel driver's FUSION flag; primary
-//! detection uses `boot_vga`.
+//! AMD discrete detection uses the AMDGPU FUSION flag with sysfs fallback markers.
+//! AMD primary detection uses `boot_vga` sysfs.
 //! NVIDIA GPUs are always treated as discrete.
 //! Falls back to index 0 if no better match is found.
 //!

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -7,17 +7,23 @@
 //! - **NVIDIA**: NVML via the `nvml-wrapper` crate (runtime-loaded
 //!   `libnvidia-ml.so`, see [`init_nvml`])
 //!
-//! All GPUs are discovered at startup and polled while the widget or popover is
-//! visible. One preferred GPU is selected only to order the displayed list and
-//! populate the compact summary fields based on:
+//! All GPUs are discovered at startup, but only the configured display set is
+//! polled while the widget or popover is visible.
 //!
-//! 1. **Explicit config**: `device = N` in `[widgets.gpu]` selects a specific index.
-//! 2. **Auto heuristic** (default): Prefers the primary discrete GPU, then any
-//!    discrete GPU, then the primary GPU.
-//!    AMD discrete detection queries the kernel driver's FUSION flag; primary
-//!    detection uses `boot_vga`.
-//!    NVIDIA GPUs are always treated as discrete.
-//!    Falls back to index 0 if no better match is found.
+//! 1. **`devices = "auto"`** (default): shows only the preferred GPU.
+//! 2. **`devices = "all"`**: shows all detected GPUs, ordered with the
+//!    preferred GPU first.
+//! 3. **`devices = [N, M]`** or **`devices = N`**: shows explicit GPU indices
+//!    in the configured order.
+//! 4. **Legacy compatibility**: `device = N` remains accepted as an alias for a
+//!    single explicit GPU selection.
+//!
+//! Preferred GPU auto-selection uses the existing heuristic: prefer the primary
+//! discrete GPU, then any discrete GPU, then the primary GPU.
+//! AMD discrete detection queries the kernel driver's FUSION flag; primary
+//! detection uses `boot_vga`.
+//! NVIDIA GPUs are always treated as discrete.
+//! Falls back to index 0 if no better match is found.
 //!
 //! ## Usage
 //!
@@ -324,6 +330,14 @@ impl GpuDevice {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+enum GpuDisplaySelection {
+    #[default]
+    Auto,
+    All,
+    Explicit(Vec<usize>),
+}
+
 /// Shared, process-wide GPU monitoring service.
 ///
 /// Discovers all available GPUs at startup and polls them at regular intervals
@@ -344,8 +358,8 @@ pub struct GpuService {
     /// All discovered GPU devices.
     devices: Vec<GpuDevice>,
 
-    /// Preferred GPU index used for display ordering and summary fields.
-    selected_index: Cell<Option<usize>>,
+    /// GPU indices currently configured for display and polling.
+    display_indices: Vec<usize>,
 
     /// Polling interval in seconds.
     poll_interval: Cell<u32>,
@@ -359,26 +373,24 @@ impl GpuService {
         debug!("GpuService: initializing");
 
         let devices = Self::discover_all_gpus();
-        let device_selection = Self::read_device_config();
+        let display_selection = Self::read_display_config();
+        let display_indices = Self::resolve_display_indices(&devices, &display_selection);
 
-        let selected_index = Self::select_gpu(&devices, &device_selection);
-
-        if let Some(idx) = selected_index {
-            let method = match device_selection {
-                Some(i) => format!("config (device = {})", i),
-                None => "auto".to_string(),
-            };
+        if let Some(idx) = display_indices.first().copied() {
             debug!(
                 "GpuService: selected GPU {} ({:?}) via {}",
                 idx,
                 devices[idx].name().unwrap_or("unknown"),
-                method,
+                Self::display_selection_description(&display_selection),
             );
+            if display_indices.len() > 1 {
+                debug!("GpuService: displaying GPU indices {:?}", display_indices);
+            }
         } else {
             debug!("GpuService: no GPU selected");
         }
 
-        let initial_snapshot = if selected_index.is_some() {
+        let initial_snapshot = if !display_indices.is_empty() {
             GpuSnapshot {
                 available: true,
                 ..Default::default()
@@ -392,7 +404,7 @@ impl GpuService {
             callbacks: Callbacks::new(),
             timer_source: RefCell::new(None),
             devices,
-            selected_index: Cell::new(selected_index),
+            display_indices,
             poll_interval: Cell::new(DEFAULT_POLL_INTERVAL_SECS),
             poll_requests: Cell::new(0),
         })
@@ -486,23 +498,16 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        if self.devices.is_empty() {
+        if self.display_indices.is_empty() {
             return;
         }
 
-        let mut snapshots = Vec::with_capacity(self.devices.len());
+        let mut snapshots = Vec::with_capacity(self.display_indices.len());
 
-        if let Some(selected_index) = self.selected_index.get()
-            && let Some(device) = self.devices.get(selected_index)
-        {
-            snapshots.push(Self::poll_device(selected_index, device));
-        }
-
-        for (idx, device) in self.devices.iter().enumerate() {
-            if Some(idx) == self.selected_index.get() {
-                continue;
+        for &idx in &self.display_indices {
+            if let Some(device) = self.devices.get(idx) {
+                snapshots.push(Self::poll_device(idx, device));
             }
-            snapshots.push(Self::poll_device(idx, device));
         }
 
         let snapshot = GpuSnapshot::from_devices(snapshots);
@@ -774,21 +779,148 @@ impl GpuService {
         devices
     }
 
-    /// Read the `device` config option from `[widgets.gpu]`.
-    fn read_device_config() -> Option<u32> {
-        ConfigManager::global()
-            .get_widget_option("gpu", "device")
-            .and_then(|v| match v {
-                toml::Value::Integer(i) if i >= 0 => Some(i as u32),
-                toml::Value::String(ref s) if s == "auto" => None,
-                other => {
-                    warn!("GpuService: invalid 'device' config value: {other}, using auto");
+    /// Read the `devices` config option from `[widgets.gpu]`.
+    fn read_display_config() -> GpuDisplaySelection {
+        let config = ConfigManager::global();
+
+        if let Some(value) = config.get_widget_option("gpu", "devices") {
+            return Self::parse_display_selection_value(&value, "devices").unwrap_or_default();
+        }
+
+        if let Some(value) = config.get_widget_option("gpu", "device") {
+            debug!("GpuService: using legacy 'device' option; prefer 'devices'");
+            return Self::parse_display_selection_value(&value, "device").unwrap_or_default();
+        }
+
+        GpuDisplaySelection::Auto
+    }
+
+    fn parse_display_selection_value(
+        value: &toml::Value,
+        option_name: &str,
+    ) -> Option<GpuDisplaySelection> {
+        match value {
+            toml::Value::Integer(index) if *index >= 0 => {
+                Some(GpuDisplaySelection::Explicit(vec![*index as usize]))
+            }
+            toml::Value::Integer(index) => {
+                warn!(
+                    "GpuService: invalid '{}' config value {} (must be >= 0), using auto",
+                    option_name, index,
+                );
+                None
+            }
+            toml::Value::String(mode) => match mode.to_lowercase().as_str() {
+                "auto" => Some(GpuDisplaySelection::Auto),
+                "all" => Some(GpuDisplaySelection::All),
+                _ => {
+                    warn!(
+                        "GpuService: invalid '{}' config value {:?}, expected 'auto', 'all', an integer, or an array of integers; using auto",
+                        option_name, mode,
+                    );
                     None
                 }
-            })
+            },
+            toml::Value::Array(entries) => {
+                let mut indices = Vec::new();
+                for entry in entries {
+                    match entry {
+                        toml::Value::Integer(index) if *index >= 0 => {
+                            let index = *index as usize;
+                            if !indices.contains(&index) {
+                                indices.push(index);
+                            }
+                        }
+                        other => {
+                            warn!(
+                                "GpuService: ignoring invalid '{}' array entry {other}; expected non-negative integers",
+                                option_name,
+                            );
+                        }
+                    }
+                }
+
+                if indices.is_empty() {
+                    warn!(
+                        "GpuService: '{}' array contained no valid GPU indices, using auto",
+                        option_name,
+                    );
+                    None
+                } else {
+                    Some(GpuDisplaySelection::Explicit(indices))
+                }
+            }
+            other => {
+                warn!(
+                    "GpuService: invalid '{}' config value: {other}, expected 'auto', 'all', an integer, or an array of integers; using auto",
+                    option_name,
+                );
+                None
+            }
+        }
+    }
+
+    fn display_selection_description(selection: &GpuDisplaySelection) -> String {
+        match selection {
+            GpuDisplaySelection::Auto => "auto".to_string(),
+            GpuDisplaySelection::All => "config (devices = all)".to_string(),
+            GpuDisplaySelection::Explicit(indices) if indices.len() == 1 => {
+                format!("config (devices = {})", indices[0])
+            }
+            GpuDisplaySelection::Explicit(indices) => {
+                format!("config (devices = {:?})", indices)
+            }
+        }
+    }
+
+    fn resolve_display_indices(
+        devices: &[GpuDevice],
+        selection: &GpuDisplaySelection,
+    ) -> Vec<usize> {
+        match selection {
+            GpuDisplaySelection::Auto => Self::auto_select(devices).into_iter().collect(),
+            GpuDisplaySelection::All => {
+                let Some(selected_index) = Self::auto_select(devices) else {
+                    return Vec::new();
+                };
+
+                let mut display_indices = Vec::with_capacity(devices.len());
+                display_indices.push(selected_index);
+                display_indices.extend((0..devices.len()).filter(|idx| *idx != selected_index));
+                display_indices
+            }
+            GpuDisplaySelection::Explicit(indices) => {
+                let mut valid_indices = Vec::with_capacity(indices.len());
+                for &idx in indices {
+                    if idx < devices.len() {
+                        if !valid_indices.contains(&idx) {
+                            valid_indices.push(idx);
+                        }
+                    } else {
+                        warn!(
+                            "GpuService: configured GPU index {} out of range (have {} GPU(s)), ignoring it",
+                            idx,
+                            devices.len(),
+                        );
+                    }
+                }
+
+                if valid_indices.is_empty() {
+                    warn!(
+                        "GpuService: configured GPU list {:?} contains no valid indices (have {} GPU(s)), falling back to auto",
+                        indices,
+                        devices.len(),
+                    );
+                    Self::auto_select(devices).into_iter().collect()
+                } else {
+                    valid_indices
+                }
+            }
+        }
     }
 
     /// Select GPU: explicit config index > first discrete > index 0.
+    #[cfg(test)]
     fn select_gpu(devices: &[GpuDevice], selection: &Option<u32>) -> Option<usize> {
         if devices.is_empty() {
             return None;
@@ -1337,6 +1469,96 @@ mod tests {
         assert!(is_amd_discrete_gpu_sysfs_fallback(&dgpu));
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_parse_display_selection_accepts_strings() {
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::String("auto".to_string()),
+                "devices"
+            ),
+            Some(GpuDisplaySelection::Auto)
+        );
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::String("all".to_string()),
+                "devices"
+            ),
+            Some(GpuDisplaySelection::All)
+        );
+    }
+
+    #[test]
+    fn test_parse_display_selection_accepts_integer_and_array() {
+        assert_eq!(
+            GpuService::parse_display_selection_value(&toml::Value::Integer(2), "devices"),
+            Some(GpuDisplaySelection::Explicit(vec![2]))
+        );
+        assert_eq!(
+            GpuService::parse_display_selection_value(
+                &toml::Value::Array(vec![toml::Value::Integer(2), toml::Value::Integer(1)]),
+                "devices",
+            ),
+            Some(GpuDisplaySelection::Explicit(vec![2, 1]))
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_auto_shows_selected_only() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::Auto),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_all_orders_selected_first() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+            dummy_amd("dGPU-2", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::All),
+            vec![1, 0, 2]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_explicit_preserves_order() {
+        let devices = vec![
+            dummy_amd("gpu-0", false, true),
+            dummy_amd("gpu-1", true, false),
+            dummy_amd("gpu-2", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(
+                &devices,
+                &GpuDisplaySelection::Explicit(vec![2, 1]),
+            ),
+            vec![2, 1]
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_indices_invalid_list_falls_back_to_auto() {
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+
+        assert_eq!(
+            GpuService::resolve_display_indices(&devices, &GpuDisplaySelection::Explicit(vec![9]),),
+            vec![1]
+        );
     }
 
     #[test]

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -975,28 +975,6 @@ impl GpuService {
         }
     }
 
-    /// Select GPU: explicit config index > first discrete > index 0.
-    #[cfg(test)]
-    fn select_gpu(devices: &[GpuDevice], selection: &Option<u32>) -> Option<usize> {
-        if devices.is_empty() {
-            return None;
-        }
-
-        if let Some(i) = selection {
-            let idx = *i as usize;
-            if idx < devices.len() {
-                return Some(idx);
-            }
-            warn!(
-                "GpuService: configured device index {} out of range (have {} GPU(s)), falling back to auto",
-                i,
-                devices.len(),
-            );
-        }
-
-        Self::auto_select(devices)
-    }
-
     /// Auto-select a GPU: prefer the primary discrete GPU, then any discrete
     /// GPU, then the primary GPU, then index 0.
     fn auto_select(devices: &[GpuDevice]) -> Option<usize> {
@@ -1261,6 +1239,7 @@ fn sysfs_pci_device_path_from_nvml_bus_id(bus_id: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn nvml_lib_candidates_are_absolute_sonames() {
@@ -1311,27 +1290,6 @@ mod tests {
 
         snap.gpu_usage = Some(100.0);
         assert!(snap.is_gpu_high());
-    }
-
-    #[test]
-    fn test_vram_percent() {
-        let mut snap = GpuDeviceSnapshot::default();
-        assert!(device_vram_percent(&snap).is_none());
-
-        snap.vram_used = Some(4 * 1024 * 1024 * 1024); // 4 GB
-        snap.vram_total = Some(8 * 1024 * 1024 * 1024); // 8 GB
-        let pct = device_vram_percent(&snap).unwrap();
-        assert!((pct - 50.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_vram_percent_zero_total() {
-        let snap = GpuDeviceSnapshot {
-            vram_used: Some(0),
-            vram_total: Some(0),
-            ..Default::default()
-        };
-        assert!(device_vram_percent(&snap).is_none());
     }
 
     #[test]
@@ -1462,71 +1420,6 @@ mod tests {
     }
 
     #[test]
-    fn test_select_gpu_explicit_index() {
-        let devices = vec![
-            dummy_amd("iGPU", false, true),
-            dummy_amd("dGPU", true, false),
-        ];
-        // Explicit config overrides auto-selection.
-        assert_eq!(GpuService::select_gpu(&devices, &Some(0)), Some(0));
-    }
-
-    #[test]
-    fn test_select_gpu_out_of_range_falls_back() {
-        let devices = vec![dummy_amd("dGPU", true, true)];
-        // Out-of-range index falls back to auto (which picks discrete at 0).
-        assert_eq!(GpuService::select_gpu(&devices, &Some(5)), Some(0));
-    }
-
-    #[test]
-    fn test_select_gpu_none_config_uses_auto() {
-        let devices = vec![
-            dummy_amd("iGPU", false, true),
-            dummy_amd("dGPU", true, false),
-        ];
-        assert_eq!(GpuService::select_gpu(&devices, &None), Some(1));
-    }
-
-    fn unique_test_dir(name: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("vibepanel-{name}-{nanos}"))
-    }
-
-    #[test]
-    fn test_amd_ioctl_uapi_layout() {
-        let request = linux_iow(
-            DRM_COMMAND_BASE + DRM_AMDGPU_INFO,
-            mem::size_of::<DrmAmdgpuInfo>(),
-        );
-        assert_eq!(mem::size_of::<DrmAmdgpuInfo>(), 32);
-        assert_eq!(request, 0x4020_6445);
-
-        let device_info = DrmAmdgpuInfoDeviceIds::default();
-        let base = &device_info as *const _ as usize;
-        let ids_flags = &device_info.ids_flags as *const _ as usize;
-        assert_eq!(ids_flags - base, 136);
-    }
-
-    #[test]
-    fn test_amd_discrete_sysfs_fallback_uses_dgpu_markers() {
-        let root = unique_test_dir("amd-gpu-detection");
-        let igpu = root.join("igpu");
-        let dgpu = root.join("dgpu");
-        fs::create_dir_all(&igpu).unwrap();
-        fs::create_dir_all(&dgpu).unwrap();
-
-        fs::write(dgpu.join("mem_info_vram_vendor"), "samsung\n").unwrap();
-
-        assert!(!is_amd_discrete_gpu_sysfs_fallback(&igpu));
-        assert!(is_amd_discrete_gpu_sysfs_fallback(&dgpu));
-
-        fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
     fn test_parse_display_selection_accepts_strings() {
         assert_eq!(
             GpuService::parse_display_selection_value(
@@ -1626,5 +1519,44 @@ mod tests {
             sysfs_pci_device_path_from_nvml_bus_id("00000080:3B:00.0"),
             Some(PathBuf::from("/sys/bus/pci/devices/0080:3b:00.0"))
         );
+    }
+
+    fn unique_test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vibepanel-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn test_amd_ioctl_uapi_layout() {
+        let request = linux_iow(
+            DRM_COMMAND_BASE + DRM_AMDGPU_INFO,
+            mem::size_of::<DrmAmdgpuInfo>(),
+        );
+        assert_eq!(mem::size_of::<DrmAmdgpuInfo>(), 32);
+        assert_eq!(request, 0x4020_6445);
+
+        let device_info = DrmAmdgpuInfoDeviceIds::default();
+        let base = &device_info as *const _ as usize;
+        let ids_flags = &device_info.ids_flags as *const _ as usize;
+        assert_eq!(ids_flags - base, 136);
+    }
+
+    #[test]
+    fn test_amd_discrete_sysfs_fallback_uses_dgpu_markers() {
+        let root = unique_test_dir("amd-gpu-detection");
+        let igpu = root.join("igpu");
+        let dgpu = root.join("dgpu");
+        fs::create_dir_all(&igpu).unwrap();
+        fs::create_dir_all(&dgpu).unwrap();
+
+        fs::write(dgpu.join("mem_info_vram_vendor"), "samsung\n").unwrap();
+
+        assert!(!is_amd_discrete_gpu_sysfs_fallback(&igpu));
+        assert!(is_amd_discrete_gpu_sysfs_fallback(&dgpu));
+
+        fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -509,21 +509,22 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        let display_indices = self.display_indices.borrow();
-        let snapshot = if display_indices.is_empty() {
-            GpuSnapshot::unknown()
-        } else {
-            let mut snapshots = Vec::with_capacity(display_indices.len());
+        let snapshot = {
+            let display_indices = self.display_indices.borrow();
+            if display_indices.is_empty() {
+                GpuSnapshot::unknown()
+            } else {
+                let mut snapshots = Vec::with_capacity(display_indices.len());
 
-            for &idx in display_indices.iter() {
-                if let Some(device) = self.devices.get(idx) {
-                    snapshots.push(Self::poll_device(idx, device));
+                for &idx in display_indices.iter() {
+                    if let Some(device) = self.devices.get(idx) {
+                        snapshots.push(Self::poll_device(idx, device));
+                    }
                 }
-            }
 
-            GpuSnapshot::from_devices(snapshots)
+                GpuSnapshot::from_devices(snapshots)
+            }
         };
-        drop(display_indices);
 
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
@@ -824,17 +825,17 @@ impl GpuService {
                 );
                 None
             }
-            toml::Value::String(mode) => match mode.to_lowercase().as_str() {
-                "auto" => Some(GpuDisplaySelection::Auto),
-                "all" => Some(GpuDisplaySelection::All),
-                _ => {
+            toml::Value::String(mode) => {
+                if let Some(selection) = Self::parse_display_selection_mode(mode) {
+                    Some(selection)
+                } else {
                     warn!(
                         "GpuService: invalid '{}' config value {:?}, expected 'auto', 'all', an integer, or an array of integers; using auto",
                         option_name, mode,
                     );
                     None
                 }
-            },
+            }
             toml::Value::Array(entries) => {
                 let mut indices = Vec::new();
                 for entry in entries {
@@ -871,6 +872,14 @@ impl GpuService {
                 );
                 None
             }
+        }
+    }
+
+    fn parse_display_selection_mode(mode: &str) -> Option<GpuDisplaySelection> {
+        match mode.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(GpuDisplaySelection::Auto),
+            "all" => Some(GpuDisplaySelection::All),
+            _ => None,
         }
     }
 
@@ -1252,7 +1261,6 @@ fn sysfs_pci_device_path_from_nvml_bus_id(bus_id: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn nvml_lib_candidates_are_absolute_sonames() {

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -7,13 +7,17 @@
 //! - **NVIDIA**: NVML via the `nvml-wrapper` crate (runtime-loaded
 //!   `libnvidia-ml.so`, see [`init_nvml`])
 //!
-//! All GPUs are discovered at startup. One is selected for active polling based on:
+//! All GPUs are discovered at startup and polled while the widget or popover is
+//! visible. One preferred GPU is selected only to order the displayed list and
+//! populate the compact summary fields based on:
 //!
 //! 1. **Explicit config**: `device = N` in `[widgets.gpu]` selects a specific index.
-//! 2. **Auto heuristic** (default): Prefers discrete GPUs over integrated.
-//!    AMD discrete detection queries the kernel driver's FUSION flag.
+//! 2. **Auto heuristic** (default): Prefers the primary discrete GPU, then any
+//!    discrete GPU, then the primary GPU.
+//!    AMD discrete detection queries the kernel driver's FUSION flag; primary
+//!    detection uses `boot_vga`.
 //!    NVIDIA GPUs are always treated as discrete.
-//!    Falls back to index 0 if no discrete GPU is found.
+//!    Falls back to index 0 if no better match is found.
 //!
 //! ## Usage
 //!
@@ -138,8 +142,7 @@ pub enum GpuPowerState {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct GpuSnapshot {
-    pub available: bool,
+pub struct GpuDeviceSnapshot {
     /// Hardware power state (active, suspended, or unknown).
     pub power_state: GpuPowerState,
     /// GPU utilization percentage (0.0 - 100.0).
@@ -158,6 +161,37 @@ pub struct GpuSnapshot {
     pub device_name: Option<String>,
 }
 
+impl GpuDeviceSnapshot {
+    fn is_gpu_high(&self) -> bool {
+        self.gpu_usage
+            .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
+            .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GpuSnapshot {
+    pub available: bool,
+    /// Hardware power state (active, suspended, or unknown).
+    pub power_state: GpuPowerState,
+    /// GPU utilization percentage (0.0 - 100.0).
+    pub gpu_usage: Option<f32>,
+    /// Used VRAM in bytes.
+    pub vram_used: Option<u64>,
+    /// Total VRAM in bytes.
+    pub vram_total: Option<u64>,
+    /// GPU temperature in degrees Celsius.
+    pub temperature: Option<f32>,
+    /// GPU clock speed in MHz.
+    pub clock_mhz: Option<u64>,
+    /// GPU power draw in watts.
+    pub power_watts: Option<f32>,
+    /// Device name (product name, or `vendor:device` PCI ID fallback).
+    pub device_name: Option<String>,
+    /// Per-device snapshots in display order (preferred GPU first).
+    pub devices: Vec<GpuDeviceSnapshot>,
+}
+
 impl GpuSnapshot {
     /// Returns a snapshot representing an unknown/unavailable GPU.
     pub fn unknown() -> Self {
@@ -166,16 +200,62 @@ impl GpuSnapshot {
 
     /// Returns true if GPU usage is above the high threshold.
     pub fn is_gpu_high(&self) -> bool {
-        self.gpu_usage
-            .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
-            .unwrap_or(false)
+        if self.devices.is_empty() {
+            self.gpu_usage
+                .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
+                .unwrap_or(false)
+        } else {
+            self.devices.iter().any(GpuDeviceSnapshot::is_gpu_high)
+        }
     }
 
-    /// VRAM usage as a percentage (0.0 - 100.0), if both used and total are known.
-    pub fn vram_percent(&self) -> Option<f32> {
-        match (self.vram_used, self.vram_total) {
-            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
-            _ => None,
+    /// Returns the per-device GPU snapshots, falling back to the summary fields
+    /// for older callers when the service has not yet populated the device list.
+    pub fn devices_for_display(&self) -> Vec<GpuDeviceSnapshot> {
+        if !self.devices.is_empty() {
+            return self.devices.clone();
+        }
+
+        if !self.available {
+            return Vec::new();
+        }
+
+        vec![GpuDeviceSnapshot {
+            power_state: self.power_state,
+            gpu_usage: self.gpu_usage,
+            vram_used: self.vram_used,
+            vram_total: self.vram_total,
+            temperature: self.temperature,
+            clock_mhz: self.clock_mhz,
+            power_watts: self.power_watts,
+            device_name: self.device_name.clone(),
+        }]
+    }
+
+    pub fn all_devices_suspended(&self) -> bool {
+        let devices = self.devices_for_display();
+        !devices.is_empty()
+            && devices
+                .iter()
+                .all(|device| device.power_state == GpuPowerState::Suspended)
+    }
+
+    fn from_devices(devices: Vec<GpuDeviceSnapshot>) -> Self {
+        let Some(summary) = devices.first().cloned() else {
+            return Self::unknown();
+        };
+
+        Self {
+            available: true,
+            power_state: summary.power_state,
+            gpu_usage: summary.gpu_usage,
+            vram_used: summary.vram_used,
+            vram_total: summary.vram_total,
+            temperature: summary.temperature,
+            clock_mhz: summary.clock_mhz,
+            power_watts: summary.power_watts,
+            device_name: summary.device_name.clone(),
+            devices,
         }
     }
 }
@@ -195,6 +275,9 @@ struct AmdGpuDevice {
 
     /// Whether this is a discrete GPU (determined via AMDGPU FUSION flag or fallback markers).
     is_discrete: bool,
+
+    /// Whether this is the primary GPU (`boot_vga == 1`).
+    is_primary: bool,
 }
 
 struct NvidiaGpuDevice {
@@ -207,6 +290,9 @@ struct NvidiaGpuDevice {
 
     /// Sysfs `power/runtime_status` path for checking hardware power state.
     runtime_status_path: Option<PathBuf>,
+
+    /// Whether this is the primary GPU (`boot_vga == 1`).
+    is_primary: bool,
 }
 
 enum GpuDevice {
@@ -229,12 +315,19 @@ impl GpuDevice {
             GpuDevice::Nvidia(_) => true,
         }
     }
+
+    fn is_primary(&self) -> bool {
+        match self {
+            GpuDevice::Amd(d) => d.is_primary,
+            GpuDevice::Nvidia(d) => d.is_primary,
+        }
+    }
 }
 
 /// Shared, process-wide GPU monitoring service.
 ///
-/// Discovers all available GPUs at startup and polls one selected device
-/// at regular intervals via vendor-specific backends (AMD sysfs, NVIDIA NVML).
+/// Discovers all available GPUs at startup and polls them at regular intervals
+/// via vendor-specific backends (AMD sysfs, NVIDIA NVML).
 /// Notifies registered callbacks whenever the snapshot updates.
 ///
 /// Unlike other services, GPU polling is demand-driven: callers must use
@@ -251,7 +344,7 @@ pub struct GpuService {
     /// All discovered GPU devices.
     devices: Vec<GpuDevice>,
 
-    /// Index into `devices` of the currently polled GPU, or `None` if no GPU.
+    /// Preferred GPU index used for display ordering and summary fields.
     selected_index: Cell<Option<usize>>,
 
     /// Polling interval in seconds.
@@ -366,7 +459,7 @@ impl GpuService {
     /// Requires `&Rc<Self>` because `start_polling` creates a weak reference
     /// for the timer closure.
     pub fn request_polling(this: &Rc<Self>) {
-        if this.selected_index.get().is_none() {
+        if this.devices.is_empty() {
             return;
         }
         let prev = this.poll_requests.get();
@@ -393,17 +486,33 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        let Some(idx) = self.selected_index.get() else {
+        if self.devices.is_empty() {
             return;
-        };
-        let Some(device) = self.devices.get(idx) else {
-            return;
-        };
+        }
 
+        let mut snapshots = Vec::with_capacity(self.devices.len());
+
+        if let Some(selected_index) = self.selected_index.get()
+            && let Some(device) = self.devices.get(selected_index)
+        {
+            snapshots.push(Self::poll_device(selected_index, device));
+        }
+
+        for (idx, device) in self.devices.iter().enumerate() {
+            if Some(idx) == self.selected_index.get() {
+                continue;
+            }
+            snapshots.push(Self::poll_device(idx, device));
+        }
+
+        let snapshot = GpuSnapshot::from_devices(snapshots);
+        *self.snapshot.borrow_mut() = snapshot;
+        self.callbacks.notify(&self.snapshot.borrow());
+    }
+
+    fn poll_device(idx: usize, device: &GpuDevice) -> GpuDeviceSnapshot {
         trace!("GpuService: polling GPU {} metrics", idx);
 
-        // Check hardware power state before touching vendor APIs.
-        // NVML calls prevent NVIDIA GPUs from entering D3cold sleep.
         let runtime_path = match device {
             GpuDevice::Amd(d) => d.runtime_status_path.as_deref(),
             GpuDevice::Nvidia(d) => d.runtime_status_path.as_deref(),
@@ -414,15 +523,11 @@ impl GpuService {
 
         if power_state == GpuPowerState::Suspended {
             trace!("GpuService: GPU {} is suspended, skipping vendor poll", idx);
-            let snapshot = GpuSnapshot {
-                available: true,
+            return GpuDeviceSnapshot {
                 power_state: GpuPowerState::Suspended,
                 device_name: device.name().map(str::to_string),
                 ..Default::default()
             };
-            *self.snapshot.borrow_mut() = snapshot;
-            self.callbacks.notify(&self.snapshot.borrow());
-            return;
         }
 
         let mut snapshot = match device {
@@ -430,12 +535,10 @@ impl GpuService {
             GpuDevice::Nvidia(nvidia) => Self::poll_nvidia(nvidia),
         };
         snapshot.power_state = power_state;
-
-        *self.snapshot.borrow_mut() = snapshot;
-        self.callbacks.notify(&self.snapshot.borrow());
+        snapshot
     }
 
-    fn poll_amd(device: &AmdGpuDevice) -> GpuSnapshot {
+    fn poll_amd(device: &AmdGpuDevice) -> GpuDeviceSnapshot {
         let gpu_usage =
             read_sysfs_u32(&device.device_path.join("gpu_busy_percent")).map(|v| v.min(100) as f32);
 
@@ -455,8 +558,7 @@ impl GpuService {
             (None, None, None)
         };
 
-        GpuSnapshot {
-            available: true,
+        GpuDeviceSnapshot {
             gpu_usage,
             vram_used,
             vram_total,
@@ -468,13 +570,12 @@ impl GpuService {
         }
     }
 
-    fn poll_nvidia(nvidia: &NvidiaGpuDevice) -> GpuSnapshot {
+    fn poll_nvidia(nvidia: &NvidiaGpuDevice) -> GpuDeviceSnapshot {
         let device = match nvidia.nvml.device_by_index(nvidia.device_index) {
             Ok(d) => d,
             Err(e) => {
                 warn!("GpuService: failed to acquire NVIDIA device handle: {e}");
-                return GpuSnapshot {
-                    available: true,
+                return GpuDeviceSnapshot {
                     device_name: nvidia.device_name.clone(),
                     ..Default::default()
                 };
@@ -501,8 +602,7 @@ impl GpuService {
 
         let power_watts = device.power_usage().ok().map(|mw| mw as f32 / 1000.0);
 
-        GpuSnapshot {
-            available: true,
+        GpuDeviceSnapshot {
             gpu_usage,
             vram_used,
             vram_total,
@@ -581,6 +681,9 @@ impl GpuService {
                     let device_name = read_device_name(&device_path);
 
                     let is_discrete = is_amd_discrete_gpu(&device_path);
+                    // boot_vga: 1 = primary VGA device, 0 = non-primary.
+                    let boot_vga = read_sysfs_u32(&device_path.join("boot_vga"));
+                    let is_primary = boot_vga == Some(1);
 
                     // Resolve the PCI device path for runtime_status.
                     // device_path is a symlink like /sys/class/drm/card1/device ->
@@ -601,6 +704,7 @@ impl GpuService {
                         runtime_status_path,
                         device_name,
                         is_discrete,
+                        is_primary,
                     });
                 }
             }
@@ -638,21 +742,20 @@ impl GpuService {
 
             let device_name = device.name().ok();
 
-            // Get PCI bus ID for runtime_status path.
-            // NVML uses an 8-char domain ("00000000:06:00.0") while sysfs uses
-            // 4-char ("0000:06:00.0"). Normalize by stripping leading zeros and
-            // re-adding a 4-char prefix.
-            let runtime_status_path = device
+            let pci_device_path = device
                 .pci_info()
                 .ok()
-                .map(|pci| {
-                    let bus_id = pci.bus_id.trim_start_matches('0');
-                    let bus_id = format!("0000{bus_id}").to_lowercase();
-                    PathBuf::from(format!(
-                        "/sys/bus/pci/devices/{bus_id}/power/runtime_status",
-                    ))
-                })
+                .and_then(|pci| sysfs_pci_device_path_from_nvml_bus_id(&pci.bus_id));
+
+            let runtime_status_path = pci_device_path
+                .as_ref()
+                .map(|path| path.join("power/runtime_status"))
                 .filter(|p| p.exists());
+
+            let is_primary = pci_device_path
+                .as_ref()
+                .and_then(|path| read_sysfs_u32(&path.join("boot_vga")))
+                == Some(1);
 
             debug!(
                 "GpuService: found NVIDIA GPU {:?} (nvml_index: {})",
@@ -664,6 +767,7 @@ impl GpuService {
                 device_index,
                 device_name,
                 runtime_status_path,
+                is_primary,
             });
         }
 
@@ -705,10 +809,22 @@ impl GpuService {
         Self::auto_select(devices)
     }
 
-    /// Auto-select a GPU: prefer discrete, then index 0.
+    /// Auto-select a GPU: prefer the primary discrete GPU, then any discrete
+    /// GPU, then the primary GPU, then index 0.
     fn auto_select(devices: &[GpuDevice]) -> Option<usize> {
         if devices.is_empty() {
             return None;
+        }
+
+        if let Some(idx) = devices
+            .iter()
+            .position(|d| d.is_discrete() && d.is_primary())
+        {
+            debug!(
+                "GpuService: auto-selected primary discrete GPU at index {}",
+                idx
+            );
+            return Some(idx);
         }
 
         // Prefer the first discrete GPU.
@@ -717,8 +833,13 @@ impl GpuService {
             return Some(idx);
         }
 
+        if let Some(idx) = devices.iter().position(|d| d.is_primary()) {
+            debug!("GpuService: auto-selected primary GPU at index {}", idx);
+            return Some(idx);
+        }
+
         // Fall back to the first GPU.
-        debug!("GpuService: no discrete GPU found, defaulting to index 0");
+        debug!("GpuService: no primary/discrete GPU found, defaulting to index 0");
         Some(0)
     }
 }
@@ -794,12 +915,41 @@ fn discover_hwmon(device_path: &Path) -> Option<PathBuf> {
 /// Tries `product_name` first (available on some AMD GPUs), then falls back
 /// to reading `vendor` + `device` IDs.
 fn read_device_name(device_path: &Path) -> Option<String> {
-    if let Some(name) = read_sysfs_string(&device_path.join("product_name")) {
+    choose_device_name(
+        read_sysfs_string(&device_path.join("product_name")),
+        read_udev_model_name(device_path),
+        read_sysfs_string(&device_path.join("vendor")),
+        read_sysfs_string(&device_path.join("device")),
+    )
+}
+
+fn read_udev_model_name(device_path: &Path) -> Option<String> {
+    let syspath = fs::canonicalize(device_path).ok()?;
+    let device = udev::Device::from_syspath(&syspath).ok()?;
+    device
+        .property_value("ID_MODEL_FROM_DATABASE")
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn choose_device_name(
+    product_name: Option<String>,
+    udev_model_name: Option<String>,
+    vendor_id: Option<String>,
+    device_id: Option<String>,
+) -> Option<String> {
+    if let Some(name) = product_name.filter(|name| !name.trim().is_empty()) {
         return Some(name);
     }
 
-    let vendor = read_sysfs_string(&device_path.join("vendor"))?;
-    let device = read_sysfs_string(&device_path.join("device"))?;
+    if let Some(name) = udev_model_name.filter(|name| !name.trim().is_empty()) {
+        return Some(name);
+    }
+
+    let vendor = vendor_id?;
+    let device = device_id?;
     Some(format!(
         "GPU [{}:{}]",
         vendor.trim_start_matches("0x"),
@@ -905,6 +1055,21 @@ fn read_runtime_status(path: &Path) -> GpuPowerState {
     }
 }
 
+fn sysfs_pci_device_path_from_nvml_bus_id(bus_id: &str) -> Option<PathBuf> {
+    let trimmed = bus_id.trim().trim_end_matches('\0');
+    let (domain_hex, bus_slot) = trimmed.split_once(':')?;
+    let domain = u32::from_str_radix(domain_hex, 16).ok()?;
+    if domain > u16::MAX as u32 {
+        return None;
+    }
+
+    Some(PathBuf::from(format!(
+        "/sys/bus/pci/devices/{:04x}:{}",
+        domain,
+        bus_slot.to_lowercase()
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -925,10 +1090,18 @@ mod tests {
         }
     }
 
+    fn device_vram_percent(snapshot: &GpuDeviceSnapshot) -> Option<f32> {
+        match (snapshot.vram_used, snapshot.vram_total) {
+            (Some(used), Some(total)) if total > 0 => Some(used as f32 / total as f32 * 100.0),
+            _ => None,
+        }
+    }
+
     #[test]
     fn test_gpu_snapshot_defaults() {
         let snap = GpuSnapshot::default();
         assert!(!snap.available);
+        assert!(snap.devices.is_empty());
         assert!(snap.gpu_usage.is_none());
         assert!(snap.vram_used.is_none());
         assert!(snap.vram_total.is_none());
@@ -955,33 +1128,120 @@ mod tests {
 
     #[test]
     fn test_vram_percent() {
-        let mut snap = GpuSnapshot::default();
-        assert!(snap.vram_percent().is_none());
+        let mut snap = GpuDeviceSnapshot::default();
+        assert!(device_vram_percent(&snap).is_none());
 
         snap.vram_used = Some(4 * 1024 * 1024 * 1024); // 4 GB
         snap.vram_total = Some(8 * 1024 * 1024 * 1024); // 8 GB
-        let pct = snap.vram_percent().unwrap();
+        let pct = device_vram_percent(&snap).unwrap();
         assert!((pct - 50.0).abs() < 0.01);
     }
 
     #[test]
     fn test_vram_percent_zero_total() {
-        let snap = GpuSnapshot {
+        let snap = GpuDeviceSnapshot {
             vram_used: Some(0),
             vram_total: Some(0),
             ..Default::default()
         };
-        assert!(snap.vram_percent().is_none());
+        assert!(device_vram_percent(&snap).is_none());
+    }
+
+    #[test]
+    fn test_choose_device_name_prefers_product_name_then_udev_then_ids() {
+        assert_eq!(
+            choose_device_name(
+                Some("AMD Radeon 780M".to_string()),
+                Some("Granite Ridge [Radeon Graphics]".to_string()),
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("AMD Radeon 780M".to_string())
+        );
+
+        assert_eq!(
+            choose_device_name(
+                None,
+                Some("Granite Ridge [Radeon Graphics]".to_string()),
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("Granite Ridge [Radeon Graphics]".to_string())
+        );
+
+        assert_eq!(
+            choose_device_name(
+                None,
+                None,
+                Some("0x1002".to_string()),
+                Some("0x13c0".to_string()),
+            ),
+            Some("GPU [1002:13c0]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_snapshot_from_devices_uses_first_device_as_summary() {
+        let snap = GpuSnapshot::from_devices(vec![
+            GpuDeviceSnapshot {
+                gpu_usage: Some(75.0),
+                device_name: Some("Primary GPU".to_string()),
+                ..Default::default()
+            },
+            GpuDeviceSnapshot {
+                gpu_usage: Some(35.0),
+                device_name: Some("Secondary GPU".to_string()),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(snap.available);
+        assert_eq!(snap.gpu_usage, Some(75.0));
+        assert_eq!(snap.device_name.as_deref(), Some("Primary GPU"));
+        assert_eq!(snap.devices.len(), 2);
+    }
+
+    #[test]
+    fn test_is_gpu_high_checks_all_devices() {
+        let snap = GpuSnapshot::from_devices(vec![
+            GpuDeviceSnapshot {
+                gpu_usage: Some(10.0),
+                ..Default::default()
+            },
+            GpuDeviceSnapshot {
+                gpu_usage: Some(95.0),
+                ..Default::default()
+            },
+        ]);
+
+        assert!(snap.is_gpu_high());
+    }
+
+    #[test]
+    fn test_devices_for_display_falls_back_to_summary_fields() {
+        let snap = GpuSnapshot {
+            available: true,
+            power_state: GpuPowerState::Active,
+            gpu_usage: Some(64.0),
+            device_name: Some("Fallback GPU".to_string()),
+            ..Default::default()
+        };
+
+        let devices = snap.devices_for_display();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].gpu_usage, Some(64.0));
+        assert_eq!(devices[0].device_name.as_deref(), Some("Fallback GPU"));
     }
 
     /// Helper to create a dummy AMD GPU device for selection tests.
-    fn dummy_amd(name: &str, is_discrete: bool) -> GpuDevice {
+    fn dummy_amd(name: &str, is_discrete: bool, is_primary: bool) -> GpuDevice {
         GpuDevice::Amd(AmdGpuDevice {
             device_path: PathBuf::from("/dev/null"),
             hwmon_path: None,
             runtime_status_path: None,
             device_name: Some(name.to_string()),
             is_discrete,
+            is_primary,
         })
     }
 
@@ -992,33 +1252,51 @@ mod tests {
 
     #[test]
     fn test_auto_select_single_integrated() {
-        let devices = vec![dummy_amd("iGPU", false)];
+        let devices = vec![dummy_amd("iGPU", false, true)];
         assert_eq!(GpuService::auto_select(&devices), Some(0));
     }
 
     #[test]
     fn test_auto_select_prefers_discrete() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
+        assert_eq!(GpuService::auto_select(&devices), Some(1));
+    }
+
+    #[test]
+    fn test_auto_select_prefers_primary_discrete() {
+        let devices = vec![
+            dummy_amd("secondary-dgpu", true, false),
+            dummy_amd("primary-dgpu", true, true),
+        ];
         assert_eq!(GpuService::auto_select(&devices), Some(1));
     }
 
     #[test]
     fn test_select_gpu_explicit_index() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
         // Explicit config overrides auto-selection.
         assert_eq!(GpuService::select_gpu(&devices, &Some(0)), Some(0));
     }
 
     #[test]
     fn test_select_gpu_out_of_range_falls_back() {
-        let devices = vec![dummy_amd("dGPU", true)];
+        let devices = vec![dummy_amd("dGPU", true, true)];
         // Out-of-range index falls back to auto (which picks discrete at 0).
         assert_eq!(GpuService::select_gpu(&devices, &Some(5)), Some(0));
     }
 
     #[test]
     fn test_select_gpu_none_config_uses_auto() {
-        let devices = vec![dummy_amd("iGPU", false), dummy_amd("dGPU", true)];
+        let devices = vec![
+            dummy_amd("iGPU", false, true),
+            dummy_amd("dGPU", true, false),
+        ];
         assert_eq!(GpuService::select_gpu(&devices, &None), Some(1));
     }
 
@@ -1059,5 +1337,17 @@ mod tests {
         assert!(is_amd_discrete_gpu_sysfs_fallback(&dgpu));
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_nvml_bus_id_to_sysfs_path_normalizes_domain() {
+        assert_eq!(
+            sysfs_pci_device_path_from_nvml_bus_id("00000000:01:00.0"),
+            Some(PathBuf::from("/sys/bus/pci/devices/0000:01:00.0"))
+        );
+        assert_eq!(
+            sysfs_pci_device_path_from_nvml_bus_id("00000080:3B:00.0"),
+            Some(PathBuf::from("/sys/bus/pci/devices/0080:3b:00.0"))
+        );
     }
 }

--- a/crates/vibepanel/src/services/gpu.rs
+++ b/crates/vibepanel/src/services/gpu.rs
@@ -12,7 +12,9 @@
 //!
 //! 1. **`devices = "auto"`** (default): shows only the preferred GPU.
 //! 2. **`devices = "all"`**: shows all detected GPUs, ordered with the
-//!    preferred GPU first.
+//!    preferred GPU first. While GPU monitoring is active, every selected GPU
+//!    is checked; runtime-suspended GPUs skip vendor polling, but active
+//!    secondary GPUs are still queried and may consume more power than `auto`.
 //! 3. **`devices = [N, M]`** or **`devices = N`**: shows explicit GPU indices
 //!    in the configured order.
 //! 4. **Legacy compatibility**: `device = N` remains accepted as an alias for a
@@ -30,7 +32,7 @@
 //! ```rust,ignore
 //! let service = GpuService::global();
 //! service.connect(|snapshot| {
-//!     if let Some(usage) = snapshot.gpu_usage {
+//!     if let Some(usage) = snapshot.devices.first().and_then(|gpu| gpu.gpu_usage) {
 //!         println!("GPU: {:.0}%", usage);
 //!     }
 //! });
@@ -149,6 +151,8 @@ pub enum GpuPowerState {
 
 #[derive(Debug, Clone, Default)]
 pub struct GpuDeviceSnapshot {
+    /// Zero-based index used by the `devices` configuration option.
+    pub device_index: usize,
     /// Hardware power state (active, suspended, or unknown).
     pub power_state: GpuPowerState,
     /// GPU utilization percentage (0.0 - 100.0).
@@ -177,92 +181,31 @@ impl GpuDeviceSnapshot {
 
 #[derive(Debug, Clone, Default)]
 pub struct GpuSnapshot {
-    pub available: bool,
-    /// Hardware power state (active, suspended, or unknown).
-    pub power_state: GpuPowerState,
-    /// GPU utilization percentage (0.0 - 100.0).
-    pub gpu_usage: Option<f32>,
-    /// Used VRAM in bytes.
-    pub vram_used: Option<u64>,
-    /// Total VRAM in bytes.
-    pub vram_total: Option<u64>,
-    /// GPU temperature in degrees Celsius.
-    pub temperature: Option<f32>,
-    /// GPU clock speed in MHz.
-    pub clock_mhz: Option<u64>,
-    /// GPU power draw in watts.
-    pub power_watts: Option<f32>,
-    /// Device name (product name, or `vendor:device` PCI ID fallback).
-    pub device_name: Option<String>,
     /// Per-device snapshots in display order (preferred GPU first).
     pub devices: Vec<GpuDeviceSnapshot>,
 }
 
 impl GpuSnapshot {
-    /// Returns a snapshot representing an unknown/unavailable GPU.
-    pub fn unknown() -> Self {
-        Self::default()
+    /// Returns whether at least one GPU is available.
+    pub fn available(&self) -> bool {
+        !self.devices.is_empty()
     }
 
     /// Returns true if GPU usage is above the high threshold.
     pub fn is_gpu_high(&self) -> bool {
-        if self.devices.is_empty() {
-            self.gpu_usage
-                .map(|u| u >= GPU_HIGH_USAGE_THRESHOLD)
-                .unwrap_or(false)
-        } else {
-            self.devices.iter().any(GpuDeviceSnapshot::is_gpu_high)
-        }
-    }
-
-    /// Returns the per-device GPU snapshots, falling back to the summary fields
-    /// for older callers when the service has not yet populated the device list.
-    pub fn devices_for_display(&self) -> Vec<GpuDeviceSnapshot> {
-        if !self.devices.is_empty() {
-            return self.devices.clone();
-        }
-
-        if !self.available {
-            return Vec::new();
-        }
-
-        vec![GpuDeviceSnapshot {
-            power_state: self.power_state,
-            gpu_usage: self.gpu_usage,
-            vram_used: self.vram_used,
-            vram_total: self.vram_total,
-            temperature: self.temperature,
-            clock_mhz: self.clock_mhz,
-            power_watts: self.power_watts,
-            device_name: self.device_name.clone(),
-        }]
+        self.devices.iter().any(GpuDeviceSnapshot::is_gpu_high)
     }
 
     pub fn all_devices_suspended(&self) -> bool {
-        let devices = self.devices_for_display();
-        !devices.is_empty()
-            && devices
+        !self.devices.is_empty()
+            && self
+                .devices
                 .iter()
                 .all(|device| device.power_state == GpuPowerState::Suspended)
     }
 
     fn from_devices(devices: Vec<GpuDeviceSnapshot>) -> Self {
-        let Some(summary) = devices.first().cloned() else {
-            return Self::unknown();
-        };
-
-        Self {
-            available: true,
-            power_state: summary.power_state,
-            gpu_usage: summary.gpu_usage,
-            vram_used: summary.vram_used,
-            vram_total: summary.vram_total,
-            temperature: summary.temperature,
-            clock_mhz: summary.clock_mhz,
-            power_watts: summary.power_watts,
-            device_name: summary.device_name.clone(),
-            devices,
-        }
+        Self { devices }
     }
 }
 
@@ -378,14 +321,7 @@ impl GpuService {
 
         Self::log_display_selection(&devices, &display_selection, &display_indices);
 
-        let initial_snapshot = if !display_indices.is_empty() {
-            GpuSnapshot {
-                available: true,
-                ..Default::default()
-            }
-        } else {
-            GpuSnapshot::unknown()
-        };
+        let initial_snapshot = Self::placeholder_snapshot(&devices, &display_indices);
 
         Rc::new(Self {
             snapshot: RefCell::new(initial_snapshot),
@@ -436,14 +372,7 @@ impl GpuService {
             return;
         }
 
-        let snapshot = if self.display_indices.borrow().is_empty() {
-            GpuSnapshot::unknown()
-        } else {
-            GpuSnapshot {
-                available: true,
-                ..Default::default()
-            }
-        };
+        let snapshot = Self::placeholder_snapshot(&self.devices, &self.display_indices.borrow());
 
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
@@ -509,22 +438,17 @@ impl GpuService {
     }
 
     fn poll(&self) {
-        let snapshot = {
-            let display_indices = self.display_indices.borrow();
-            if display_indices.is_empty() {
-                GpuSnapshot::unknown()
-            } else {
-                let mut snapshots = Vec::with_capacity(display_indices.len());
-
-                for &idx in display_indices.iter() {
-                    if let Some(device) = self.devices.get(idx) {
-                        snapshots.push(Self::poll_device(idx, device));
-                    }
-                }
-
-                GpuSnapshot::from_devices(snapshots)
-            }
-        };
+        let snapshot = GpuSnapshot::from_devices(
+            self.display_indices
+                .borrow()
+                .iter()
+                .filter_map(|&idx| {
+                    self.devices
+                        .get(idx)
+                        .map(|device| Self::poll_device(idx, device))
+                })
+                .collect(),
+        );
 
         *self.snapshot.borrow_mut() = snapshot;
         self.callbacks.notify(&self.snapshot.borrow());
@@ -544,6 +468,7 @@ impl GpuService {
         if power_state == GpuPowerState::Suspended {
             trace!("GpuService: GPU {} is suspended, skipping vendor poll", idx);
             return GpuDeviceSnapshot {
+                device_index: idx,
                 power_state: GpuPowerState::Suspended,
                 device_name: device.name().map(str::to_string),
                 ..Default::default()
@@ -554,8 +479,24 @@ impl GpuService {
             GpuDevice::Amd(amd) => Self::poll_amd(amd),
             GpuDevice::Nvidia(nvidia) => Self::poll_nvidia(nvidia),
         };
+        snapshot.device_index = idx;
         snapshot.power_state = power_state;
         snapshot
+    }
+
+    fn placeholder_snapshot(devices: &[GpuDevice], display_indices: &[usize]) -> GpuSnapshot {
+        GpuSnapshot::from_devices(
+            display_indices
+                .iter()
+                .filter_map(|&device_index| {
+                    devices.get(device_index).map(|device| GpuDeviceSnapshot {
+                        device_index,
+                        device_name: device.name().map(str::to_string),
+                        ..Default::default()
+                    })
+                })
+                .collect(),
+        )
     }
 
     fn poll_amd(device: &AmdGpuDevice) -> GpuDeviceSnapshot {
@@ -678,8 +619,8 @@ impl GpuService {
             }
         }
 
-        // Sort by card number for deterministic ordering
-        cards.sort();
+        // Sort numerically so card10 follows card9 rather than card1.
+        cards.sort_by_key(|path| drm_card_index(path).unwrap_or(u32::MAX));
 
         let mut devices = Vec::new();
 
@@ -1221,6 +1162,14 @@ fn read_runtime_status(path: &Path) -> GpuPowerState {
     }
 }
 
+fn drm_card_index(path: &Path) -> Option<u32> {
+    path.file_name()?
+        .to_str()?
+        .strip_prefix("card")?
+        .parse()
+        .ok()
+}
+
 fn sysfs_pci_device_path_from_nvml_bus_id(bus_id: &str) -> Option<PathBuf> {
     let trimmed = bus_id.trim().trim_end_matches('\0');
     let (domain_hex, bus_slot) = trimmed.split_once(':')?;
@@ -1266,30 +1215,19 @@ mod tests {
     #[test]
     fn test_gpu_snapshot_defaults() {
         let snap = GpuSnapshot::default();
-        assert!(!snap.available);
+        assert!(!snap.available());
         assert!(snap.devices.is_empty());
-        assert!(snap.gpu_usage.is_none());
-        assert!(snap.vram_used.is_none());
-        assert!(snap.vram_total.is_none());
-        assert!(snap.temperature.is_none());
-        assert!(snap.clock_mhz.is_none());
-        assert!(snap.power_watts.is_none());
-        assert!(snap.device_name.is_none());
     }
 
     #[test]
     fn test_is_gpu_high() {
-        let mut snap = GpuSnapshot::default();
-        assert!(!snap.is_gpu_high());
-
-        snap.gpu_usage = Some(89.0);
-        assert!(!snap.is_gpu_high());
-
-        snap.gpu_usage = Some(90.0);
-        assert!(snap.is_gpu_high());
-
-        snap.gpu_usage = Some(100.0);
-        assert!(snap.is_gpu_high());
+        for (usage, expected) in [(89.0, false), (90.0, true), (100.0, true)] {
+            let snap = GpuSnapshot::from_devices(vec![GpuDeviceSnapshot {
+                gpu_usage: Some(usage),
+                ..Default::default()
+            }]);
+            assert_eq!(snap.is_gpu_high(), expected);
+        }
     }
 
     #[test]
@@ -1326,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_from_devices_uses_first_device_as_summary() {
+    fn test_snapshot_from_devices_preserves_devices() {
         let snap = GpuSnapshot::from_devices(vec![
             GpuDeviceSnapshot {
                 gpu_usage: Some(75.0),
@@ -1340,10 +1278,10 @@ mod tests {
             },
         ]);
 
-        assert!(snap.available);
-        assert_eq!(snap.gpu_usage, Some(75.0));
-        assert_eq!(snap.device_name.as_deref(), Some("Primary GPU"));
+        assert!(snap.available());
         assert_eq!(snap.devices.len(), 2);
+        assert_eq!(snap.devices[0].gpu_usage, Some(75.0));
+        assert_eq!(snap.devices[0].device_name.as_deref(), Some("Primary GPU"));
     }
 
     #[test]
@@ -1363,19 +1301,10 @@ mod tests {
     }
 
     #[test]
-    fn test_devices_for_display_falls_back_to_summary_fields() {
-        let snap = GpuSnapshot {
-            available: true,
-            power_state: GpuPowerState::Active,
-            gpu_usage: Some(64.0),
-            device_name: Some("Fallback GPU".to_string()),
-            ..Default::default()
-        };
-
-        let devices = snap.devices_for_display();
-        assert_eq!(devices.len(), 1);
-        assert_eq!(devices[0].gpu_usage, Some(64.0));
-        assert_eq!(devices[0].device_name.as_deref(), Some("Fallback GPU"));
+    fn test_drm_card_index_parses_numeric_suffix() {
+        assert_eq!(drm_card_index(Path::new("/sys/class/drm/card2")), Some(2));
+        assert_eq!(drm_card_index(Path::new("/sys/class/drm/card10")), Some(10));
+        assert_eq!(drm_card_index(Path::new("/sys/class/drm/renderD128")), None);
     }
 
     /// Helper to create a dummy AMD GPU device for selection tests.

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -1404,7 +1404,4 @@ pub mod system_popover {
 
     /// GPU title row container (`.system-gpu-title`).
     pub const GPU_TITLE: &str = "system-gpu-title";
-
-    /// GPU metrics label in title row (clock · power · temp) (`.system-gpu-metrics`).
-    pub const GPU_METRICS: &str = "system-gpu-metrics";
 }

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -21,7 +21,9 @@ use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
+use crate::widgets::{
+    VERTICAL_METRIC_CHARS, WidgetConfig, format_vertical_metric, warn_unknown_options,
+};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
@@ -209,12 +211,12 @@ fn cpu_label_width(format: &CpuFormat, stable_width: bool, is_vertical: bool) ->
     }
 
     Some(match (format, is_vertical) {
-        (CpuFormat::Usage, false) => 3,       // 99%
-        (CpuFormat::Usage, true) => 3,        // 99%
-        (CpuFormat::Temperature, false) => 4, // 99°C
-        (CpuFormat::Temperature, true) => 3,  // 99°
-        (CpuFormat::Both, false) => 8,        // 99% 99°C
-        (CpuFormat::Both, true) => 3,         // 99% / 99°
+        (CpuFormat::Usage, false) => 3,                          // 99%
+        (CpuFormat::Usage, true) => VERTICAL_METRIC_CHARS,       // 99%
+        (CpuFormat::Temperature, false) => 4,                    // 99°C
+        (CpuFormat::Temperature, true) => VERTICAL_METRIC_CHARS, // 99°
+        (CpuFormat::Both, false) => 8,                           // 99% 99°C
+        (CpuFormat::Both, true) => VERTICAL_METRIC_CHARS,        // 99% / 99°
     })
 }
 

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -152,10 +152,7 @@ impl CpuWidget {
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let percentage_label = base.add_label(None, &[widget::CPU_LABEL, class::VCENTER_CAPS]);
         if is_vertical {
-            percentage_label.set_wrap(true);
-            percentage_label.set_single_line_mode(false);
             percentage_label.set_justify(gtk4::Justification::Center);
-            percentage_label.set_yalign(0.5);
         }
         if let Some(width_chars) = cpu_label_width(&config.format, config.stable_width, is_vertical)
         {
@@ -283,7 +280,7 @@ fn update_cpu_widget(
 
 fn format_cpu_usage(cpu_usage: f32, is_vertical: bool) -> String {
     if is_vertical {
-        format_vertical_metric(cpu_usage as f64, '%')
+        format_vertical_metric(cpu_usage, '%')
     } else {
         format!("{cpu_usage:.0}%")
     }
@@ -294,14 +291,14 @@ fn format_cpu_label(snapshot: &SystemSnapshot, format: &CpuFormat, is_vertical: 
     match format {
         CpuFormat::Usage => format_cpu_usage(snapshot.cpu_usage, is_vertical),
         CpuFormat::Temperature => match snapshot.cpu_temp {
-            Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
+            Some(temp) if is_vertical => format_vertical_metric(temp, '°'),
             Some(temp) => format!("{temp:.0}°C"),
             None => "—".to_string(),
         },
         CpuFormat::Both => {
             let usage_part = format_cpu_usage(snapshot.cpu_usage, is_vertical);
             let temp_part = match snapshot.cpu_temp {
-                Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
+                Some(temp) if is_vertical => format_vertical_metric(temp, '°'),
                 Some(temp) => format!("{temp:.0}°C"),
                 None => "—".to_string(),
             };

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -21,7 +21,7 @@ use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, warn_unknown_options};
+use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
@@ -151,6 +151,12 @@ impl CpuWidget {
 
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let percentage_label = base.add_label(None, &[widget::CPU_LABEL, class::VCENTER_CAPS]);
+        if is_vertical {
+            percentage_label.set_wrap(true);
+            percentage_label.set_single_line_mode(false);
+            percentage_label.set_justify(gtk4::Justification::Center);
+            percentage_label.set_yalign(0.5);
+        }
         if let Some(width_chars) = cpu_label_width(&config.format, config.stable_width, is_vertical)
         {
             percentage_label.set_width_chars(width_chars);
@@ -207,11 +213,11 @@ fn cpu_label_width(format: &CpuFormat, stable_width: bool, is_vertical: bool) ->
 
     Some(match (format, is_vertical) {
         (CpuFormat::Usage, false) => 3,       // 99%
-        (CpuFormat::Usage, true) => 2,        // 99
+        (CpuFormat::Usage, true) => 3,        // 99%
         (CpuFormat::Temperature, false) => 4, // 99°C
         (CpuFormat::Temperature, true) => 3,  // 99°
         (CpuFormat::Both, false) => 8,        // 99% 99°C
-        (CpuFormat::Both, true) => 3,         // widest line: 99°
+        (CpuFormat::Both, true) => 3,         // 99% / 99°
     })
 }
 
@@ -277,7 +283,7 @@ fn update_cpu_widget(
 
 fn format_cpu_usage(cpu_usage: f32, is_vertical: bool) -> String {
     if is_vertical {
-        format!("{cpu_usage:.0}")
+        format_vertical_metric(cpu_usage as f64, '%')
     } else {
         format!("{cpu_usage:.0}%")
     }
@@ -288,14 +294,14 @@ fn format_cpu_label(snapshot: &SystemSnapshot, format: &CpuFormat, is_vertical: 
     match format {
         CpuFormat::Usage => format_cpu_usage(snapshot.cpu_usage, is_vertical),
         CpuFormat::Temperature => match snapshot.cpu_temp {
-            Some(temp) if is_vertical => format!("{temp:.0}°"),
+            Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
             Some(temp) => format!("{temp:.0}°C"),
             None => "—".to_string(),
         },
         CpuFormat::Both => {
             let usage_part = format_cpu_usage(snapshot.cpu_usage, is_vertical);
             let temp_part = match snapshot.cpu_temp {
-                Some(temp) if is_vertical => format!("{temp:.0}°"),
+                Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
                 Some(temp) => format!("{temp:.0}°C"),
                 None => "—".to_string(),
             };
@@ -356,14 +362,29 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, false), "42%");
-        assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, true), "42");
+        assert_eq!(format_cpu_label(&snapshot, &CpuFormat::Usage, true), "42%");
         assert_eq!(
             format_cpu_label(&snapshot, &CpuFormat::Both, true),
-            "42\n72°"
+            "42%\n72°"
         );
         assert_eq!(
             format_cpu_label(&snapshot, &CpuFormat::Temperature, true),
             "72°"
+        );
+
+        let boundary = SystemSnapshot {
+            cpu_usage: 100.0,
+            cpu_temp: Some(100.0),
+            ..snapshot
+        };
+        assert_eq!(format_cpu_label(&boundary, &CpuFormat::Usage, true), "100");
+        assert_eq!(
+            format_cpu_label(&boundary, &CpuFormat::Temperature, true),
+            "100"
+        );
+        assert_eq!(
+            format_cpu_label(&boundary, &CpuFormat::Both, true),
+            "100\n100"
         );
     }
 

--- a/crates/vibepanel/src/widgets/css/system.rs
+++ b/crates/vibepanel/src/widgets/css/system.rs
@@ -82,10 +82,6 @@ button.system-expander-header > overlay > box {
 .system-gpu-title {
     margin-bottom: 4px;
 }
-
-/* GPU metrics in title row (clock · power · temp) */
-.system-gpu-metrics {
-}
 "#
 }
 

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -59,7 +59,7 @@ pub struct GpuConfig {
 
 impl WidgetConfig for GpuConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("gpu", entry, &["show_icon", "format", "device"]);
+        warn_unknown_options("gpu", entry, &["show_icon", "format", "device", "devices"]);
 
         let show_icon = entry
             .options

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -15,7 +15,7 @@ use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
-use crate::services::gpu::{GpuPowerState, GpuService, GpuSnapshot};
+use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::IconHandle;
 use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long};
 use crate::services::tooltip::TooltipManager;
@@ -188,9 +188,28 @@ impl Drop for GpuWidget {
 
 /// Format GPU label text according to the selected format.
 fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: bool) -> String {
+    let devices = snapshot.devices_for_display();
+    if devices.is_empty() {
+        return "—".to_string();
+    }
+
+    let separator = if is_vertical { "\n" } else { " | " };
+    devices
+        .iter()
+        .map(|device| format_gpu_device_label(device, format, is_vertical))
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+fn format_gpu_device_label(
+    snapshot: &GpuDeviceSnapshot,
+    format: &GpuFormat,
+    is_vertical: bool,
+) -> String {
     if snapshot.power_state == GpuPowerState::Suspended {
         return "Idle".to_string();
     }
+
     match format {
         GpuFormat::Usage => match snapshot.gpu_usage {
             Some(usage) => format_gpu_usage(usage, is_vertical),
@@ -228,6 +247,61 @@ fn format_gpu_usage(usage: f32, is_vertical: bool) -> String {
     }
 }
 
+fn format_gpu_tooltip(snapshot: &GpuSnapshot) -> String {
+    let devices = snapshot.devices_for_display();
+    if devices.is_empty() {
+        return "GPU: No supported GPU detected".to_string();
+    }
+
+    devices
+        .iter()
+        .enumerate()
+        .map(|(index, device)| format_gpu_tooltip_block(index, device))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_gpu_tooltip_block(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+    let mut lines = Vec::new();
+    let title = match snapshot.device_name.as_deref() {
+        Some(name) => format!("GPU {}: {}", index + 1, name),
+        None => format!("GPU {}", index + 1),
+    };
+    lines.push(title);
+
+    if snapshot.power_state == GpuPowerState::Suspended {
+        lines.push("State: Idle (suspended)".to_string());
+    } else if let Some(usage) = snapshot.gpu_usage {
+        lines.push(format!("Usage: {:.1}%", usage));
+    } else {
+        lines.push("Usage: --".to_string());
+    }
+
+    if let Some(temp) = snapshot.temperature {
+        lines.push(format!("Temp: {:.0}°C", temp));
+    }
+
+    match (snapshot.vram_used, snapshot.vram_total) {
+        (Some(used), Some(total)) => lines.push(format!(
+            "VRAM: {} / {}",
+            format_bytes_long(used),
+            format_bytes_long(total)
+        )),
+        (Some(used), None) => lines.push(format!("VRAM: {} used", format_bytes_long(used))),
+        _ => {}
+    }
+
+    if let Some(mhz) = snapshot.clock_mhz {
+        lines.push(format!("Clock: {} MHz", mhz));
+    }
+
+    if let Some(watts) = snapshot.power_watts {
+        lines.push(format!("Power: {:.1} W", watts));
+    }
+
+    lines.join("\n")
+}
+
 /// Update GPU widget visuals and tooltip from a snapshot.
 fn update_gpu_widget(
     container: &gtk4::Box,
@@ -261,7 +335,7 @@ fn update_gpu_widget(
         icon_handle.remove_css_class(widget::GPU_HIGH);
     }
 
-    if snapshot.power_state == GpuPowerState::Suspended {
+    if snapshot.all_devices_suspended() {
         container.add_css_class(widget::GPU_SUSPENDED);
     } else {
         container.remove_css_class(widget::GPU_SUSPENDED);
@@ -273,41 +347,7 @@ fn update_gpu_widget(
     gpu_label.set_label(&text);
     gpu_label.set_visible(true);
 
-    let mut lines = Vec::new();
-
-    if snapshot.power_state == GpuPowerState::Suspended {
-        lines.push("GPU: Idle (suspended)".to_string());
-    } else if let Some(usage) = snapshot.gpu_usage {
-        lines.push(format!("GPU: {:.1}%", usage));
-    } else {
-        lines.push("GPU: --".to_string());
-    }
-
-    if let Some(temp) = snapshot.temperature {
-        lines.push(format!("Temp: {:.0}°C", temp));
-    }
-
-    if let (Some(used), Some(total)) = (snapshot.vram_used, snapshot.vram_total) {
-        lines.push(format!(
-            "VRAM: {} / {}",
-            format_bytes_long(used),
-            format_bytes_long(total)
-        ));
-    }
-
-    if let Some(mhz) = snapshot.clock_mhz {
-        lines.push(format!("Clock: {} MHz", mhz));
-    }
-
-    if let Some(watts) = snapshot.power_watts {
-        lines.push(format!("Power: {:.1} W", watts));
-    }
-
-    if let Some(ref name) = snapshot.device_name {
-        lines.push(name.clone());
-    }
-
-    let tooltip = lines.join("\n");
+    let tooltip = format_gpu_tooltip(snapshot);
     let tooltip_manager = TooltipManager::global();
     tooltip_manager.set_styled_tooltip(container, &tooltip);
 }
@@ -315,6 +355,27 @@ fn update_gpu_widget(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn multi_gpu_snapshot() -> GpuSnapshot {
+        GpuSnapshot {
+            available: true,
+            devices: vec![
+                GpuDeviceSnapshot {
+                    gpu_usage: Some(76.0),
+                    temperature: Some(72.0),
+                    device_name: Some("AMD Radeon".to_string()),
+                    ..Default::default()
+                },
+                GpuDeviceSnapshot {
+                    gpu_usage: Some(41.0),
+                    temperature: Some(61.0),
+                    device_name: Some("NVIDIA RTX".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn test_gpu_config_defaults() {
@@ -451,5 +512,27 @@ mod tests {
             "—"
         );
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Both, false), "— —");
+    }
+
+    #[test]
+    fn test_format_gpu_label_multiple_devices() {
+        let snapshot = multi_gpu_snapshot();
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Usage, false),
+            "76% | 41%"
+        );
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Usage, true),
+            "76\n41"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_tooltip_multiple_devices() {
+        let tooltip = format_gpu_tooltip(&multi_gpu_snapshot());
+        assert!(tooltip.contains("GPU 1: AMD Radeon"));
+        assert!(tooltip.contains("GPU 2: NVIDIA RTX"));
+        assert!(tooltip.contains("Usage: 76.0%"));
+        assert!(tooltip.contains("Usage: 41.0%"));
     }
 }

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -9,8 +9,11 @@
 //! - `TooltipManager` for styled tooltips
 //! - Shared popover with CPU/Memory widgets for detailed system info
 
-use gtk4::Label;
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, Label, Orientation};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
@@ -22,7 +25,7 @@ use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, warn_unknown_options};
+use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
 
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_STABLE_WIDTH: bool = true;
@@ -115,6 +118,97 @@ pub struct GpuWidget {
     system_callback_id: CallbackId,
 }
 
+#[derive(Clone)]
+enum GpuBarDisplay {
+    Horizontal(Label),
+    Vertical {
+        container: GtkBox,
+        labels: Rc<RefCell<Vec<Label>>>,
+        width_chars: Option<i32>,
+    },
+}
+
+impl GpuBarDisplay {
+    fn new(base: &BaseWidget, config: &GpuConfig, is_vertical: bool) -> Self {
+        let width_chars = gpu_label_width(&config.format, config.stable_width, is_vertical);
+
+        if !is_vertical {
+            let label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
+            if let Some(width_chars) = width_chars {
+                label.set_width_chars(width_chars);
+            }
+            return Self::Horizontal(label);
+        }
+
+        let container = GtkBox::new(Orientation::Vertical, 4);
+        container.set_halign(Align::Fill);
+        container.set_hexpand(true);
+        container.set_valign(Align::Center);
+        base.content().append(&container);
+
+        Self::Vertical {
+            container,
+            labels: Rc::new(RefCell::new(Vec::new())),
+            width_chars,
+        }
+    }
+
+    fn update(&self, snapshot: &GpuSnapshot, format: &GpuFormat) {
+        match self {
+            Self::Horizontal(label) => {
+                label.set_label(&format_gpu_label(snapshot, format, false));
+                label.set_visible(true);
+            }
+            Self::Vertical {
+                container,
+                labels,
+                width_chars,
+            } => {
+                let devices = snapshot.devices_for_display();
+                let texts = if devices.is_empty() {
+                    vec!["—".to_string()]
+                } else {
+                    devices
+                        .iter()
+                        .map(|device| format_gpu_device_label(device, format, true))
+                        .collect()
+                };
+
+                let mut labels = labels.borrow_mut();
+                if labels.len() != texts.len() {
+                    while let Some(child) = container.first_child() {
+                        container.remove(&child);
+                    }
+                    labels.clear();
+
+                    for _ in 0..texts.len() {
+                        let label = Label::new(None);
+                        label.add_css_class(widget::GPU_LABEL);
+                        label.add_css_class(class::VCENTER_CAPS);
+                        label.set_halign(Align::Fill);
+                        label.set_hexpand(true);
+                        label.set_xalign(0.5);
+                        label.set_wrap(true);
+                        label.set_single_line_mode(false);
+                        label.set_justify(gtk4::Justification::Center);
+                        label.set_yalign(0.5);
+                        if let Some(width_chars) = width_chars {
+                            label.set_width_chars(*width_chars);
+                        }
+                        container.append(&label);
+                        labels.push(label);
+                    }
+                }
+
+                for (label, text) in labels.iter().zip(texts) {
+                    label.set_label(&text);
+                    label.set_visible(true);
+                }
+            }
+        }
+    }
+}
+
 impl GpuWidget {
     /// Create a new GPU widget with the given configuration.
     pub fn new(config: GpuConfig) -> Self {
@@ -136,11 +230,7 @@ impl GpuWidget {
         let icon_handle = base.add_icon("video-display-symbolic", &[widget::GPU_ICON]);
 
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
-        let gpu_label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
-        if let Some(width_chars) = gpu_label_width(&config.format, config.stable_width, is_vertical)
-        {
-            gpu_label.set_width_chars(width_chars);
-        }
+        let gpu_display = GpuBarDisplay::new(&base, &config, is_vertical);
 
         icon_handle.widget().set_visible(config.show_icon);
 
@@ -152,7 +242,7 @@ impl GpuWidget {
         let gpu_callback_id = {
             let container = base.widget().clone();
             let icon_handle = icon_handle.clone();
-            let gpu_label = gpu_label.clone();
+            let gpu_display = gpu_display.clone();
             let show_icon = config.show_icon;
             let format = config.format.clone();
             let popover_binding = popover_binding.clone();
@@ -161,10 +251,9 @@ impl GpuWidget {
                 update_gpu_widget(
                     &container,
                     &icon_handle,
-                    &gpu_label,
+                    &gpu_display,
                     show_icon,
                     &format,
-                    is_vertical,
                     snapshot,
                 );
 
@@ -206,11 +295,11 @@ fn gpu_label_width(format: &GpuFormat, stable_width: bool, is_vertical: bool) ->
 
     Some(match (format, is_vertical) {
         (GpuFormat::Usage, false) => 3,       // 99%
-        (GpuFormat::Usage, true) => 2,        // 99
+        (GpuFormat::Usage, true) => 3,        // 99%
         (GpuFormat::Temperature, false) => 4, // 99°C
         (GpuFormat::Temperature, true) => 3,  // 99°
         (GpuFormat::Both, false) => 8,        // 99% 99°C
-        (GpuFormat::Both, true) => 3,         // widest line: 99°
+        (GpuFormat::Both, true) => 3,         // 99% / 99°
     })
 }
 
@@ -230,12 +319,12 @@ fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: boo
         return "—".to_string();
     }
 
-    let separator = if is_vertical { "\n" } else { " | " };
-    devices
+    let labels = devices
         .iter()
         .map(|device| format_gpu_device_label(device, format, is_vertical))
-        .collect::<Vec<_>>()
-        .join(separator)
+        .collect::<Vec<_>>();
+
+    labels.join(if is_vertical { "\n" } else { " | " })
 }
 
 fn format_gpu_device_label(
@@ -244,7 +333,7 @@ fn format_gpu_device_label(
     is_vertical: bool,
 ) -> String {
     if snapshot.power_state == GpuPowerState::Suspended {
-        return "Idle".to_string();
+        return if is_vertical { "—" } else { "Idle" }.to_string();
     }
 
     match format {
@@ -253,7 +342,7 @@ fn format_gpu_device_label(
             None => "—".to_string(),
         },
         GpuFormat::Temperature => match snapshot.temperature {
-            Some(temp) if is_vertical => format!("{:.0}°", temp),
+            Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
             Some(temp) => format!("{:.0}°C", temp),
             None => "—".to_string(),
         },
@@ -263,7 +352,7 @@ fn format_gpu_device_label(
                 None => "—".to_string(),
             };
             let temp_part = match snapshot.temperature {
-                Some(temp) if is_vertical => format!("{:.0}°", temp),
+                Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
                 Some(temp) => format!("{:.0}°C", temp),
                 None => "—".to_string(),
             };
@@ -278,7 +367,7 @@ fn format_gpu_device_label(
 
 fn format_gpu_usage(usage: f32, is_vertical: bool) -> String {
     if is_vertical {
-        format!("{usage:.0}")
+        format_vertical_metric(usage as f64, '%')
     } else {
         format!("{usage:.0}%")
     }
@@ -343,10 +432,9 @@ fn format_gpu_tooltip_block(index: usize, snapshot: &GpuDeviceSnapshot) -> Strin
 fn update_gpu_widget(
     container: &gtk4::Box,
     icon_handle: &IconHandle,
-    gpu_label: &Label,
+    gpu_display: &GpuBarDisplay,
     show_icon: bool,
     format: &GpuFormat,
-    is_vertical: bool,
     snapshot: &GpuSnapshot,
 ) {
     if !snapshot.available {
@@ -356,8 +444,7 @@ fn update_gpu_widget(
         if show_icon {
             icon_handle.widget().set_visible(true);
         }
-        gpu_label.set_label("—");
-        gpu_label.set_visible(true);
+        gpu_display.update(snapshot, format);
 
         let tooltip_manager = TooltipManager::global();
         tooltip_manager.set_styled_tooltip(container, "GPU: No supported GPU detected");
@@ -380,9 +467,7 @@ fn update_gpu_widget(
 
     icon_handle.widget().set_visible(show_icon);
 
-    let text = format_gpu_label(snapshot, format, is_vertical);
-    gpu_label.set_label(&text);
-    gpu_label.set_visible(true);
+    gpu_display.update(snapshot, format);
 
     let tooltip = format_gpu_tooltip(snapshot);
     let tooltip_manager = TooltipManager::global();
@@ -475,7 +560,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, false), "76%");
-        assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, true), "76");
+        assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, true), "76%");
     }
 
     #[test]
@@ -525,7 +610,22 @@ mod tests {
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Both, true),
-            "76\n72°"
+            "76%\n72°"
+        );
+
+        let boundary = GpuSnapshot {
+            gpu_usage: Some(100.0),
+            temperature: Some(100.0),
+            ..snapshot
+        };
+        assert_eq!(format_gpu_label(&boundary, &GpuFormat::Usage, true), "100");
+        assert_eq!(
+            format_gpu_label(&boundary, &GpuFormat::Temperature, true),
+            "100"
+        );
+        assert_eq!(
+            format_gpu_label(&boundary, &GpuFormat::Both, true),
+            "100\n100"
         );
     }
 
@@ -541,7 +641,10 @@ mod tests {
             format_gpu_label(&snapshot, &GpuFormat::Both, false),
             "76% —"
         );
-        assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Both, true), "76\n—");
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Both, true),
+            "76%\n—"
+        );
     }
 
     #[test]
@@ -569,8 +672,30 @@ mod tests {
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Usage, true),
-            "76\n41"
+            "76%\n41%"
         );
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Both, true),
+            "76%\n72°\n41%\n61°"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_label_compacts_suspended_device_vertically() {
+        let snapshot = GpuSnapshot {
+            available: true,
+            devices: vec![GpuDeviceSnapshot {
+                power_state: GpuPowerState::Suspended,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Usage, false),
+            "Idle"
+        );
+        assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, true), "—");
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -15,7 +15,7 @@ use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
-use crate::services::gpu::{GpuPowerState, GpuService, GpuSnapshot};
+use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::IconHandle;
 use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long};
 use crate::services::tooltip::TooltipManager;
@@ -225,9 +225,28 @@ impl Drop for GpuWidget {
 
 /// Format GPU label text according to the selected format.
 fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: bool) -> String {
+    let devices = snapshot.devices_for_display();
+    if devices.is_empty() {
+        return "—".to_string();
+    }
+
+    let separator = if is_vertical { "\n" } else { " | " };
+    devices
+        .iter()
+        .map(|device| format_gpu_device_label(device, format, is_vertical))
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+fn format_gpu_device_label(
+    snapshot: &GpuDeviceSnapshot,
+    format: &GpuFormat,
+    is_vertical: bool,
+) -> String {
     if snapshot.power_state == GpuPowerState::Suspended {
         return "Idle".to_string();
     }
+
     match format {
         GpuFormat::Usage => match snapshot.gpu_usage {
             Some(usage) => format_gpu_usage(usage, is_vertical),
@@ -265,6 +284,61 @@ fn format_gpu_usage(usage: f32, is_vertical: bool) -> String {
     }
 }
 
+fn format_gpu_tooltip(snapshot: &GpuSnapshot) -> String {
+    let devices = snapshot.devices_for_display();
+    if devices.is_empty() {
+        return "GPU: No supported GPU detected".to_string();
+    }
+
+    devices
+        .iter()
+        .enumerate()
+        .map(|(index, device)| format_gpu_tooltip_block(index, device))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_gpu_tooltip_block(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+    let mut lines = Vec::new();
+    let title = match snapshot.device_name.as_deref() {
+        Some(name) => format!("GPU {}: {}", index + 1, name),
+        None => format!("GPU {}", index + 1),
+    };
+    lines.push(title);
+
+    if snapshot.power_state == GpuPowerState::Suspended {
+        lines.push("State: Idle (suspended)".to_string());
+    } else if let Some(usage) = snapshot.gpu_usage {
+        lines.push(format!("Usage: {:.1}%", usage));
+    } else {
+        lines.push("Usage: --".to_string());
+    }
+
+    if let Some(temp) = snapshot.temperature {
+        lines.push(format!("Temp: {:.0}°C", temp));
+    }
+
+    match (snapshot.vram_used, snapshot.vram_total) {
+        (Some(used), Some(total)) => lines.push(format!(
+            "VRAM: {} / {}",
+            format_bytes_long(used),
+            format_bytes_long(total)
+        )),
+        (Some(used), None) => lines.push(format!("VRAM: {} used", format_bytes_long(used))),
+        _ => {}
+    }
+
+    if let Some(mhz) = snapshot.clock_mhz {
+        lines.push(format!("Clock: {} MHz", mhz));
+    }
+
+    if let Some(watts) = snapshot.power_watts {
+        lines.push(format!("Power: {:.1} W", watts));
+    }
+
+    lines.join("\n")
+}
+
 /// Update GPU widget visuals and tooltip from a snapshot.
 fn update_gpu_widget(
     container: &gtk4::Box,
@@ -298,7 +372,7 @@ fn update_gpu_widget(
         icon_handle.remove_css_class(widget::GPU_HIGH);
     }
 
-    if snapshot.power_state == GpuPowerState::Suspended {
+    if snapshot.all_devices_suspended() {
         container.add_css_class(widget::GPU_SUSPENDED);
     } else {
         container.remove_css_class(widget::GPU_SUSPENDED);
@@ -310,41 +384,7 @@ fn update_gpu_widget(
     gpu_label.set_label(&text);
     gpu_label.set_visible(true);
 
-    let mut lines = Vec::new();
-
-    if snapshot.power_state == GpuPowerState::Suspended {
-        lines.push("GPU: Idle (suspended)".to_string());
-    } else if let Some(usage) = snapshot.gpu_usage {
-        lines.push(format!("GPU: {:.1}%", usage));
-    } else {
-        lines.push("GPU: --".to_string());
-    }
-
-    if let Some(temp) = snapshot.temperature {
-        lines.push(format!("Temp: {:.0}°C", temp));
-    }
-
-    if let (Some(used), Some(total)) = (snapshot.vram_used, snapshot.vram_total) {
-        lines.push(format!(
-            "VRAM: {} / {}",
-            format_bytes_long(used),
-            format_bytes_long(total)
-        ));
-    }
-
-    if let Some(mhz) = snapshot.clock_mhz {
-        lines.push(format!("Clock: {} MHz", mhz));
-    }
-
-    if let Some(watts) = snapshot.power_watts {
-        lines.push(format!("Power: {:.1} W", watts));
-    }
-
-    if let Some(ref name) = snapshot.device_name {
-        lines.push(name.clone());
-    }
-
-    let tooltip = lines.join("\n");
+    let tooltip = format_gpu_tooltip(snapshot);
     let tooltip_manager = TooltipManager::global();
     tooltip_manager.set_styled_tooltip(container, &tooltip);
 }
@@ -352,6 +392,27 @@ fn update_gpu_widget(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn multi_gpu_snapshot() -> GpuSnapshot {
+        GpuSnapshot {
+            available: true,
+            devices: vec![
+                GpuDeviceSnapshot {
+                    gpu_usage: Some(76.0),
+                    temperature: Some(72.0),
+                    device_name: Some("AMD Radeon".to_string()),
+                    ..Default::default()
+                },
+                GpuDeviceSnapshot {
+                    gpu_usage: Some(41.0),
+                    temperature: Some(61.0),
+                    device_name: Some("NVIDIA RTX".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn test_gpu_config_defaults() {
@@ -497,5 +558,27 @@ mod tests {
             "—"
         );
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Both, false), "— —");
+    }
+
+    #[test]
+    fn test_format_gpu_label_multiple_devices() {
+        let snapshot = multi_gpu_snapshot();
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Usage, false),
+            "76% | 41%"
+        );
+        assert_eq!(
+            format_gpu_label(&snapshot, &GpuFormat::Usage, true),
+            "76\n41"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_tooltip_multiple_devices() {
+        let tooltip = format_gpu_tooltip(&multi_gpu_snapshot());
+        assert!(tooltip.contains("GPU 1: AMD Radeon"));
+        assert!(tooltip.contains("GPU 2: NVIDIA RTX"));
+        assert!(tooltip.contains("Usage: 76.0%"));
+        assert!(tooltip.contains("Usage: 41.0%"));
     }
 }

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -17,16 +17,20 @@ use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::IconHandle;
-use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long};
+use crate::services::system::{SystemService, SystemSnapshot};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
+use crate::widgets::gpu_format;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
+use crate::widgets::{
+    VERTICAL_METRIC_CHARS, WidgetConfig, format_vertical_metric, warn_unknown_options,
+};
 
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_STABLE_WIDTH: bool = true;
 const DEVICE_SEPARATOR: &str = " | ";
+const VERTICAL_DEVICE_SEPARATOR: &str = "\n<span size=\"2pt\">&#x2009;</span>\n";
 
 /// GPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -154,7 +158,6 @@ impl GpuWidget {
             let icon_handle = icon_handle.clone();
             let gpu_label = gpu_label.clone();
             let config = config.clone();
-            let popover_binding = popover_binding.clone();
 
             gpu_service.connect(move |snapshot: &GpuSnapshot| {
                 update_gpu_widget(
@@ -165,8 +168,6 @@ impl GpuWidget {
                     is_vertical,
                     snapshot,
                 );
-
-                popover_binding.update_gpu_if_open(snapshot);
             })
         };
 
@@ -208,19 +209,19 @@ fn gpu_label_width(
     }
 
     let per_device = match (format, is_vertical) {
-        (GpuFormat::Usage, false) => 3,       // 99%
-        (GpuFormat::Usage, true) => 3,        // 99%
-        (GpuFormat::Temperature, false) => 4, // 99°C
-        (GpuFormat::Temperature, true) => 3,  // 99°
-        (GpuFormat::Both, false) => 8,        // 99% 99°C
-        (GpuFormat::Both, true) => 3,         // 99% / 99°
+        (GpuFormat::Usage, false) => 3,                          // 99%
+        (GpuFormat::Usage, true) => VERTICAL_METRIC_CHARS,       // 99%
+        (GpuFormat::Temperature, false) => 4,                    // 99°C
+        (GpuFormat::Temperature, true) => VERTICAL_METRIC_CHARS, // 99°
+        (GpuFormat::Both, false) => 8,                           // 99% 99°C
+        (GpuFormat::Both, true) => VERTICAL_METRIC_CHARS,        // 99% / 99°
     };
 
     let device_count = device_count.max(1) as i32;
     Some(if is_vertical {
         per_device
     } else {
-        device_count * per_device + (device_count - 1) * DEVICE_SEPARATOR.len() as i32
+        device_count * per_device + (device_count - 1) * DEVICE_SEPARATOR.chars().count() as i32
     })
 }
 
@@ -246,7 +247,7 @@ fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: boo
         .collect::<Vec<_>>();
 
     labels.join(if is_vertical {
-        "\n\n"
+        VERTICAL_DEVICE_SEPARATOR
     } else {
         DEVICE_SEPARATOR
     })
@@ -313,13 +314,7 @@ fn format_gpu_tooltip(snapshot: &GpuSnapshot) -> String {
 
 fn format_gpu_tooltip_block(snapshot: &GpuDeviceSnapshot, show_index: bool) -> String {
     let mut lines = Vec::new();
-    let title = match (show_index, snapshot.device_name.as_deref()) {
-        (true, Some(name)) => format!("GPU {}: {}", snapshot.device_index, name),
-        (true, None) => format!("GPU {}", snapshot.device_index),
-        (false, Some(name)) => format!("GPU: {name}"),
-        (false, None) => "GPU".to_string(),
-    };
-    lines.push(title);
+    lines.push(gpu_format::device_title(snapshot, show_index));
 
     if snapshot.power_state == GpuPowerState::Suspended {
         lines.push("State: Idle (suspended)".to_string());
@@ -333,22 +328,16 @@ fn format_gpu_tooltip_block(snapshot: &GpuDeviceSnapshot, show_index: bool) -> S
         lines.push(format!("Temp: {:.0}°C", temp));
     }
 
-    match (snapshot.vram_used, snapshot.vram_total) {
-        (Some(used), Some(total)) => lines.push(format!(
-            "VRAM: {} / {}",
-            format_bytes_long(used),
-            format_bytes_long(total)
-        )),
-        (Some(used), None) => lines.push(format!("VRAM: {} used", format_bytes_long(used))),
-        _ => {}
+    if let Some(value) = gpu_format::vram(snapshot) {
+        lines.push(format!("VRAM: {value}"));
     }
 
-    if let Some(mhz) = snapshot.clock_mhz {
-        lines.push(format!("Clock: {} MHz", mhz));
+    if let Some(value) = gpu_format::clock(snapshot) {
+        lines.push(format!("Clock: {value}"));
     }
 
-    if let Some(watts) = snapshot.power_watts {
-        lines.push(format!("Power: {:.1} W", watts));
+    if let Some(value) = gpu_format::power(snapshot) {
+        lines.push(format!("Power: {value}"));
     }
 
     lines.join("\n")
@@ -370,7 +359,7 @@ fn update_gpu_widget(
         snapshot.devices.len(),
     );
     gpu_label.set_width_chars(width_chars.unwrap_or(-1));
-    gpu_label.set_label(&format_gpu_label(snapshot, &config.format, is_vertical));
+    gpu_label.set_markup(&format_gpu_label(snapshot, &config.format, is_vertical));
     gpu_label.set_visible(true);
 
     if snapshot.is_gpu_high() {
@@ -571,11 +560,11 @@ mod tests {
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Usage, true),
-            "76%\n\n41%"
+            "76%\n<span size=\"2pt\">&#x2009;</span>\n41%"
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Both, true),
-            "76%\n72°\n\n41%\n61°"
+            "76%\n72°\n<span size=\"2pt\">&#x2009;</span>\n41%\n61°"
         );
     }
 

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -65,7 +65,7 @@ impl WidgetConfig for GpuConfig {
         warn_unknown_options(
             "gpu",
             entry,
-            &["show_icon", "format", "device", "stable_width"],
+            &["show_icon", "format", "device", "devices", "stable_width"],
         );
 
         let show_icon = entry

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -9,11 +9,8 @@
 //! - `TooltipManager` for styled tooltips
 //! - Shared popover with CPU/Memory widgets for detailed system info
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
+use gtk4::Label;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Label, Orientation};
 use vibepanel_core::config::WidgetEntry;
 
 use crate::services::callbacks::CallbackId;
@@ -29,6 +26,7 @@ use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options}
 
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_STABLE_WIDTH: bool = true;
+const DEVICE_SEPARATOR: &str = " | ";
 
 /// GPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -118,97 +116,6 @@ pub struct GpuWidget {
     system_callback_id: CallbackId,
 }
 
-#[derive(Clone)]
-enum GpuBarDisplay {
-    Horizontal(Label),
-    Vertical {
-        container: GtkBox,
-        labels: Rc<RefCell<Vec<Label>>>,
-        width_chars: Option<i32>,
-    },
-}
-
-impl GpuBarDisplay {
-    fn new(base: &BaseWidget, config: &GpuConfig, is_vertical: bool) -> Self {
-        let width_chars = gpu_label_width(&config.format, config.stable_width, is_vertical);
-
-        if !is_vertical {
-            let label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
-            if let Some(width_chars) = width_chars {
-                label.set_width_chars(width_chars);
-            }
-            return Self::Horizontal(label);
-        }
-
-        let container = GtkBox::new(Orientation::Vertical, 4);
-        container.set_halign(Align::Fill);
-        container.set_hexpand(true);
-        container.set_valign(Align::Center);
-        base.content().append(&container);
-
-        Self::Vertical {
-            container,
-            labels: Rc::new(RefCell::new(Vec::new())),
-            width_chars,
-        }
-    }
-
-    fn update(&self, snapshot: &GpuSnapshot, format: &GpuFormat) {
-        match self {
-            Self::Horizontal(label) => {
-                label.set_label(&format_gpu_label(snapshot, format, false));
-                label.set_visible(true);
-            }
-            Self::Vertical {
-                container,
-                labels,
-                width_chars,
-            } => {
-                let devices = snapshot.devices_for_display();
-                let texts = if devices.is_empty() {
-                    vec!["—".to_string()]
-                } else {
-                    devices
-                        .iter()
-                        .map(|device| format_gpu_device_label(device, format, true))
-                        .collect()
-                };
-
-                let mut labels = labels.borrow_mut();
-                if labels.len() != texts.len() {
-                    while let Some(child) = container.first_child() {
-                        container.remove(&child);
-                    }
-                    labels.clear();
-
-                    for _ in 0..texts.len() {
-                        let label = Label::new(None);
-                        label.add_css_class(widget::GPU_LABEL);
-                        label.add_css_class(class::VCENTER_CAPS);
-                        label.set_halign(Align::Fill);
-                        label.set_hexpand(true);
-                        label.set_xalign(0.5);
-                        label.set_wrap(true);
-                        label.set_single_line_mode(false);
-                        label.set_justify(gtk4::Justification::Center);
-                        label.set_yalign(0.5);
-                        if let Some(width_chars) = width_chars {
-                            label.set_width_chars(*width_chars);
-                        }
-                        container.append(&label);
-                        labels.push(label);
-                    }
-                }
-
-                for (label, text) in labels.iter().zip(texts) {
-                    label.set_label(&text);
-                    label.set_visible(true);
-                }
-            }
-        }
-    }
-}
-
 impl GpuWidget {
     /// Create a new GPU widget with the given configuration.
     pub fn new(config: GpuConfig) -> Self {
@@ -230,7 +137,10 @@ impl GpuWidget {
         let icon_handle = base.add_icon("video-display-symbolic", &[widget::GPU_ICON]);
 
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
-        let gpu_display = GpuBarDisplay::new(&base, &config, is_vertical);
+        let gpu_label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
+        if is_vertical {
+            gpu_label.set_justify(gtk4::Justification::Center);
+        }
 
         icon_handle.widget().set_visible(config.show_icon);
 
@@ -242,18 +152,17 @@ impl GpuWidget {
         let gpu_callback_id = {
             let container = base.widget().clone();
             let icon_handle = icon_handle.clone();
-            let gpu_display = gpu_display.clone();
-            let show_icon = config.show_icon;
-            let format = config.format.clone();
+            let gpu_label = gpu_label.clone();
+            let config = config.clone();
             let popover_binding = popover_binding.clone();
 
             gpu_service.connect(move |snapshot: &GpuSnapshot| {
                 update_gpu_widget(
                     &container,
                     &icon_handle,
-                    &gpu_display,
-                    show_icon,
-                    &format,
+                    &gpu_label,
+                    &config,
+                    is_vertical,
                     snapshot,
                 );
 
@@ -288,18 +197,30 @@ impl GpuWidget {
     }
 }
 
-fn gpu_label_width(format: &GpuFormat, stable_width: bool, is_vertical: bool) -> Option<i32> {
+fn gpu_label_width(
+    format: &GpuFormat,
+    stable_width: bool,
+    is_vertical: bool,
+    device_count: usize,
+) -> Option<i32> {
     if !stable_width {
         return None;
     }
 
-    Some(match (format, is_vertical) {
+    let per_device = match (format, is_vertical) {
         (GpuFormat::Usage, false) => 3,       // 99%
         (GpuFormat::Usage, true) => 3,        // 99%
         (GpuFormat::Temperature, false) => 4, // 99°C
         (GpuFormat::Temperature, true) => 3,  // 99°
         (GpuFormat::Both, false) => 8,        // 99% 99°C
         (GpuFormat::Both, true) => 3,         // 99% / 99°
+    };
+
+    let device_count = device_count.max(1) as i32;
+    Some(if is_vertical {
+        per_device
+    } else {
+        device_count * per_device + (device_count - 1) * DEVICE_SEPARATOR.len() as i32
     })
 }
 
@@ -314,7 +235,7 @@ impl Drop for GpuWidget {
 
 /// Format GPU label text according to the selected format.
 fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: bool) -> String {
-    let devices = snapshot.devices_for_display();
+    let devices = &snapshot.devices;
     if devices.is_empty() {
         return "—".to_string();
     }
@@ -324,7 +245,11 @@ fn format_gpu_label(snapshot: &GpuSnapshot, format: &GpuFormat, is_vertical: boo
         .map(|device| format_gpu_device_label(device, format, is_vertical))
         .collect::<Vec<_>>();
 
-    labels.join(if is_vertical { "\n" } else { " | " })
+    labels.join(if is_vertical {
+        "\n\n"
+    } else {
+        DEVICE_SEPARATOR
+    })
 }
 
 fn format_gpu_device_label(
@@ -342,7 +267,7 @@ fn format_gpu_device_label(
             None => "—".to_string(),
         },
         GpuFormat::Temperature => match snapshot.temperature {
-            Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
+            Some(temp) if is_vertical => format_vertical_metric(temp, '°'),
             Some(temp) => format!("{:.0}°C", temp),
             None => "—".to_string(),
         },
@@ -352,7 +277,7 @@ fn format_gpu_device_label(
                 None => "—".to_string(),
             };
             let temp_part = match snapshot.temperature {
-                Some(temp) if is_vertical => format_vertical_metric(temp as f64, '°'),
+                Some(temp) if is_vertical => format_vertical_metric(temp, '°'),
                 Some(temp) => format!("{:.0}°C", temp),
                 None => "—".to_string(),
             };
@@ -367,31 +292,32 @@ fn format_gpu_device_label(
 
 fn format_gpu_usage(usage: f32, is_vertical: bool) -> String {
     if is_vertical {
-        format_vertical_metric(usage as f64, '%')
+        format_vertical_metric(usage, '%')
     } else {
         format!("{usage:.0}%")
     }
 }
 
 fn format_gpu_tooltip(snapshot: &GpuSnapshot) -> String {
-    let devices = snapshot.devices_for_display();
+    let devices = &snapshot.devices;
     if devices.is_empty() {
         return "GPU: No supported GPU detected".to_string();
     }
 
     devices
         .iter()
-        .enumerate()
-        .map(|(index, device)| format_gpu_tooltip_block(index, device))
+        .map(|device| format_gpu_tooltip_block(device, devices.len() > 1))
         .collect::<Vec<_>>()
         .join("\n\n")
 }
 
-fn format_gpu_tooltip_block(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+fn format_gpu_tooltip_block(snapshot: &GpuDeviceSnapshot, show_index: bool) -> String {
     let mut lines = Vec::new();
-    let title = match snapshot.device_name.as_deref() {
-        Some(name) => format!("GPU {}: {}", index + 1, name),
-        None => format!("GPU {}", index + 1),
+    let title = match (show_index, snapshot.device_name.as_deref()) {
+        (true, Some(name)) => format!("GPU {}: {}", snapshot.device_index, name),
+        (true, None) => format!("GPU {}", snapshot.device_index),
+        (false, Some(name)) => format!("GPU: {name}"),
+        (false, None) => "GPU".to_string(),
     };
     lines.push(title);
 
@@ -432,24 +358,20 @@ fn format_gpu_tooltip_block(index: usize, snapshot: &GpuDeviceSnapshot) -> Strin
 fn update_gpu_widget(
     container: &gtk4::Box,
     icon_handle: &IconHandle,
-    gpu_display: &GpuBarDisplay,
-    show_icon: bool,
-    format: &GpuFormat,
+    gpu_label: &Label,
+    config: &GpuConfig,
+    is_vertical: bool,
     snapshot: &GpuSnapshot,
 ) {
-    if !snapshot.available {
-        container.remove_css_class(widget::GPU_HIGH);
-        icon_handle.remove_css_class(widget::GPU_HIGH);
-
-        if show_icon {
-            icon_handle.widget().set_visible(true);
-        }
-        gpu_display.update(snapshot, format);
-
-        let tooltip_manager = TooltipManager::global();
-        tooltip_manager.set_styled_tooltip(container, "GPU: No supported GPU detected");
-        return;
-    }
+    let width_chars = gpu_label_width(
+        &config.format,
+        config.stable_width,
+        is_vertical,
+        snapshot.devices.len(),
+    );
+    gpu_label.set_width_chars(width_chars.unwrap_or(-1));
+    gpu_label.set_label(&format_gpu_label(snapshot, &config.format, is_vertical));
+    gpu_label.set_visible(true);
 
     if snapshot.is_gpu_high() {
         container.add_css_class(widget::GPU_HIGH);
@@ -465,9 +387,7 @@ fn update_gpu_widget(
         container.remove_css_class(widget::GPU_SUSPENDED);
     }
 
-    icon_handle.widget().set_visible(show_icon);
-
-    gpu_display.update(snapshot, format);
+    icon_handle.widget().set_visible(config.show_icon);
 
     let tooltip = format_gpu_tooltip(snapshot);
     let tooltip_manager = TooltipManager::global();
@@ -478,24 +398,34 @@ fn update_gpu_widget(
 mod tests {
     use super::*;
 
+    fn gpu_snapshot(gpu_usage: Option<f32>, temperature: Option<f32>) -> GpuSnapshot {
+        GpuSnapshot {
+            devices: vec![GpuDeviceSnapshot {
+                gpu_usage,
+                temperature,
+                ..Default::default()
+            }],
+        }
+    }
+
     fn multi_gpu_snapshot() -> GpuSnapshot {
         GpuSnapshot {
-            available: true,
             devices: vec![
                 GpuDeviceSnapshot {
+                    device_index: 1,
                     gpu_usage: Some(76.0),
                     temperature: Some(72.0),
                     device_name: Some("AMD Radeon".to_string()),
                     ..Default::default()
                 },
                 GpuDeviceSnapshot {
+                    device_index: 0,
                     gpu_usage: Some(41.0),
                     temperature: Some(61.0),
                     device_name: Some("NVIDIA RTX".to_string()),
                     ..Default::default()
                 },
             ],
-            ..Default::default()
         }
     }
 
@@ -533,8 +463,11 @@ mod tests {
 
     #[test]
     fn test_gpu_label_width_usage_matches_percentage_width() {
-        assert_eq!(gpu_label_width(&GpuFormat::Usage, true, false), Some(3));
-        assert_eq!(gpu_label_width(&GpuFormat::Usage, false, false), None);
+        assert_eq!(gpu_label_width(&GpuFormat::Usage, true, false, 1), Some(3));
+        assert_eq!(gpu_label_width(&GpuFormat::Usage, false, false, 1), None);
+        assert_eq!(gpu_label_width(&GpuFormat::Usage, true, false, 2), Some(9));
+        assert_eq!(gpu_label_width(&GpuFormat::Both, true, false, 2), Some(19));
+        assert_eq!(gpu_label_width(&GpuFormat::Both, true, true, 2), Some(3));
     }
 
     #[test]
@@ -553,24 +486,14 @@ mod tests {
 
     #[test]
     fn test_format_gpu_label_usage() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: Some(76.0),
-            temperature: Some(72.0),
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(Some(76.0), Some(72.0));
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, false), "76%");
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, true), "76%");
     }
 
     #[test]
     fn test_format_gpu_label_temperature() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: Some(76.0),
-            temperature: Some(72.0),
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(Some(76.0), Some(72.0));
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Temperature, false),
             "72°C"
@@ -583,12 +506,7 @@ mod tests {
 
     #[test]
     fn test_format_gpu_label_temperature_unavailable() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: Some(76.0),
-            temperature: None,
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(Some(76.0), None);
         // Shows dash when temperature is unavailable — no silent fallback
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Temperature, false),
@@ -598,12 +516,7 @@ mod tests {
 
     #[test]
     fn test_format_gpu_label_both() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: Some(76.0),
-            temperature: Some(72.0),
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(Some(76.0), Some(72.0));
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Both, false),
             "76% 72°C"
@@ -613,11 +526,7 @@ mod tests {
             "76%\n72°"
         );
 
-        let boundary = GpuSnapshot {
-            gpu_usage: Some(100.0),
-            temperature: Some(100.0),
-            ..snapshot
-        };
+        let boundary = gpu_snapshot(Some(100.0), Some(100.0));
         assert_eq!(format_gpu_label(&boundary, &GpuFormat::Usage, true), "100");
         assert_eq!(
             format_gpu_label(&boundary, &GpuFormat::Temperature, true),
@@ -631,12 +540,7 @@ mod tests {
 
     #[test]
     fn test_format_gpu_label_both_no_temp() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: Some(76.0),
-            temperature: None,
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(Some(76.0), None);
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Both, false),
             "76% —"
@@ -649,12 +553,7 @@ mod tests {
 
     #[test]
     fn test_format_gpu_label_no_data() {
-        let snapshot = GpuSnapshot {
-            available: true,
-            gpu_usage: None,
-            temperature: None,
-            ..Default::default()
-        };
+        let snapshot = gpu_snapshot(None, None);
         assert_eq!(format_gpu_label(&snapshot, &GpuFormat::Usage, false), "—");
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Temperature, false),
@@ -672,23 +571,21 @@ mod tests {
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Usage, true),
-            "76%\n41%"
+            "76%\n\n41%"
         );
         assert_eq!(
             format_gpu_label(&snapshot, &GpuFormat::Both, true),
-            "76%\n72°\n41%\n61°"
+            "76%\n72°\n\n41%\n61°"
         );
     }
 
     #[test]
     fn test_format_gpu_label_compacts_suspended_device_vertically() {
         let snapshot = GpuSnapshot {
-            available: true,
             devices: vec![GpuDeviceSnapshot {
                 power_state: GpuPowerState::Suspended,
                 ..Default::default()
             }],
-            ..Default::default()
         };
 
         assert_eq!(
@@ -702,7 +599,7 @@ mod tests {
     fn test_format_gpu_tooltip_multiple_devices() {
         let tooltip = format_gpu_tooltip(&multi_gpu_snapshot());
         assert!(tooltip.contains("GPU 1: AMD Radeon"));
-        assert!(tooltip.contains("GPU 2: NVIDIA RTX"));
+        assert!(tooltip.contains("GPU 0: NVIDIA RTX"));
         assert!(tooltip.contains("Usage: 76.0%"));
         assert!(tooltip.contains("Usage: 41.0%"));
     }

--- a/crates/vibepanel/src/widgets/gpu_format.rs
+++ b/crates/vibepanel/src/widgets/gpu_format.rs
@@ -1,0 +1,103 @@
+//! Shared formatting for GPU metrics displayed by widgets.
+
+use crate::services::gpu::GpuDeviceSnapshot;
+use crate::services::system::format_bytes_long;
+
+pub(crate) fn device_title(snapshot: &GpuDeviceSnapshot, show_index: bool) -> String {
+    match (show_index, snapshot.device_name.as_deref()) {
+        (true, Some(name)) => format!("GPU {}: {name}", snapshot.device_index),
+        (true, None) => format!("GPU {}", snapshot.device_index),
+        (false, Some(name)) => format!("GPU: {name}"),
+        (false, None) => "GPU".to_string(),
+    }
+}
+
+pub(crate) fn vram(snapshot: &GpuDeviceSnapshot) -> Option<String> {
+    match (snapshot.vram_used, snapshot.vram_total) {
+        (Some(used), Some(total)) => Some(format!(
+            "{} / {}",
+            format_bytes_long(used),
+            format_bytes_long(total)
+        )),
+        (Some(used), None) => Some(format!("{} used", format_bytes_long(used))),
+        _ => None,
+    }
+}
+
+pub(crate) fn power(snapshot: &GpuDeviceSnapshot) -> Option<String> {
+    match (snapshot.power_watts, snapshot.power_limit_watts) {
+        (Some(value), Some(limit)) => Some(format!("{value:.1} / {limit:.0} W")),
+        (Some(value), None) => Some(format!("{value:.1} W")),
+        _ => None,
+    }
+}
+
+pub(crate) fn clock(snapshot: &GpuDeviceSnapshot) -> Option<String> {
+    match (snapshot.clock_mhz, snapshot.max_clock_mhz) {
+        (Some(value), Some(limit)) => Some(format!("{value} / {limit} MHz")),
+        (Some(value), None) => Some(format!("{value} MHz")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clock, device_title, power, vram};
+    use crate::services::gpu::GpuDeviceSnapshot;
+
+    #[test]
+    fn formats_available_gpu_metrics() {
+        let snapshot = GpuDeviceSnapshot {
+            vram_used: Some(4 * 1024 * 1024 * 1024),
+            vram_total: Some(8 * 1024 * 1024 * 1024),
+            power_watts: Some(118.6),
+            clock_mhz: Some(2430),
+            ..Default::default()
+        };
+
+        assert_eq!(vram(&snapshot).as_deref(), Some("4.0 GB / 8.0 GB"));
+        assert_eq!(power(&snapshot).as_deref(), Some("118.6 W"));
+        assert_eq!(clock(&snapshot).as_deref(), Some("2430 MHz"));
+    }
+
+    #[test]
+    fn formats_gpu_metrics_with_limits() {
+        let snapshot = GpuDeviceSnapshot {
+            power_watts: Some(120.0),
+            power_limit_watts: Some(300.0),
+            clock_mhz: Some(1500),
+            max_clock_mhz: Some(2500),
+            ..Default::default()
+        };
+
+        assert_eq!(power(&snapshot).as_deref(), Some("120.0 / 300 W"));
+        assert_eq!(clock(&snapshot).as_deref(), Some("1500 / 2500 MHz"));
+    }
+
+    #[test]
+    fn omits_unavailable_gpu_metrics() {
+        let snapshot = GpuDeviceSnapshot::default();
+
+        assert_eq!(vram(&snapshot), None);
+        assert_eq!(power(&snapshot), None);
+        assert_eq!(clock(&snapshot), None);
+    }
+
+    #[test]
+    fn formats_device_titles_with_optional_index_and_name() {
+        let named = GpuDeviceSnapshot {
+            device_index: 3,
+            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
+            ..Default::default()
+        };
+        let unnamed = GpuDeviceSnapshot {
+            device_index: 3,
+            ..Default::default()
+        };
+
+        assert_eq!(device_title(&named, true), "GPU 3: NVIDIA GeForce RTX 4090");
+        assert_eq!(device_title(&named, false), "GPU: NVIDIA GeForce RTX 4090");
+        assert_eq!(device_title(&unnamed, true), "GPU 3");
+        assert_eq!(device_title(&unnamed, false), "GPU");
+    }
+}

--- a/crates/vibepanel/src/widgets/history_graph.rs
+++ b/crates/vibepanel/src/widgets/history_graph.rs
@@ -1,0 +1,223 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use gtk4::{DrawingArea, cairo};
+
+const INSET: f64 = 2.0;
+const LINE_WIDTH: f64 = 1.5;
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Automatic scaling is part of the shared API for later graph consumers.
+pub(crate) enum HistoryScale {
+    Fixed { min: f64, max: f64 },
+    Automatic { min: f64, headroom: f64 },
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Dashed series are supported even though the first consumer is solid-only.
+pub(crate) enum LineStyle {
+    Solid,
+    Dashed,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HistorySeries {
+    pub values: Vec<Option<f64>>,
+    pub style: LineStyle,
+    pub alpha: f64,
+}
+
+impl HistorySeries {
+    pub(crate) fn solid(values: Vec<Option<f64>>) -> Self {
+        Self {
+            values,
+            style: LineStyle::Solid,
+            alpha: 1.0,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct HistoryGraph {
+    area: DrawingArea,
+    series: Rc<RefCell<Vec<HistorySeries>>>,
+}
+
+impl HistoryGraph {
+    pub(crate) fn new(capacity: usize, height: i32, scale: HistoryScale) -> Self {
+        let capacity = capacity.max(2);
+        let series = Rc::new(RefCell::new(Vec::new()));
+        let area = DrawingArea::new();
+        area.set_size_request(-1, height);
+        area.set_hexpand(true);
+        area.set_can_target(false);
+
+        let draw_series = series.clone();
+        area.set_draw_func(move |area, cr, width, height| {
+            draw_history(
+                area,
+                cr,
+                width,
+                height,
+                capacity,
+                scale,
+                &draw_series.borrow(),
+            );
+        });
+
+        Self { area, series }
+    }
+
+    pub(crate) fn widget(&self) -> &DrawingArea {
+        &self.area
+    }
+
+    pub(crate) fn set_series(&self, series: Vec<HistorySeries>) {
+        *self.series.borrow_mut() = series;
+        self.area.queue_draw();
+    }
+}
+
+fn draw_history(
+    area: &DrawingArea,
+    cr: &cairo::Context,
+    width: i32,
+    height: i32,
+    capacity: usize,
+    scale: HistoryScale,
+    series: &[HistorySeries],
+) {
+    if width < 2 || height < 2 {
+        return;
+    }
+
+    let (min, max) = scale_bounds(scale, series);
+    let width = f64::from(width);
+    let height = f64::from(height);
+    let plot_width = (width - INSET * 2.0).max(1.0);
+    let plot_height = (height - INSET * 2.0).max(1.0);
+    let x_step = plot_width / capacity.saturating_sub(1).max(1) as f64;
+    let color = area.color();
+    let color = (
+        color.red() as f64,
+        color.green() as f64,
+        color.blue() as f64,
+        color.alpha() as f64,
+    );
+
+    for series in series {
+        let values = if series.values.len() > capacity {
+            &series.values[series.values.len() - capacity..]
+        } else {
+            &series.values
+        };
+        let first_x = width - INSET - x_step * values.len().saturating_sub(1) as f64;
+        draw_series(
+            cr,
+            values,
+            first_x,
+            x_step,
+            plot_height,
+            min,
+            max,
+            color,
+            series,
+        );
+    }
+}
+
+fn scale_bounds(scale: HistoryScale, series: &[HistorySeries]) -> (f64, f64) {
+    match scale {
+        HistoryScale::Fixed { min, max } if min.is_finite() && max.is_finite() && max > min => {
+            (min, max)
+        }
+        HistoryScale::Fixed { min, .. } => (min, min + 1.0),
+        HistoryScale::Automatic { min, headroom } => {
+            let maximum = series
+                .iter()
+                .flat_map(|series| series.values.iter().flatten())
+                .copied()
+                .filter(|value| value.is_finite())
+                .fold(min, f64::max);
+            let max = min + (maximum - min) * (1.0 + headroom.max(0.0));
+            (min, max.max(min + 1.0))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_series(
+    cr: &cairo::Context,
+    values: &[Option<f64>],
+    first_x: f64,
+    x_step: f64,
+    plot_height: f64,
+    min: f64,
+    max: f64,
+    color: (f64, f64, f64, f64),
+    series: &HistorySeries,
+) {
+    let mut run = Vec::new();
+    for (index, value) in values
+        .iter()
+        .copied()
+        .chain(std::iter::once(None))
+        .enumerate()
+    {
+        if let Some(value) = value.filter(|value| value.is_finite()) {
+            let x = first_x + x_step * index as f64;
+            let normalized = ((value.clamp(min, max) - min) / (max - min)).clamp(0.0, 1.0);
+            run.push((x, INSET + plot_height * (1.0 - normalized)));
+            continue;
+        }
+
+        if run.len() >= 2 {
+            cr.move_to(run[0].0, run[0].1);
+            for &(x, y) in run.iter().skip(1) {
+                cr.line_to(x, y);
+            }
+            cr.set_source_rgba(
+                color.0,
+                color.1,
+                color.2,
+                series.alpha.clamp(0.0, 1.0) * color.3,
+            );
+            cr.set_line_width(LINE_WIDTH);
+            match series.style {
+                LineStyle::Solid => cr.set_dash(&[], 0.0),
+                LineStyle::Dashed => cr.set_dash(&[4.0, 3.0], 0.0),
+            }
+            let _ = cr.stroke();
+        }
+        run.clear();
+    }
+    cr.set_dash(&[], 0.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn automatic_scale_is_shared_across_series() {
+        let series = vec![
+            HistorySeries::solid(vec![Some(10.0)]),
+            HistorySeries {
+                values: vec![Some(20.0), None],
+                style: LineStyle::Dashed,
+                alpha: 0.5,
+            },
+        ];
+        assert_eq!(
+            scale_bounds(
+                HistoryScale::Automatic {
+                    min: 0.0,
+                    headroom: 0.1
+                },
+                &series
+            ),
+            (0.0, 22.0)
+        );
+    }
+}

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -21,7 +21,9 @@ use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
+use crate::widgets::{
+    VERTICAL_METRIC_CHARS, WidgetConfig, format_vertical_metric, warn_unknown_options,
+};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
@@ -191,7 +193,7 @@ fn memory_label_width(format: &MemoryFormat, stable_width: bool, is_vertical: bo
     }
 
     Some(match (format, is_vertical) {
-        (_, true) => 3,                     // vertical mode always renders percentage
+        (_, true) => VERTICAL_METRIC_CHARS, // vertical mode always renders percentage
         (MemoryFormat::Percentage, _) => 3, // 99%
         (MemoryFormat::Absolute, _) => 5,   // 10.0G / 999M
         (MemoryFormat::Both, _) => 10,      // 10.0/16.0G

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -207,7 +207,7 @@ impl Drop for MemoryWidget {
 /// Format memory usage according to the selected format.
 fn format_memory(snapshot: &SystemSnapshot, format: &MemoryFormat, is_vertical: bool) -> String {
     if is_vertical {
-        return format_vertical_metric(snapshot.memory_percent as f64, '%');
+        return format_vertical_metric(snapshot.memory_percent, '%');
     }
 
     match format {

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -21,7 +21,7 @@ use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, widget};
 use crate::widgets::base::BaseWidget;
 use crate::widgets::system_popover::SystemPopoverBinding;
-use crate::widgets::{WidgetConfig, warn_unknown_options};
+use crate::widgets::{WidgetConfig, format_vertical_metric, warn_unknown_options};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
@@ -191,10 +191,10 @@ fn memory_label_width(format: &MemoryFormat, stable_width: bool, is_vertical: bo
     }
 
     Some(match (format, is_vertical) {
-        (_, true) => 2, // vertical mode always renders percentage without %
+        (_, true) => 3,                     // vertical mode always renders percentage
         (MemoryFormat::Percentage, _) => 3, // 99%
-        (MemoryFormat::Absolute, _) => 5, // 10.0G / 999M
-        (MemoryFormat::Both, _) => 10, // 10.0/16.0G
+        (MemoryFormat::Absolute, _) => 5,   // 10.0G / 999M
+        (MemoryFormat::Both, _) => 10,      // 10.0/16.0G
     })
 }
 
@@ -207,7 +207,7 @@ impl Drop for MemoryWidget {
 /// Format memory usage according to the selected format.
 fn format_memory(snapshot: &SystemSnapshot, format: &MemoryFormat, is_vertical: bool) -> String {
     if is_vertical {
-        return format!("{:.0}", snapshot.memory_percent);
+        return format_vertical_metric(snapshot.memory_percent as f64, '%');
     }
 
     match format {
@@ -341,13 +341,22 @@ mod tests {
         );
         assert_eq!(
             format_memory(&snapshot, &MemoryFormat::Percentage, true),
-            "76"
+            "76%"
         );
         assert_eq!(
             format_memory(&snapshot, &MemoryFormat::Absolute, true),
-            "76"
+            "76%"
         );
-        assert_eq!(format_memory(&snapshot, &MemoryFormat::Both, true), "76");
+        assert_eq!(format_memory(&snapshot, &MemoryFormat::Both, true), "76%");
+
+        let boundary = SystemSnapshot {
+            memory_percent: 100.0,
+            ..snapshot
+        };
+        assert_eq!(
+            format_memory(&boundary, &MemoryFormat::Percentage, true),
+            "100"
+        );
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -123,7 +123,7 @@ pub(crate) fn popover_kind_for(widget_name: &str) -> PopoverKind {
 
 /// Format a rounded vertical metric without exceeding the three-character
 /// width budget solely to show its unit.
-pub(crate) fn format_vertical_metric(value: f64, unit: char) -> String {
+pub(crate) fn format_vertical_metric(value: f32, unit: char) -> String {
     let value = format!("{value:.0}");
     if value.chars().count() < 3 {
         format!("{value}{unit}")
@@ -339,7 +339,7 @@ impl WidgetFactory {
                 Some(BuiltWidget::new(root, memory).with_edge_interaction(edge_interaction))
             }
             "gpu" => {
-                if !GpuService::global().snapshot().available {
+                if !GpuService::global().snapshot().available() {
                     debug!("Skipping gpu widget: no supported GPU detected");
                     return None;
                 }
@@ -430,7 +430,7 @@ impl WidgetFactory {
                 Some(BuiltWidget::new(root, memory))
             }
             "gpu" => {
-                if !GpuService::global().snapshot().available {
+                if !GpuService::global().snapshot().available() {
                     debug!("Skipping gpu widget: no supported GPU detected");
                     return None;
                 }

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -21,6 +21,8 @@ mod clock;
 mod cpu;
 mod custom;
 mod gpu;
+mod gpu_format;
+mod history_graph;
 mod keyboard_layout;
 pub mod layer_shell_popover;
 mod mango_layout;
@@ -121,11 +123,13 @@ pub(crate) fn popover_kind_for(widget_name: &str) -> PopoverKind {
     }
 }
 
+pub(crate) const VERTICAL_METRIC_CHARS: i32 = 3;
+
 /// Format a rounded vertical metric without exceeding the three-character
 /// width budget solely to show its unit.
 pub(crate) fn format_vertical_metric(value: f32, unit: char) -> String {
     let value = format!("{value:.0}");
-    if value.chars().count() < 3 {
+    if value.chars().count() < VERTICAL_METRIC_CHARS as usize {
         format!("{value}{unit}")
     } else {
         value

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -121,6 +121,17 @@ pub(crate) fn popover_kind_for(widget_name: &str) -> PopoverKind {
     }
 }
 
+/// Format a rounded vertical metric without exceeding the three-character
+/// width budget solely to show its unit.
+pub(crate) fn format_vertical_metric(value: f64, unit: char) -> String {
+    let value = format!("{value:.0}");
+    if value.chars().count() < 3 {
+        format!("{value}{unit}")
+    } else {
+        value
+    }
+}
+
 use crate::services::battery::BatteryService;
 use crate::services::gpu::GpuService;
 
@@ -537,5 +548,14 @@ mod tests {
         assert_eq!(popover_kind_for("battery"), PopoverKind::Unmergeable);
         assert_eq!(popover_kind_for("media"), PopoverKind::Unmergeable);
         assert_eq!(popover_kind_for("unknown"), PopoverKind::Unmergeable);
+    }
+
+    #[test]
+    fn vertical_metric_drops_unit_when_it_would_exceed_three_chars() {
+        assert_eq!(format_vertical_metric(4.0, '%'), "4%");
+        assert_eq!(format_vertical_metric(76.0, '%'), "76%");
+        assert_eq!(format_vertical_metric(100.0, '%'), "100");
+        assert_eq!(format_vertical_metric(41.0, '°'), "41°");
+        assert_eq!(format_vertical_metric(100.0, '°'), "100");
     }
 }

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -10,8 +10,11 @@
 //! │ │  CPU      │ │  Memory   │ │
 //! │ └───────────┘ └───────────┘ │
 //! ├─────────────────────────────┤
-//! │ ┌───────────────────────────┤  (conditional: only if GPU detected)
-//! │ │  GPU                      │
+//! │ ┌───────────┐ ┌───────────┐ │  (conditional: GPU cards, max 2 per row)
+//! │ │  GPU 1    │ │  GPU 2    │ │
+//! │ └───────────┘ └───────────┘ │
+//! │ ┌───────────────────────────┤  (odd last GPU spans full width)
+//! │ │  GPU 3                    │
 //! │ └───────────────────────────┤
 //! ├─────────────────────────────┤
 //! │ ┌───────────┐ ┌───────────┐ │
@@ -25,6 +28,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Label, Orientation, ProgressBar, Revealer, RevealerTransitionType, Widget,
@@ -32,16 +36,30 @@ use gtk4::{
 
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
-use crate::services::gpu::{GpuService, GpuSnapshot};
+use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::{IconHandle, IconsService};
-use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long, format_speed};
+use crate::services::system::{
+    SystemService, SystemSnapshot, format_bytes, format_bytes_long, format_speed,
+};
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
+
+const GPU_TITLE_MAX_CHARS: i32 = 12;
+const GPU_DETAIL_MAX_CHARS: i32 = 22;
 
 /// A single pre-allocated per-core row with its updatable widgets.
 #[derive(Clone)]
 struct CoreRow {
     bar: ProgressBar,
     pct_label: Label,
+}
+
+#[derive(Clone)]
+struct GpuCardRow {
+    card: GtkBox,
+    title_label: Label,
+    usage_label: Label,
+    usage_progress: ProgressBar,
+    detail_label: Label,
 }
 
 /// Controller owning the system popover UI elements and update logic.
@@ -72,14 +90,9 @@ pub struct SystemPopoverController {
     load_5_label: Label,
     load_15_label: Label,
 
-    // GPU section (conditional: only present when GPU is detected)
-    gpu_card: GtkBox,
-    gpu_metrics_label: Label,
-    gpu_usage_label: Label,
-    gpu_progress: ProgressBar,
-    gpu_vram_value_label: Label,
-    gpu_vram_progress: ProgressBar,
-    gpu_vram_detail_label: Label,
+    // GPU section (conditional: only present when GPUs are detected)
+    gpu_cards_box: GtkBox,
+    gpu_card_rows: Rc<RefCell<Vec<GpuCardRow>>>,
 }
 
 impl SystemPopoverController {
@@ -129,53 +142,51 @@ impl SystemPopoverController {
 
     /// Update the GPU card from the latest GPU snapshot.
     pub fn update_from_gpu_snapshot(&self, snapshot: &GpuSnapshot) {
-        if !snapshot.available {
-            self.gpu_card.set_visible(false);
+        let devices = snapshot.devices_for_display();
+        if devices.is_empty() {
+            self.gpu_cards_box.set_visible(false);
             return;
         }
-        self.gpu_card.set_visible(true);
+        self.gpu_cards_box.set_visible(true);
+        self.sync_gpu_card_rows(devices.len());
 
-        if let Some(usage) = snapshot.gpu_usage {
-            self.gpu_usage_label.set_label(&format!("{:.1}%", usage));
-            self.gpu_progress.set_fraction(usage as f64 / 100.0);
-        } else {
-            self.gpu_usage_label.set_label("--");
-            self.gpu_progress.set_fraction(0.0);
+        let rows = self.gpu_card_rows.borrow();
+        for (index, (row, device)) in rows.iter().zip(devices.iter()).enumerate() {
+            update_gpu_card_row(row, index, device);
         }
+    }
 
-        // Clock + power + temperature on metrics row
-        let mut metrics_parts = Vec::new();
-        if let Some(mhz) = snapshot.clock_mhz {
-            metrics_parts.push(format!("{} MHz", mhz));
-        }
-        if let Some(watts) = snapshot.power_watts {
-            metrics_parts.push(format!("{:.1} W", watts));
-        }
-        if let Some(temp) = snapshot.temperature {
-            metrics_parts.push(format!("{:.0}°C", temp));
-        }
-        let metrics_text = metrics_parts.join(" \u{00B7} ");
-        self.gpu_metrics_label.set_label(&metrics_text);
-        self.gpu_metrics_label.set_visible(!metrics_text.is_empty());
-
-        // VRAM bar + detail
-        let vram_pct = snapshot.vram_percent();
-        if let Some(pct) = vram_pct {
-            self.gpu_vram_value_label.set_label(&format!("{:.1}%", pct));
-            self.gpu_vram_progress.set_fraction(pct as f64 / 100.0);
-        } else {
-            self.gpu_vram_value_label.set_label("--");
-            self.gpu_vram_progress.set_fraction(0.0);
+    fn sync_gpu_card_rows(&self, count: usize) {
+        let mut rows = self.gpu_card_rows.borrow_mut();
+        if rows.len() == count {
+            return;
         }
 
-        let vram_detail = match (snapshot.vram_used, snapshot.vram_total) {
-            (Some(used), Some(total)) => {
-                format!("{} / {}", format_bytes_long(used), format_bytes_long(total))
+        while let Some(child) = self.gpu_cards_box.first_child() {
+            self.gpu_cards_box.remove(&child);
+        }
+        rows.clear();
+
+        for _ in 0..count {
+            let row = build_gpu_card_row();
+            rows.push(row);
+        }
+
+        let mut next_card = 0;
+        for cards_in_row in gpu_cards_per_row(count) {
+            let row_container = GtkBox::new(Orientation::Horizontal, 8);
+            row_container.set_homogeneous(cards_in_row == 2);
+            row_container.set_hexpand(true);
+
+            for _ in 0..cards_in_row {
+                let card = &rows[next_card].card;
+                card.set_hexpand(true);
+                row_container.append(card);
+                next_card += 1;
             }
-            (Some(used), None) => format!("{} used", format_bytes_long(used)),
-            _ => "--".to_string(),
-        };
-        self.gpu_vram_detail_label.set_label(&vram_detail);
+
+            self.gpu_cards_box.append(&row_container);
+        }
     }
 
     /// Toggle the cores expander visibility.
@@ -297,6 +308,137 @@ fn stat_row(label_text: &str, value_width_chars: i32) -> (GtkBox, Label) {
     (row, value)
 }
 
+fn build_gpu_card_row() -> GpuCardRow {
+    let icons = IconsService::global();
+
+    let card = GtkBox::new(Orientation::Vertical, 0);
+    card.add_css_class(card::BASE);
+    card.add_css_class(sp::SECTION_CARD);
+    card.add_css_class(sp::GPU_CARD);
+    card.set_hexpand(true);
+
+    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
+
+    let gpu_title_row = GtkBox::new(Orientation::Horizontal, 6);
+    gpu_title_row.add_css_class(sp::SECTION_TITLE);
+    gpu_title_row.add_css_class(sp::GPU_TITLE);
+
+    let gpu_icon = icons.create_icon("video-display-symbolic", &[icon::TEXT, sp::SECTION_ICON]);
+    gpu_title_row.append(&gpu_icon.widget());
+
+    let title_label = Label::new(Some("GPU"));
+    title_label.add_css_class(surface::POPOVER_TITLE);
+    title_label.set_xalign(0.0);
+    title_label.set_hexpand(true);
+    title_label.set_ellipsize(EllipsizeMode::End);
+    title_label.set_single_line_mode(true);
+    title_label.set_max_width_chars(GPU_TITLE_MAX_CHARS);
+    gpu_title_row.append(&title_label);
+
+    gpu_section.append(&gpu_title_row);
+
+    let (gpu_usage_row, usage_label) = stat_row("Usage", 6);
+    gpu_section.append(&gpu_usage_row);
+
+    let usage_progress = ProgressBar::new();
+    usage_progress.add_css_class(sp::PROGRESS_BAR);
+    gpu_section.append(&usage_progress);
+
+    let detail_label = Label::new(Some("--"));
+    detail_label.add_css_class(color::MUTED);
+    detail_label.set_halign(Align::Start);
+    detail_label.set_xalign(0.0);
+    detail_label.set_ellipsize(EllipsizeMode::End);
+    detail_label.set_single_line_mode(true);
+    detail_label.set_max_width_chars(GPU_DETAIL_MAX_CHARS);
+    gpu_section.append(&detail_label);
+
+    card.append(&gpu_section);
+
+    GpuCardRow {
+        card,
+        title_label,
+        usage_label,
+        usage_progress,
+        detail_label,
+    }
+}
+
+fn update_gpu_card_row(row: &GpuCardRow, index: usize, snapshot: &GpuDeviceSnapshot) {
+    row.title_label
+        .set_label(&format_gpu_card_title(index, snapshot));
+
+    if snapshot.power_state == GpuPowerState::Suspended {
+        row.usage_label.set_label("Idle");
+        row.usage_progress.set_fraction(0.0);
+    } else if let Some(usage) = snapshot.gpu_usage {
+        row.usage_label.set_label(&format!("{:.1}%", usage));
+        row.usage_progress.set_fraction(usage as f64 / 100.0);
+    } else {
+        row.usage_label.set_label("--");
+        row.usage_progress.set_fraction(0.0);
+    }
+
+    row.detail_label
+        .set_label(&format_gpu_card_detail(snapshot));
+}
+
+fn format_gpu_card_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+    snapshot
+        .device_name
+        .as_ref()
+        .filter(|name| !name.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| format!("GPU {}", index + 1))
+}
+
+fn format_gpu_card_detail(snapshot: &GpuDeviceSnapshot) -> String {
+    let mut parts = Vec::new();
+
+    match (snapshot.vram_used, snapshot.vram_total) {
+        (Some(used), Some(total)) => {
+            parts.push(format!("{} / {}", format_bytes(used), format_bytes(total)))
+        }
+        (Some(used), None) => parts.push(format!("{} used", format_bytes(used))),
+        _ => {}
+    }
+
+    if let Some(temp) = snapshot.temperature {
+        parts.push(format!("{:.0}°C", temp));
+    }
+
+    if let Some(watts) = snapshot.power_watts {
+        parts.push(format!("{:.0}W", watts));
+    }
+
+    if parts.is_empty() {
+        if let Some(mhz) = snapshot.clock_mhz {
+            parts.push(format!("{}MHz", mhz));
+        } else if let Some(name) = snapshot.device_name.as_ref() {
+            parts.push(name.clone());
+        } else if snapshot.power_state == GpuPowerState::Suspended {
+            parts.push("Suspended".to_string());
+        } else {
+            parts.push("--".to_string());
+        }
+    }
+
+    parts.join(" · ")
+}
+
+fn gpu_cards_per_row(count: usize) -> Vec<usize> {
+    let mut rows = Vec::new();
+    let mut remaining = count;
+
+    while remaining > 0 {
+        let cards_in_row = if remaining == 1 { 1 } else { 2 };
+        rows.push(cards_in_row);
+        remaining = remaining.saturating_sub(cards_in_row);
+    }
+
+    rows
+}
+
 /// Build a system resource popover content widget.
 pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverController) {
     let system_service = SystemService::global();
@@ -382,61 +524,13 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
     cores_revealer.set_child(Some(&cpu_cores_box));
     container.append(&cores_revealer);
 
-    // GPU section (full-width card, conditionally visible)
+    // GPU section (one full-width card per detected GPU)
     let gpu_service = GpuService::global();
-    let gpu_available = gpu_service.snapshot().available;
-
-    let gpu_card = GtkBox::new(Orientation::Vertical, 0);
-    gpu_card.add_css_class(card::BASE);
-    gpu_card.add_css_class(sp::SECTION_CARD);
-    gpu_card.add_css_class(sp::GPU_CARD);
-    gpu_card.set_margin_top(8);
-    gpu_card.set_visible(gpu_available);
-
-    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
-
-    // Row 1: [icon] GPU  <clock · power · temp>
-    let gpu_title_row = GtkBox::new(Orientation::Horizontal, 6);
-    gpu_title_row.add_css_class(sp::SECTION_TITLE);
-    gpu_title_row.add_css_class(sp::GPU_TITLE);
-
-    let gpu_icon = icons.create_icon("video-display-symbolic", &[icon::TEXT, sp::SECTION_ICON]);
-    gpu_title_row.append(&gpu_icon.widget());
-
-    let gpu_label = Label::new(Some("GPU"));
-    gpu_label.add_css_class(surface::POPOVER_TITLE);
-    gpu_title_row.append(&gpu_label);
-
-    let gpu_metrics_label = Label::new(None);
-    gpu_metrics_label.add_css_class(color::MUTED);
-    gpu_metrics_label.add_css_class(sp::GPU_METRICS);
-    gpu_metrics_label.set_hexpand(true);
-    gpu_metrics_label.set_halign(Align::End);
-    gpu_title_row.append(&gpu_metrics_label);
-
-    gpu_section.append(&gpu_title_row);
-
-    let (gpu_usage_row, gpu_usage_label) = stat_row("Usage", 6);
-    gpu_section.append(&gpu_usage_row);
-
-    let gpu_progress = ProgressBar::new();
-    gpu_progress.add_css_class(sp::PROGRESS_BAR);
-    gpu_section.append(&gpu_progress);
-
-    let (gpu_vram_row, gpu_vram_value_label) = stat_row("VRAM", 6);
-    gpu_section.append(&gpu_vram_row);
-
-    let gpu_vram_progress = ProgressBar::new();
-    gpu_vram_progress.add_css_class(sp::PROGRESS_BAR);
-    gpu_section.append(&gpu_vram_progress);
-
-    let gpu_vram_detail_label = Label::new(Some("-- / --"));
-    gpu_vram_detail_label.add_css_class(color::MUTED);
-    gpu_vram_detail_label.set_halign(Align::Start);
-    gpu_section.append(&gpu_vram_detail_label);
-
-    gpu_card.append(&gpu_section);
-    container.append(&gpu_card);
+    let gpu_snapshot = gpu_service.snapshot();
+    let gpu_cards_box = GtkBox::new(Orientation::Vertical, 8);
+    gpu_cards_box.set_margin_top(8);
+    gpu_cards_box.set_visible(!gpu_snapshot.devices_for_display().is_empty());
+    container.append(&gpu_cards_box);
 
     let bottom_row = GtkBox::new(Orientation::Horizontal, 8);
     bottom_row.set_homogeneous(true);
@@ -570,13 +664,8 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
         load_1_label,
         load_5_label,
         load_15_label,
-        gpu_card,
-        gpu_metrics_label,
-        gpu_usage_label,
-        gpu_progress,
-        gpu_vram_value_label,
-        gpu_vram_progress,
-        gpu_vram_detail_label,
+        gpu_cards_box,
+        gpu_card_rows: Rc::new(RefCell::new(Vec::new())),
     };
 
     let controller_clone = controller.clone();
@@ -586,10 +675,76 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
 
     controller.update_from_snapshot(&snapshot);
 
-    let gpu_snapshot = gpu_service.snapshot();
     controller.update_from_gpu_snapshot(&gpu_snapshot);
 
     (container.upcast::<Widget>(), controller)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_gpu_card_detail, format_gpu_card_title, gpu_cards_per_row};
+    use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState};
+
+    #[test]
+    fn test_gpu_cards_per_row_even() {
+        assert_eq!(gpu_cards_per_row(0), Vec::<usize>::new());
+        assert_eq!(gpu_cards_per_row(2), vec![2]);
+        assert_eq!(gpu_cards_per_row(4), vec![2, 2]);
+    }
+
+    #[test]
+    fn test_gpu_cards_per_row_odd() {
+        assert_eq!(gpu_cards_per_row(1), vec![1]);
+        assert_eq!(gpu_cards_per_row(3), vec![2, 1]);
+        assert_eq!(gpu_cards_per_row(5), vec![2, 2, 1]);
+    }
+
+    #[test]
+    fn test_format_gpu_card_detail_prefers_compact_stats() {
+        let snapshot = GpuDeviceSnapshot {
+            vram_used: Some(4 * 1024 * 1024 * 1024),
+            vram_total: Some(8 * 1024 * 1024 * 1024),
+            temperature: Some(62.0),
+            power_watts: Some(118.6),
+            device_name: Some("Very Long GPU Name".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_gpu_card_detail(&snapshot),
+            "4.0G / 8.0G · 62°C · 119W"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_card_detail_falls_back_when_stats_missing() {
+        let snapshot = GpuDeviceSnapshot {
+            power_state: GpuPowerState::Suspended,
+            ..Default::default()
+        };
+
+        assert_eq!(format_gpu_card_detail(&snapshot), "Suspended");
+    }
+
+    #[test]
+    fn test_format_gpu_card_title_prefers_device_name() {
+        let snapshot = GpuDeviceSnapshot {
+            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_gpu_card_title(0, &snapshot),
+            "NVIDIA GeForce RTX 4090"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_card_title_falls_back_to_index() {
+        let snapshot = GpuDeviceSnapshot::default();
+
+        assert_eq!(format_gpu_card_title(1, &snapshot), "GPU 2");
+    }
 }
 
 /// A binding that manages the system popover lifecycle for bar widgets.

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -10,11 +10,10 @@
 //! │ │  CPU      │ │  Memory   │ │
 //! │ └───────────┘ └───────────┘ │
 //! ├─────────────────────────────┤
-//! │ ┌───────────┐ ┌───────────┐ │  (conditional: GPU cards, max 2 per row)
-//! │ │  GPU 1    │ │  GPU 2    │ │
-//! │ └───────────┘ └───────────┘ │
-//! │ ┌───────────────────────────┤  (odd last GPU spans full width)
-//! │ │  GPU 3                    │
+//! │ ┌───────────────────────────┤  (conditional: all GPUs in one card)
+//! │ │  GPU                      │
+//! │ │  GPU 1              76%  │
+//! │ │  GPU 2              41%  │
 //! │ └───────────────────────────┤
 //! ├─────────────────────────────┤
 //! │ ┌───────────┐ ┌───────────┐ │
@@ -44,8 +43,9 @@ use crate::services::system::{
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
 use crate::widgets::layer_shell_popover::animate_reveal;
 
-const GPU_TITLE_MAX_CHARS: i32 = 12;
-const GPU_DETAIL_MAX_CHARS: i32 = 22;
+const GPU_TITLE_MAX_CHARS: i32 = 34;
+const GPU_VRAM_MAX_CHARS: i32 = 18;
+const GPU_METRICS_MAX_CHARS: i32 = 24;
 
 /// A single pre-allocated per-core row with its updatable widgets.
 #[derive(Clone)]
@@ -55,12 +55,13 @@ struct CoreRow {
 }
 
 #[derive(Clone)]
-struct GpuCardRow {
-    card: GtkBox,
+struct GpuDeviceRow {
+    container: GtkBox,
     title_label: Label,
     usage_label: Label,
     usage_progress: ProgressBar,
-    detail_label: Label,
+    vram_detail_label: Label,
+    metrics_label: Label,
 }
 
 /// Controller owning the system popover UI elements and update logic.
@@ -92,8 +93,9 @@ pub struct SystemPopoverController {
     load_15_label: Label,
 
     // GPU section (conditional: only present when GPUs are detected)
-    gpu_cards_box: GtkBox,
-    gpu_card_rows: Rc<RefCell<Vec<GpuCardRow>>>,
+    gpu_card: GtkBox,
+    gpu_devices_box: GtkBox,
+    gpu_device_rows: Rc<RefCell<Vec<GpuDeviceRow>>>,
 }
 
 impl SystemPopoverController {
@@ -145,48 +147,33 @@ impl SystemPopoverController {
     pub fn update_from_gpu_snapshot(&self, snapshot: &GpuSnapshot) {
         let devices = snapshot.devices_for_display();
         if devices.is_empty() {
-            self.gpu_cards_box.set_visible(false);
+            self.gpu_card.set_visible(false);
             return;
         }
-        self.gpu_cards_box.set_visible(true);
-        self.sync_gpu_card_rows(devices.len());
+        self.gpu_card.set_visible(true);
+        self.sync_gpu_device_rows(devices.len());
 
-        let rows = self.gpu_card_rows.borrow();
+        let rows = self.gpu_device_rows.borrow();
         for (index, (row, device)) in rows.iter().zip(devices.iter()).enumerate() {
-            update_gpu_card_row(row, index, device);
+            update_gpu_device_row(row, index, device);
         }
     }
 
-    fn sync_gpu_card_rows(&self, count: usize) {
-        let mut rows = self.gpu_card_rows.borrow_mut();
+    fn sync_gpu_device_rows(&self, count: usize) {
+        let mut rows = self.gpu_device_rows.borrow_mut();
         if rows.len() == count {
             return;
         }
 
-        while let Some(child) = self.gpu_cards_box.first_child() {
-            self.gpu_cards_box.remove(&child);
+        while let Some(child) = self.gpu_devices_box.first_child() {
+            self.gpu_devices_box.remove(&child);
         }
         rows.clear();
 
         for _ in 0..count {
-            let row = build_gpu_card_row();
+            let row = build_gpu_device_row();
+            self.gpu_devices_box.append(&row.container);
             rows.push(row);
-        }
-
-        let mut next_card = 0;
-        for cards_in_row in gpu_cards_per_row(count) {
-            let row_container = GtkBox::new(Orientation::Horizontal, 8);
-            row_container.set_homogeneous(cards_in_row == 2);
-            row_container.set_hexpand(true);
-
-            for _ in 0..cards_in_row {
-                let card = &rows[next_card].card;
-                card.set_hexpand(true);
-                row_container.append(card);
-                next_card += 1;
-            }
-
-            self.gpu_cards_box.append(&row_container);
         }
     }
 
@@ -309,65 +296,66 @@ fn stat_row(label_text: &str, value_width_chars: i32) -> (GtkBox, Label) {
     (row, value)
 }
 
-fn build_gpu_card_row() -> GpuCardRow {
-    let icons = IconsService::global();
-
-    let card = GtkBox::new(Orientation::Vertical, 0);
-    card.add_css_class(card::BASE);
-    card.add_css_class(sp::SECTION_CARD);
-    card.add_css_class(sp::GPU_CARD);
-    card.set_hexpand(true);
-
-    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
-
-    let gpu_title_row = GtkBox::new(Orientation::Horizontal, 6);
-    gpu_title_row.add_css_class(sp::SECTION_TITLE);
-    gpu_title_row.add_css_class(sp::GPU_TITLE);
-
-    let gpu_icon = icons.create_icon("video-display-symbolic", &[icon::TEXT, sp::SECTION_ICON]);
-    gpu_title_row.append(&gpu_icon.widget());
+fn build_gpu_device_row() -> GpuDeviceRow {
+    let container = GtkBox::new(Orientation::Vertical, 6);
+    let summary_row = GtkBox::new(Orientation::Horizontal, 8);
 
     let title_label = Label::new(Some("GPU"));
-    title_label.add_css_class(surface::POPOVER_TITLE);
+    title_label.set_halign(Align::Start);
     title_label.set_xalign(0.0);
     title_label.set_hexpand(true);
     title_label.set_ellipsize(EllipsizeMode::End);
     title_label.set_single_line_mode(true);
     title_label.set_max_width_chars(GPU_TITLE_MAX_CHARS);
-    gpu_title_row.append(&title_label);
+    summary_row.append(&title_label);
 
-    gpu_section.append(&gpu_title_row);
-
-    let (gpu_usage_row, usage_label) = stat_row("Usage", 6);
-    gpu_section.append(&gpu_usage_row);
+    let usage_label = Label::new(Some("--"));
+    usage_label.set_halign(Align::End);
+    usage_label.set_width_chars(6);
+    usage_label.set_xalign(1.0);
+    summary_row.append(&usage_label);
+    container.append(&summary_row);
 
     let usage_progress = ProgressBar::new();
     usage_progress.add_css_class(sp::PROGRESS_BAR);
-    gpu_section.append(&usage_progress);
+    container.append(&usage_progress);
 
-    let detail_label = Label::new(Some("--"));
-    detail_label.add_css_class(color::MUTED);
-    detail_label.set_halign(Align::Start);
-    detail_label.set_xalign(0.0);
-    detail_label.set_ellipsize(EllipsizeMode::End);
-    detail_label.set_single_line_mode(true);
-    detail_label.set_max_width_chars(GPU_DETAIL_MAX_CHARS);
-    gpu_section.append(&detail_label);
+    let detail_row = GtkBox::new(Orientation::Horizontal, 8);
 
-    card.append(&gpu_section);
+    let vram_detail_label = Label::new(Some("--"));
+    vram_detail_label.add_css_class(color::MUTED);
+    vram_detail_label.set_halign(Align::Start);
+    vram_detail_label.set_xalign(0.0);
+    vram_detail_label.set_ellipsize(EllipsizeMode::End);
+    vram_detail_label.set_single_line_mode(true);
+    vram_detail_label.set_hexpand(true);
+    vram_detail_label.set_max_width_chars(GPU_VRAM_MAX_CHARS);
+    detail_row.append(&vram_detail_label);
 
-    GpuCardRow {
-        card,
+    let metrics_label = Label::new(None);
+    metrics_label.add_css_class(color::MUTED);
+    metrics_label.set_halign(Align::End);
+    metrics_label.set_xalign(1.0);
+    metrics_label.set_ellipsize(EllipsizeMode::End);
+    metrics_label.set_single_line_mode(true);
+    metrics_label.set_max_width_chars(GPU_METRICS_MAX_CHARS);
+    detail_row.append(&metrics_label);
+
+    container.append(&detail_row);
+
+    GpuDeviceRow {
+        container,
         title_label,
         usage_label,
         usage_progress,
-        detail_label,
+        vram_detail_label,
+        metrics_label,
     }
 }
 
-fn update_gpu_card_row(row: &GpuCardRow, index: usize, snapshot: &GpuDeviceSnapshot) {
+fn update_gpu_device_row(row: &GpuDeviceRow, index: usize, snapshot: &GpuDeviceSnapshot) {
     row.title_label
-        .set_label(&format_gpu_card_title(index, snapshot));
+        .set_label(&format_gpu_device_title(index, snapshot));
 
     if snapshot.power_state == GpuPowerState::Suspended {
         row.usage_label.set_label("Idle");
@@ -380,11 +368,14 @@ fn update_gpu_card_row(row: &GpuCardRow, index: usize, snapshot: &GpuDeviceSnaps
         row.usage_progress.set_fraction(0.0);
     }
 
-    row.detail_label
-        .set_label(&format_gpu_card_detail(snapshot));
+    row.vram_detail_label
+        .set_label(&format_gpu_device_vram(snapshot));
+    let metrics = format_gpu_device_metrics(snapshot);
+    row.metrics_label.set_label(&metrics);
+    row.metrics_label.set_visible(!metrics.is_empty());
 }
 
-fn format_gpu_card_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+fn format_gpu_device_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
     snapshot
         .device_name
         .as_ref()
@@ -393,16 +384,19 @@ fn format_gpu_card_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
         .unwrap_or_else(|| format!("GPU {}", index + 1))
 }
 
-fn format_gpu_card_detail(snapshot: &GpuDeviceSnapshot) -> String {
-    let mut parts = Vec::new();
-
+fn format_gpu_device_vram(snapshot: &GpuDeviceSnapshot) -> String {
     match (snapshot.vram_used, snapshot.vram_total) {
         (Some(used), Some(total)) => {
-            parts.push(format!("{} / {}", format_bytes(used), format_bytes(total)))
+            format!("{} / {}", format_bytes(used), format_bytes(total))
         }
-        (Some(used), None) => parts.push(format!("{} used", format_bytes(used))),
-        _ => {}
+        (Some(used), None) => format!("{} used", format_bytes(used)),
+        _ if snapshot.power_state == GpuPowerState::Suspended => "Suspended".to_string(),
+        _ => "--".to_string(),
     }
+}
+
+fn format_gpu_device_metrics(snapshot: &GpuDeviceSnapshot) -> String {
+    let mut parts = Vec::new();
 
     if let Some(temp) = snapshot.temperature {
         parts.push(format!("{:.0}°C", temp));
@@ -412,32 +406,11 @@ fn format_gpu_card_detail(snapshot: &GpuDeviceSnapshot) -> String {
         parts.push(format!("{:.0}W", watts));
     }
 
-    if parts.is_empty() {
-        if let Some(mhz) = snapshot.clock_mhz {
-            parts.push(format!("{}MHz", mhz));
-        } else if let Some(name) = snapshot.device_name.as_ref() {
-            parts.push(name.clone());
-        } else if snapshot.power_state == GpuPowerState::Suspended {
-            parts.push("Suspended".to_string());
-        } else {
-            parts.push("--".to_string());
-        }
+    if let Some(mhz) = snapshot.clock_mhz {
+        parts.push(format!("{}MHz", mhz));
     }
 
     parts.join(" · ")
-}
-
-fn gpu_cards_per_row(count: usize) -> Vec<usize> {
-    let mut rows = Vec::new();
-    let mut remaining = count;
-
-    while remaining > 0 {
-        let cards_in_row = if remaining == 1 { 1 } else { 2 };
-        rows.push(cards_in_row);
-        remaining = remaining.saturating_sub(cards_in_row);
-    }
-
-    rows
 }
 
 /// Build a system resource popover content widget.
@@ -525,13 +498,26 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
     cores_revealer.set_child(Some(&cpu_cores_box));
     container.append(&cores_revealer);
 
-    // GPU section (one full-width card per detected GPU)
+    // GPU section (all detected GPUs in one full-width card)
     let gpu_service = GpuService::global();
     let gpu_snapshot = gpu_service.snapshot();
-    let gpu_cards_box = GtkBox::new(Orientation::Vertical, 8);
-    gpu_cards_box.set_margin_top(8);
-    gpu_cards_box.set_visible(!gpu_snapshot.devices_for_display().is_empty());
-    container.append(&gpu_cards_box);
+
+    let gpu_card = GtkBox::new(Orientation::Vertical, 0);
+    gpu_card.add_css_class(card::BASE);
+    gpu_card.add_css_class(sp::SECTION_CARD);
+    gpu_card.add_css_class(sp::GPU_CARD);
+    gpu_card.set_margin_top(8);
+    gpu_card.set_visible(!gpu_snapshot.devices_for_display().is_empty());
+
+    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
+    let gpu_title = section_title("video-display-symbolic", "GPU", &icons);
+    gpu_title.add_css_class(sp::GPU_TITLE);
+    gpu_section.append(&gpu_title);
+
+    let gpu_devices_box = GtkBox::new(Orientation::Vertical, 14);
+    gpu_section.append(&gpu_devices_box);
+    gpu_card.append(&gpu_section);
+    container.append(&gpu_card);
 
     let bottom_row = GtkBox::new(Orientation::Horizontal, 8);
     bottom_row.set_homogeneous(true);
@@ -665,8 +651,9 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
         load_1_label,
         load_5_label,
         load_15_label,
-        gpu_cards_box,
-        gpu_card_rows: Rc::new(RefCell::new(Vec::new())),
+        gpu_card,
+        gpu_devices_box,
+        gpu_device_rows: Rc::new(RefCell::new(Vec::new())),
     };
 
     let controller_clone = controller.clone();
@@ -683,68 +670,58 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
 
 #[cfg(test)]
 mod tests {
-    use super::{format_gpu_card_detail, format_gpu_card_title, gpu_cards_per_row};
+    use super::{format_gpu_device_metrics, format_gpu_device_title, format_gpu_device_vram};
     use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState};
 
     #[test]
-    fn test_gpu_cards_per_row_even() {
-        assert_eq!(gpu_cards_per_row(0), Vec::<usize>::new());
-        assert_eq!(gpu_cards_per_row(2), vec![2]);
-        assert_eq!(gpu_cards_per_row(4), vec![2, 2]);
-    }
-
-    #[test]
-    fn test_gpu_cards_per_row_odd() {
-        assert_eq!(gpu_cards_per_row(1), vec![1]);
-        assert_eq!(gpu_cards_per_row(3), vec![2, 1]);
-        assert_eq!(gpu_cards_per_row(5), vec![2, 2, 1]);
-    }
-
-    #[test]
-    fn test_format_gpu_card_detail_prefers_compact_stats() {
+    fn test_format_gpu_device_details_group_vram_and_metrics() {
         let snapshot = GpuDeviceSnapshot {
             vram_used: Some(4 * 1024 * 1024 * 1024),
             vram_total: Some(8 * 1024 * 1024 * 1024),
             temperature: Some(62.0),
             power_watts: Some(118.6),
+            clock_mhz: Some(2430),
             device_name: Some("Very Long GPU Name".to_string()),
             ..Default::default()
         };
 
+        assert_eq!(format_gpu_device_vram(&snapshot), "4.0G / 8.0G");
         assert_eq!(
-            format_gpu_card_detail(&snapshot),
-            "4.0G / 8.0G · 62°C · 119W"
+            format_gpu_device_metrics(&snapshot),
+            "62°C · 119W · 2430MHz"
         );
     }
 
     #[test]
-    fn test_format_gpu_card_detail_falls_back_when_stats_missing() {
+    fn test_format_gpu_device_vram_shows_suspended_state_when_missing() {
         let snapshot = GpuDeviceSnapshot {
             power_state: GpuPowerState::Suspended,
+            device_name: Some("Intel Integrated Graphics".to_string()),
             ..Default::default()
         };
 
-        assert_eq!(format_gpu_card_detail(&snapshot), "Suspended");
+        assert_eq!(format_gpu_device_vram(&snapshot), "Suspended");
+        assert_eq!(format_gpu_device_metrics(&snapshot), "");
     }
 
     #[test]
-    fn test_format_gpu_card_title_prefers_device_name() {
+    fn test_format_gpu_device_title_prefers_device_name() {
         let snapshot = GpuDeviceSnapshot {
             device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
             ..Default::default()
         };
 
         assert_eq!(
-            format_gpu_card_title(0, &snapshot),
+            format_gpu_device_title(0, &snapshot),
             "NVIDIA GeForce RTX 4090"
         );
     }
 
     #[test]
-    fn test_format_gpu_card_title_falls_back_to_index() {
+    fn test_format_gpu_device_title_falls_back_to_index() {
         let snapshot = GpuDeviceSnapshot::default();
 
-        assert_eq!(format_gpu_card_title(1, &snapshot), "GPU 2");
+        assert_eq!(format_gpu_device_title(1, &snapshot), "GPU 2");
     }
 }
 

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -10,8 +10,11 @@
 //! │ │  CPU      │ │  Memory   │ │
 //! │ └───────────┘ └───────────┘ │
 //! ├─────────────────────────────┤
-//! │ ┌───────────────────────────┤  (conditional: only if GPU detected)
-//! │ │  GPU                      │
+//! │ ┌───────────┐ ┌───────────┐ │  (conditional: GPU cards, max 2 per row)
+//! │ │  GPU 1    │ │  GPU 2    │ │
+//! │ └───────────┘ └───────────┘ │
+//! │ ┌───────────────────────────┤  (odd last GPU spans full width)
+//! │ │  GPU 3                    │
 //! │ └───────────────────────────┤
 //! ├─────────────────────────────┤
 //! │ ┌───────────┐ ┌───────────┐ │
@@ -25,6 +28,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Label, Orientation, ProgressBar, Revealer, RevealerTransitionType, Widget,
@@ -32,17 +36,31 @@ use gtk4::{
 
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
-use crate::services::gpu::{GpuService, GpuSnapshot};
+use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::{IconHandle, IconsService};
-use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long, format_speed};
+use crate::services::system::{
+    SystemService, SystemSnapshot, format_bytes, format_bytes_long, format_speed,
+};
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
 use crate::widgets::layer_shell_popover::animate_reveal;
+
+const GPU_TITLE_MAX_CHARS: i32 = 12;
+const GPU_DETAIL_MAX_CHARS: i32 = 22;
 
 /// A single pre-allocated per-core row with its updatable widgets.
 #[derive(Clone)]
 struct CoreRow {
     bar: ProgressBar,
     pct_label: Label,
+}
+
+#[derive(Clone)]
+struct GpuCardRow {
+    card: GtkBox,
+    title_label: Label,
+    usage_label: Label,
+    usage_progress: ProgressBar,
+    detail_label: Label,
 }
 
 /// Controller owning the system popover UI elements and update logic.
@@ -73,14 +91,9 @@ pub struct SystemPopoverController {
     load_5_label: Label,
     load_15_label: Label,
 
-    // GPU section (conditional: only present when GPU is detected)
-    gpu_card: GtkBox,
-    gpu_metrics_label: Label,
-    gpu_usage_label: Label,
-    gpu_progress: ProgressBar,
-    gpu_vram_value_label: Label,
-    gpu_vram_progress: ProgressBar,
-    gpu_vram_detail_label: Label,
+    // GPU section (conditional: only present when GPUs are detected)
+    gpu_cards_box: GtkBox,
+    gpu_card_rows: Rc<RefCell<Vec<GpuCardRow>>>,
 }
 
 impl SystemPopoverController {
@@ -130,53 +143,51 @@ impl SystemPopoverController {
 
     /// Update the GPU card from the latest GPU snapshot.
     pub fn update_from_gpu_snapshot(&self, snapshot: &GpuSnapshot) {
-        if !snapshot.available {
-            self.gpu_card.set_visible(false);
+        let devices = snapshot.devices_for_display();
+        if devices.is_empty() {
+            self.gpu_cards_box.set_visible(false);
             return;
         }
-        self.gpu_card.set_visible(true);
+        self.gpu_cards_box.set_visible(true);
+        self.sync_gpu_card_rows(devices.len());
 
-        if let Some(usage) = snapshot.gpu_usage {
-            self.gpu_usage_label.set_label(&format!("{:.1}%", usage));
-            self.gpu_progress.set_fraction(usage as f64 / 100.0);
-        } else {
-            self.gpu_usage_label.set_label("--");
-            self.gpu_progress.set_fraction(0.0);
+        let rows = self.gpu_card_rows.borrow();
+        for (index, (row, device)) in rows.iter().zip(devices.iter()).enumerate() {
+            update_gpu_card_row(row, index, device);
         }
+    }
 
-        // Clock + power + temperature on metrics row
-        let mut metrics_parts = Vec::new();
-        if let Some(mhz) = snapshot.clock_mhz {
-            metrics_parts.push(format!("{} MHz", mhz));
-        }
-        if let Some(watts) = snapshot.power_watts {
-            metrics_parts.push(format!("{:.1} W", watts));
-        }
-        if let Some(temp) = snapshot.temperature {
-            metrics_parts.push(format!("{:.0}°C", temp));
-        }
-        let metrics_text = metrics_parts.join(" \u{00B7} ");
-        self.gpu_metrics_label.set_label(&metrics_text);
-        self.gpu_metrics_label.set_visible(!metrics_text.is_empty());
-
-        // VRAM bar + detail
-        let vram_pct = snapshot.vram_percent();
-        if let Some(pct) = vram_pct {
-            self.gpu_vram_value_label.set_label(&format!("{:.1}%", pct));
-            self.gpu_vram_progress.set_fraction(pct as f64 / 100.0);
-        } else {
-            self.gpu_vram_value_label.set_label("--");
-            self.gpu_vram_progress.set_fraction(0.0);
+    fn sync_gpu_card_rows(&self, count: usize) {
+        let mut rows = self.gpu_card_rows.borrow_mut();
+        if rows.len() == count {
+            return;
         }
 
-        let vram_detail = match (snapshot.vram_used, snapshot.vram_total) {
-            (Some(used), Some(total)) => {
-                format!("{} / {}", format_bytes_long(used), format_bytes_long(total))
+        while let Some(child) = self.gpu_cards_box.first_child() {
+            self.gpu_cards_box.remove(&child);
+        }
+        rows.clear();
+
+        for _ in 0..count {
+            let row = build_gpu_card_row();
+            rows.push(row);
+        }
+
+        let mut next_card = 0;
+        for cards_in_row in gpu_cards_per_row(count) {
+            let row_container = GtkBox::new(Orientation::Horizontal, 8);
+            row_container.set_homogeneous(cards_in_row == 2);
+            row_container.set_hexpand(true);
+
+            for _ in 0..cards_in_row {
+                let card = &rows[next_card].card;
+                card.set_hexpand(true);
+                row_container.append(card);
+                next_card += 1;
             }
-            (Some(used), None) => format!("{} used", format_bytes_long(used)),
-            _ => "--".to_string(),
-        };
-        self.gpu_vram_detail_label.set_label(&vram_detail);
+
+            self.gpu_cards_box.append(&row_container);
+        }
     }
 
     /// Toggle the cores expander visibility.
@@ -298,6 +309,137 @@ fn stat_row(label_text: &str, value_width_chars: i32) -> (GtkBox, Label) {
     (row, value)
 }
 
+fn build_gpu_card_row() -> GpuCardRow {
+    let icons = IconsService::global();
+
+    let card = GtkBox::new(Orientation::Vertical, 0);
+    card.add_css_class(card::BASE);
+    card.add_css_class(sp::SECTION_CARD);
+    card.add_css_class(sp::GPU_CARD);
+    card.set_hexpand(true);
+
+    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
+
+    let gpu_title_row = GtkBox::new(Orientation::Horizontal, 6);
+    gpu_title_row.add_css_class(sp::SECTION_TITLE);
+    gpu_title_row.add_css_class(sp::GPU_TITLE);
+
+    let gpu_icon = icons.create_icon("video-display-symbolic", &[icon::TEXT, sp::SECTION_ICON]);
+    gpu_title_row.append(&gpu_icon.widget());
+
+    let title_label = Label::new(Some("GPU"));
+    title_label.add_css_class(surface::POPOVER_TITLE);
+    title_label.set_xalign(0.0);
+    title_label.set_hexpand(true);
+    title_label.set_ellipsize(EllipsizeMode::End);
+    title_label.set_single_line_mode(true);
+    title_label.set_max_width_chars(GPU_TITLE_MAX_CHARS);
+    gpu_title_row.append(&title_label);
+
+    gpu_section.append(&gpu_title_row);
+
+    let (gpu_usage_row, usage_label) = stat_row("Usage", 6);
+    gpu_section.append(&gpu_usage_row);
+
+    let usage_progress = ProgressBar::new();
+    usage_progress.add_css_class(sp::PROGRESS_BAR);
+    gpu_section.append(&usage_progress);
+
+    let detail_label = Label::new(Some("--"));
+    detail_label.add_css_class(color::MUTED);
+    detail_label.set_halign(Align::Start);
+    detail_label.set_xalign(0.0);
+    detail_label.set_ellipsize(EllipsizeMode::End);
+    detail_label.set_single_line_mode(true);
+    detail_label.set_max_width_chars(GPU_DETAIL_MAX_CHARS);
+    gpu_section.append(&detail_label);
+
+    card.append(&gpu_section);
+
+    GpuCardRow {
+        card,
+        title_label,
+        usage_label,
+        usage_progress,
+        detail_label,
+    }
+}
+
+fn update_gpu_card_row(row: &GpuCardRow, index: usize, snapshot: &GpuDeviceSnapshot) {
+    row.title_label
+        .set_label(&format_gpu_card_title(index, snapshot));
+
+    if snapshot.power_state == GpuPowerState::Suspended {
+        row.usage_label.set_label("Idle");
+        row.usage_progress.set_fraction(0.0);
+    } else if let Some(usage) = snapshot.gpu_usage {
+        row.usage_label.set_label(&format!("{:.1}%", usage));
+        row.usage_progress.set_fraction(usage as f64 / 100.0);
+    } else {
+        row.usage_label.set_label("--");
+        row.usage_progress.set_fraction(0.0);
+    }
+
+    row.detail_label
+        .set_label(&format_gpu_card_detail(snapshot));
+}
+
+fn format_gpu_card_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
+    snapshot
+        .device_name
+        .as_ref()
+        .filter(|name| !name.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| format!("GPU {}", index + 1))
+}
+
+fn format_gpu_card_detail(snapshot: &GpuDeviceSnapshot) -> String {
+    let mut parts = Vec::new();
+
+    match (snapshot.vram_used, snapshot.vram_total) {
+        (Some(used), Some(total)) => {
+            parts.push(format!("{} / {}", format_bytes(used), format_bytes(total)))
+        }
+        (Some(used), None) => parts.push(format!("{} used", format_bytes(used))),
+        _ => {}
+    }
+
+    if let Some(temp) = snapshot.temperature {
+        parts.push(format!("{:.0}°C", temp));
+    }
+
+    if let Some(watts) = snapshot.power_watts {
+        parts.push(format!("{:.0}W", watts));
+    }
+
+    if parts.is_empty() {
+        if let Some(mhz) = snapshot.clock_mhz {
+            parts.push(format!("{}MHz", mhz));
+        } else if let Some(name) = snapshot.device_name.as_ref() {
+            parts.push(name.clone());
+        } else if snapshot.power_state == GpuPowerState::Suspended {
+            parts.push("Suspended".to_string());
+        } else {
+            parts.push("--".to_string());
+        }
+    }
+
+    parts.join(" · ")
+}
+
+fn gpu_cards_per_row(count: usize) -> Vec<usize> {
+    let mut rows = Vec::new();
+    let mut remaining = count;
+
+    while remaining > 0 {
+        let cards_in_row = if remaining == 1 { 1 } else { 2 };
+        rows.push(cards_in_row);
+        remaining = remaining.saturating_sub(cards_in_row);
+    }
+
+    rows
+}
+
 /// Build a system resource popover content widget.
 pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverController) {
     let system_service = SystemService::global();
@@ -383,61 +525,13 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
     cores_revealer.set_child(Some(&cpu_cores_box));
     container.append(&cores_revealer);
 
-    // GPU section (full-width card, conditionally visible)
+    // GPU section (one full-width card per detected GPU)
     let gpu_service = GpuService::global();
-    let gpu_available = gpu_service.snapshot().available;
-
-    let gpu_card = GtkBox::new(Orientation::Vertical, 0);
-    gpu_card.add_css_class(card::BASE);
-    gpu_card.add_css_class(sp::SECTION_CARD);
-    gpu_card.add_css_class(sp::GPU_CARD);
-    gpu_card.set_margin_top(8);
-    gpu_card.set_visible(gpu_available);
-
-    let gpu_section = GtkBox::new(Orientation::Vertical, 8);
-
-    // Row 1: [icon] GPU  <clock · power · temp>
-    let gpu_title_row = GtkBox::new(Orientation::Horizontal, 6);
-    gpu_title_row.add_css_class(sp::SECTION_TITLE);
-    gpu_title_row.add_css_class(sp::GPU_TITLE);
-
-    let gpu_icon = icons.create_icon("video-display-symbolic", &[icon::TEXT, sp::SECTION_ICON]);
-    gpu_title_row.append(&gpu_icon.widget());
-
-    let gpu_label = Label::new(Some("GPU"));
-    gpu_label.add_css_class(surface::POPOVER_TITLE);
-    gpu_title_row.append(&gpu_label);
-
-    let gpu_metrics_label = Label::new(None);
-    gpu_metrics_label.add_css_class(color::MUTED);
-    gpu_metrics_label.add_css_class(sp::GPU_METRICS);
-    gpu_metrics_label.set_hexpand(true);
-    gpu_metrics_label.set_halign(Align::End);
-    gpu_title_row.append(&gpu_metrics_label);
-
-    gpu_section.append(&gpu_title_row);
-
-    let (gpu_usage_row, gpu_usage_label) = stat_row("Usage", 6);
-    gpu_section.append(&gpu_usage_row);
-
-    let gpu_progress = ProgressBar::new();
-    gpu_progress.add_css_class(sp::PROGRESS_BAR);
-    gpu_section.append(&gpu_progress);
-
-    let (gpu_vram_row, gpu_vram_value_label) = stat_row("VRAM", 6);
-    gpu_section.append(&gpu_vram_row);
-
-    let gpu_vram_progress = ProgressBar::new();
-    gpu_vram_progress.add_css_class(sp::PROGRESS_BAR);
-    gpu_section.append(&gpu_vram_progress);
-
-    let gpu_vram_detail_label = Label::new(Some("-- / --"));
-    gpu_vram_detail_label.add_css_class(color::MUTED);
-    gpu_vram_detail_label.set_halign(Align::Start);
-    gpu_section.append(&gpu_vram_detail_label);
-
-    gpu_card.append(&gpu_section);
-    container.append(&gpu_card);
+    let gpu_snapshot = gpu_service.snapshot();
+    let gpu_cards_box = GtkBox::new(Orientation::Vertical, 8);
+    gpu_cards_box.set_margin_top(8);
+    gpu_cards_box.set_visible(!gpu_snapshot.devices_for_display().is_empty());
+    container.append(&gpu_cards_box);
 
     let bottom_row = GtkBox::new(Orientation::Horizontal, 8);
     bottom_row.set_homogeneous(true);
@@ -571,13 +665,8 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
         load_1_label,
         load_5_label,
         load_15_label,
-        gpu_card,
-        gpu_metrics_label,
-        gpu_usage_label,
-        gpu_progress,
-        gpu_vram_value_label,
-        gpu_vram_progress,
-        gpu_vram_detail_label,
+        gpu_cards_box,
+        gpu_card_rows: Rc::new(RefCell::new(Vec::new())),
     };
 
     let controller_clone = controller.clone();
@@ -587,10 +676,76 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
 
     controller.update_from_snapshot(&snapshot);
 
-    let gpu_snapshot = gpu_service.snapshot();
     controller.update_from_gpu_snapshot(&gpu_snapshot);
 
     (container.upcast::<Widget>(), controller)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_gpu_card_detail, format_gpu_card_title, gpu_cards_per_row};
+    use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState};
+
+    #[test]
+    fn test_gpu_cards_per_row_even() {
+        assert_eq!(gpu_cards_per_row(0), Vec::<usize>::new());
+        assert_eq!(gpu_cards_per_row(2), vec![2]);
+        assert_eq!(gpu_cards_per_row(4), vec![2, 2]);
+    }
+
+    #[test]
+    fn test_gpu_cards_per_row_odd() {
+        assert_eq!(gpu_cards_per_row(1), vec![1]);
+        assert_eq!(gpu_cards_per_row(3), vec![2, 1]);
+        assert_eq!(gpu_cards_per_row(5), vec![2, 2, 1]);
+    }
+
+    #[test]
+    fn test_format_gpu_card_detail_prefers_compact_stats() {
+        let snapshot = GpuDeviceSnapshot {
+            vram_used: Some(4 * 1024 * 1024 * 1024),
+            vram_total: Some(8 * 1024 * 1024 * 1024),
+            temperature: Some(62.0),
+            power_watts: Some(118.6),
+            device_name: Some("Very Long GPU Name".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_gpu_card_detail(&snapshot),
+            "4.0G / 8.0G · 62°C · 119W"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_card_detail_falls_back_when_stats_missing() {
+        let snapshot = GpuDeviceSnapshot {
+            power_state: GpuPowerState::Suspended,
+            ..Default::default()
+        };
+
+        assert_eq!(format_gpu_card_detail(&snapshot), "Suspended");
+    }
+
+    #[test]
+    fn test_format_gpu_card_title_prefers_device_name() {
+        let snapshot = GpuDeviceSnapshot {
+            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_gpu_card_title(0, &snapshot),
+            "NVIDIA GeForce RTX 4090"
+        );
+    }
+
+    #[test]
+    fn test_format_gpu_card_title_falls_back_to_index() {
+        let snapshot = GpuDeviceSnapshot::default();
+
+        assert_eq!(format_gpu_card_title(1, &snapshot), "GPU 2");
+    }
 }
 
 /// A binding that manages the system popover lifecycle for bar widgets.

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -30,20 +30,26 @@ use std::rc::Rc;
 use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Label, Orientation, ProgressBar, Revealer, RevealerTransitionType, Widget,
+    Align, Box as GtkBox, Label, Orientation, PolicyType, ProgressBar, Revealer,
+    RevealerTransitionType, ScrolledWindow, Widget,
 };
 
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
-use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
+use crate::services::gpu::{
+    GpuDeviceSnapshot, GpuHistorySample, GpuPowerState, GpuService, GpuSnapshot,
+};
 use crate::services::icons::{IconHandle, IconsService};
 use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long, format_speed};
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
+use crate::widgets::gpu_format;
+use crate::widgets::history_graph::{HistoryGraph, HistoryScale, HistorySeries};
 use crate::widgets::layer_shell_popover::animate_reveal;
 
-const GPU_TITLE_MAX_CHARS: i32 = 34;
-const GPU_VRAM_MAX_CHARS: i32 = 18;
-const GPU_METRICS_MAX_CHARS: i32 = 24;
+const GPU_TITLE_MAX_CHARS: i32 = 44;
+const GPU_GRAPH_HEIGHT: i32 = 56;
+const GPU_VALUE_MAX_CHARS: i32 = 20;
+const GPU_DEVICES_MAX_HEIGHT: i32 = 360;
 
 /// A single pre-allocated per-core row with its updatable widgets.
 #[derive(Clone)]
@@ -55,11 +61,60 @@ struct CoreRow {
 #[derive(Clone)]
 struct GpuDeviceRow {
     container: GtkBox,
+    header: GtkBox,
+    graph: HistoryGraph,
     title_label: Label,
     usage_label: Label,
-    usage_progress: ProgressBar,
-    vram_detail_label: Label,
-    metrics_label: Label,
+    temp_label: Label,
+    metrics: GtkBox,
+    vram: GpuMetricBar,
+    power: GpuMetricBar,
+    clock: GpuMetricBar,
+}
+
+#[derive(Clone)]
+struct GpuMetricBar {
+    container: GtkBox,
+    bar: ProgressBar,
+    value: Label,
+}
+
+impl GpuMetricBar {
+    fn new(caption: &str) -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 4);
+        container.set_hexpand(true);
+
+        let label = Label::new(Some(caption));
+        label.add_css_class(color::MUTED);
+        label.set_halign(Align::Start);
+        container.append(&label);
+
+        let bar = ProgressBar::new();
+        bar.add_css_class(sp::PROGRESS_BAR);
+        container.append(&bar);
+
+        let value = Label::new(Some("--"));
+        value.add_css_class(color::MUTED);
+        value.set_halign(Align::Start);
+        value.set_xalign(0.0);
+        value.set_max_width_chars(GPU_VALUE_MAX_CHARS);
+        value.set_ellipsize(EllipsizeMode::End);
+        container.append(&value);
+
+        Self {
+            container,
+            bar,
+            value,
+        }
+    }
+
+    fn show(&self, value: &str, fraction: Option<f64>) {
+        self.value.set_label(value);
+        self.bar
+            .set_fraction(fraction.unwrap_or(0.0).clamp(0.0, 1.0));
+        self.bar
+            .set_opacity(if fraction.is_some() { 1.0 } else { 0.35 });
+    }
 }
 
 /// Controller owning the system popover UI elements and update logic.
@@ -92,6 +147,8 @@ pub struct SystemPopoverController {
 
     // GPU section (conditional: only present when GPUs are detected)
     gpu_card: GtkBox,
+    gpu_usage_label: Label,
+    gpu_temp_label: Label,
     gpu_devices_box: GtkBox,
     gpu_device_rows: Rc<RefCell<Vec<GpuDeviceRow>>>,
 }
@@ -151,9 +208,18 @@ impl SystemPopoverController {
         self.gpu_card.set_visible(true);
         self.sync_gpu_device_rows(devices.len());
 
+        let show_index = devices.len() > 1;
+        self.gpu_usage_label.set_visible(!show_index);
+        self.gpu_temp_label.set_visible(!show_index);
+        if let [device] = devices.as_slice() {
+            update_gpu_headline(&self.gpu_usage_label, &self.gpu_temp_label, device);
+        }
+
         let rows = self.gpu_device_rows.borrow();
+        let gpu_service = GpuService::global();
         for (row, device) in rows.iter().zip(devices.iter()) {
-            update_gpu_device_row(row, device, devices.len() > 1);
+            let history = gpu_service.history(device.device_index);
+            update_gpu_device_row(row, device, &history, show_index);
         }
     }
 
@@ -256,6 +322,19 @@ fn section_title(icon_name: &str, text: &str, icons: &IconsService) -> GtkBox {
 
 /// Create a section title with icon, label, and a right-aligned value (for CPU temp).
 fn section_title_with_value(icon_name: &str, text: &str, icons: &IconsService) -> (GtkBox, Label) {
+    let (container, values) = section_title_with_values(icon_name, text, icons);
+    let value = Label::new(Some(""));
+    value.add_css_class(color::MUTED);
+    values.append(&value);
+
+    (container, value)
+}
+
+fn section_title_with_values(
+    icon_name: &str,
+    text: &str,
+    icons: &IconsService,
+) -> (GtkBox, GtkBox) {
     let container = GtkBox::new(Orientation::Horizontal, 6);
     container.add_css_class(sp::SECTION_TITLE);
 
@@ -266,13 +345,12 @@ fn section_title_with_value(icon_name: &str, text: &str, icons: &IconsService) -
     label.add_css_class(surface::POPOVER_TITLE);
     container.append(&label);
 
-    let value = Label::new(Some(""));
-    value.add_css_class(color::MUTED);
-    value.set_hexpand(true);
-    value.set_halign(Align::End);
-    container.append(&value);
+    let values = GtkBox::new(Orientation::Horizontal, 8);
+    values.set_hexpand(true);
+    values.set_halign(Align::End);
+    container.append(&values);
 
-    (container, value)
+    (container, values)
 }
 
 /// Create a stat row with label and value.
@@ -296,7 +374,7 @@ fn stat_row(label_text: &str, value_width_chars: i32) -> (GtkBox, Label) {
 
 fn build_gpu_device_row() -> GpuDeviceRow {
     let container = GtkBox::new(Orientation::Vertical, 6);
-    let summary_row = GtkBox::new(Orientation::Horizontal, 8);
+    let header = GtkBox::new(Orientation::Horizontal, 8);
 
     let title_label = Label::new(Some("GPU"));
     title_label.set_halign(Align::Start);
@@ -305,116 +383,135 @@ fn build_gpu_device_row() -> GpuDeviceRow {
     title_label.set_ellipsize(EllipsizeMode::End);
     title_label.set_single_line_mode(true);
     title_label.set_max_width_chars(GPU_TITLE_MAX_CHARS);
-    summary_row.append(&title_label);
+    header.append(&title_label);
+
+    let temp_label = Label::new(None);
+    temp_label.add_css_class(color::MUTED);
+    temp_label.set_halign(Align::End);
+    header.append(&temp_label);
 
     let usage_label = Label::new(Some("--"));
+    usage_label.add_css_class(color::ACCENT);
     usage_label.set_halign(Align::End);
-    usage_label.set_width_chars(6);
+    usage_label.set_width_chars(4);
     usage_label.set_xalign(1.0);
-    summary_row.append(&usage_label);
-    container.append(&summary_row);
+    header.append(&usage_label);
 
-    let usage_progress = ProgressBar::new();
-    usage_progress.add_css_class(sp::PROGRESS_BAR);
-    container.append(&usage_progress);
+    let graph = HistoryGraph::new(
+        crate::services::gpu::GPU_HISTORY_SAMPLES,
+        GPU_GRAPH_HEIGHT,
+        HistoryScale::Fixed {
+            min: 0.0,
+            max: 100.0,
+        },
+    );
+    graph.widget().add_css_class(color::ACCENT);
 
-    let detail_row = GtkBox::new(Orientation::Horizontal, 8);
+    let vram = GpuMetricBar::new("VRAM");
+    let power = GpuMetricBar::new("Power");
+    let clock = GpuMetricBar::new("Clock");
+    let metrics = GtkBox::new(Orientation::Horizontal, 12);
+    metrics.set_homogeneous(true);
+    for metric in [&vram, &power, &clock] {
+        metrics.append(&metric.container);
+    }
 
-    let vram_detail_label = Label::new(Some("--"));
-    vram_detail_label.add_css_class(color::MUTED);
-    vram_detail_label.set_halign(Align::Start);
-    vram_detail_label.set_xalign(0.0);
-    vram_detail_label.set_ellipsize(EllipsizeMode::End);
-    vram_detail_label.set_single_line_mode(true);
-    vram_detail_label.set_hexpand(true);
-    vram_detail_label.set_max_width_chars(GPU_VRAM_MAX_CHARS);
-    detail_row.append(&vram_detail_label);
-
-    let metrics_label = Label::new(None);
-    metrics_label.add_css_class(color::MUTED);
-    metrics_label.set_halign(Align::End);
-    metrics_label.set_xalign(1.0);
-    metrics_label.set_ellipsize(EllipsizeMode::End);
-    metrics_label.set_single_line_mode(true);
-    metrics_label.set_max_width_chars(GPU_METRICS_MAX_CHARS);
-    detail_row.append(&metrics_label);
-
-    container.append(&detail_row);
+    container.append(&header);
+    container.append(graph.widget());
+    container.append(&metrics);
 
     GpuDeviceRow {
         container,
+        header,
+        graph,
         title_label,
         usage_label,
-        usage_progress,
-        vram_detail_label,
-        metrics_label,
+        temp_label,
+        metrics,
+        vram,
+        power,
+        clock,
     }
 }
 
-fn update_gpu_device_row(row: &GpuDeviceRow, snapshot: &GpuDeviceSnapshot, show_index: bool) {
-    row.title_label
-        .set_label(&format_gpu_device_title(snapshot, show_index));
+fn update_gpu_device_row(
+    row: &GpuDeviceRow,
+    snapshot: &GpuDeviceSnapshot,
+    history: &[GpuHistorySample],
+    show_index: bool,
+) {
+    row.header.set_visible(show_index);
+    if show_index {
+        row.title_label
+            .set_label(&gpu_format::device_title(snapshot, true));
+        update_gpu_headline(&row.usage_label, &row.temp_label, snapshot);
+    }
+    row.graph.set_series(vec![HistorySeries::solid(
+        history
+            .iter()
+            .map(|sample| sample.usage.map(f64::from))
+            .collect(),
+    )]);
 
     if snapshot.power_state == GpuPowerState::Suspended {
-        row.usage_label.set_label("Idle");
-        row.usage_progress.set_fraction(0.0);
-    } else if let Some(usage) = snapshot.gpu_usage {
-        row.usage_label.set_label(&format!("{:.1}%", usage));
-        row.usage_progress.set_fraction(usage as f64 / 100.0);
+        row.graph.widget().set_visible(false);
+        row.metrics.set_visible(false);
+        return;
+    }
+
+    row.graph.widget().set_visible(true);
+    row.metrics.set_visible(true);
+    row.vram.show(
+        &gpu_format::vram(snapshot).unwrap_or_else(|| "--".to_string()),
+        gpu_vram_fraction(snapshot),
+    );
+    row.power.show(
+        &gpu_format::power(snapshot).unwrap_or_else(|| "--".to_string()),
+        gpu_power_fraction(snapshot),
+    );
+    row.clock.show(
+        &gpu_format::clock(snapshot).unwrap_or_else(|| "--".to_string()),
+        gpu_clock_fraction(snapshot),
+    );
+}
+
+fn update_gpu_headline(usage: &Label, temperature: &Label, snapshot: &GpuDeviceSnapshot) {
+    if snapshot.power_state == GpuPowerState::Suspended {
+        usage.set_label("Idle");
+        temperature.set_visible(false);
+        return;
+    }
+    usage.set_label(
+        &snapshot
+            .gpu_usage
+            .map_or_else(|| "--".to_string(), |v| format!("{v:.0}%")),
+    );
+    if let Some(value) = snapshot.temperature {
+        temperature.set_label(&format!("{value:.0}°C"));
+        temperature.set_visible(true);
     } else {
-        row.usage_label.set_label("--");
-        row.usage_progress.set_fraction(0.0);
-    }
-
-    row.vram_detail_label
-        .set_label(&format_gpu_device_vram(snapshot));
-    let metrics = format_gpu_device_metrics(snapshot);
-    row.metrics_label.set_label(&metrics);
-    row.metrics_label.set_visible(!metrics.is_empty());
-}
-
-fn format_gpu_device_title(snapshot: &GpuDeviceSnapshot, show_index: bool) -> String {
-    let name = snapshot
-        .device_name
-        .as_ref()
-        .filter(|name| !name.trim().is_empty())
-        .map(String::as_str);
-
-    match (show_index, name) {
-        (true, Some(name)) => format!("GPU {}: {name}", snapshot.device_index),
-        (true, None) => format!("GPU {}", snapshot.device_index),
-        (false, Some(name)) => name.to_string(),
-        (false, None) => "GPU".to_string(),
+        temperature.set_visible(false);
     }
 }
 
-fn format_gpu_device_vram(snapshot: &GpuDeviceSnapshot) -> String {
-    match (snapshot.vram_used, snapshot.vram_total) {
-        (Some(used), Some(total)) => {
-            format!("{} / {}", format_bytes_long(used), format_bytes_long(total))
-        }
-        (Some(used), None) => format!("{} used", format_bytes_long(used)),
-        _ if snapshot.power_state == GpuPowerState::Suspended => "Suspended".to_string(),
-        _ => "--".to_string(),
+fn gpu_vram_fraction(snapshot: &GpuDeviceSnapshot) -> Option<f64> {
+    snapshot
+        .vram_percent()
+        .map(|value| f64::from(value / 100.0))
+}
+
+fn gpu_power_fraction(snapshot: &GpuDeviceSnapshot) -> Option<f64> {
+    match (snapshot.power_watts, snapshot.power_limit_watts) {
+        (Some(value), Some(limit)) if limit > 0.0 => Some(f64::from(value / limit)),
+        _ => None,
     }
 }
 
-fn format_gpu_device_metrics(snapshot: &GpuDeviceSnapshot) -> String {
-    let mut parts = Vec::new();
-
-    if let Some(temp) = snapshot.temperature {
-        parts.push(format!("{:.0}°C", temp));
+fn gpu_clock_fraction(snapshot: &GpuDeviceSnapshot) -> Option<f64> {
+    match (snapshot.clock_mhz, snapshot.max_clock_mhz) {
+        (Some(value), Some(limit)) if limit > 0 => Some(value as f64 / limit as f64),
+        _ => None,
     }
-
-    if let Some(watts) = snapshot.power_watts {
-        parts.push(format!("{:.0}W", watts));
-    }
-
-    if let Some(mhz) = snapshot.clock_mhz {
-        parts.push(format!("{}MHz", mhz));
-    }
-
-    parts.join(" · ")
 }
 
 /// Build a system resource popover content widget.
@@ -514,12 +611,26 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
     gpu_card.set_visible(gpu_snapshot.available());
 
     let gpu_section = GtkBox::new(Orientation::Vertical, 8);
-    let gpu_title = section_title("video-display-symbolic", "GPU", &icons);
+    let (gpu_title, gpu_values) =
+        section_title_with_values("video-display-symbolic", "GPU", &icons);
     gpu_title.add_css_class(sp::GPU_TITLE);
+    let gpu_temp_label = Label::new(None);
+    gpu_temp_label.add_css_class(color::MUTED);
+    gpu_values.append(&gpu_temp_label);
+    let gpu_usage_label = Label::new(Some("--"));
+    gpu_usage_label.add_css_class(color::ACCENT);
+    gpu_usage_label.set_width_chars(4);
+    gpu_usage_label.set_xalign(1.0);
+    gpu_values.append(&gpu_usage_label);
     gpu_section.append(&gpu_title);
 
     let gpu_devices_box = GtkBox::new(Orientation::Vertical, 14);
-    gpu_section.append(&gpu_devices_box);
+    let gpu_devices_scroller = ScrolledWindow::new();
+    gpu_devices_scroller.set_policy(PolicyType::Never, PolicyType::Automatic);
+    gpu_devices_scroller.set_propagate_natural_height(true);
+    gpu_devices_scroller.set_max_content_height(GPU_DEVICES_MAX_HEIGHT);
+    gpu_devices_scroller.set_child(Some(&gpu_devices_box));
+    gpu_section.append(&gpu_devices_scroller);
     gpu_card.append(&gpu_section);
     container.append(&gpu_card);
 
@@ -656,6 +767,8 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
         load_5_label,
         load_15_label,
         gpu_card,
+        gpu_usage_label,
+        gpu_temp_label,
         gpu_devices_box,
         gpu_device_rows: Rc::new(RefCell::new(Vec::new())),
     };
@@ -674,65 +787,20 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
 
 #[cfg(test)]
 mod tests {
-    use super::{format_gpu_device_metrics, format_gpu_device_title, format_gpu_device_vram};
-    use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState};
+    use super::{gpu_clock_fraction, gpu_power_fraction};
+    use crate::services::gpu::GpuDeviceSnapshot;
 
     #[test]
-    fn test_format_gpu_device_details_group_vram_and_metrics() {
+    fn test_gpu_metric_fractions_use_real_limits() {
         let snapshot = GpuDeviceSnapshot {
-            vram_used: Some(4 * 1024 * 1024 * 1024),
-            vram_total: Some(8 * 1024 * 1024 * 1024),
-            temperature: Some(62.0),
-            power_watts: Some(118.6),
-            clock_mhz: Some(2430),
-            device_name: Some("Very Long GPU Name".to_string()),
+            power_watts: Some(120.0),
+            power_limit_watts: Some(300.0),
+            clock_mhz: Some(1500),
+            max_clock_mhz: Some(2500),
             ..Default::default()
         };
-
-        assert_eq!(format_gpu_device_vram(&snapshot), "4.0 GB / 8.0 GB");
-        assert_eq!(
-            format_gpu_device_metrics(&snapshot),
-            "62°C · 119W · 2430MHz"
-        );
-    }
-
-    #[test]
-    fn test_format_gpu_device_vram_shows_suspended_state_when_missing() {
-        let snapshot = GpuDeviceSnapshot {
-            power_state: GpuPowerState::Suspended,
-            device_name: Some("Intel Integrated Graphics".to_string()),
-            ..Default::default()
-        };
-
-        assert_eq!(format_gpu_device_vram(&snapshot), "Suspended");
-        assert_eq!(format_gpu_device_metrics(&snapshot), "");
-    }
-
-    #[test]
-    fn test_format_gpu_device_title_prefers_device_name() {
-        let snapshot = GpuDeviceSnapshot {
-            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            format_gpu_device_title(&snapshot, false),
-            "NVIDIA GeForce RTX 4090"
-        );
-    }
-
-    #[test]
-    fn test_format_gpu_device_title_uses_config_index_for_multiple_devices() {
-        let snapshot = GpuDeviceSnapshot {
-            device_index: 3,
-            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            format_gpu_device_title(&snapshot, true),
-            "GPU 3: NVIDIA GeForce RTX 4090"
-        );
+        assert!(gpu_power_fraction(&snapshot).is_some_and(|value| (value - 0.4).abs() < 0.001));
+        assert_eq!(gpu_clock_fraction(&snapshot), Some(0.6));
     }
 }
 
@@ -740,9 +808,6 @@ mod tests {
 #[derive(Clone)]
 pub struct SystemPopoverBinding {
     controller: Rc<RefCell<Option<SystemPopoverController>>>,
-    /// Held to keep the `Rc` alive; managed via clones in open/close closures.
-    #[allow(dead_code)]
-    gpu_callback_id: Rc<Cell<Option<CallbackId>>>,
 }
 
 impl SystemPopoverBinding {
@@ -821,23 +886,13 @@ impl SystemPopoverBinding {
             }
         });
 
-        Self {
-            controller,
-            gpu_callback_id,
-        }
+        Self { controller }
     }
 
     /// Update the popover if it's currently open.
     pub fn update_if_open(&self, snapshot: &SystemSnapshot) {
         if let Some(controller) = self.controller.borrow().as_ref() {
             controller.update_from_snapshot(snapshot);
-        }
-    }
-
-    /// Update the GPU section of the popover if it's currently open.
-    pub fn update_gpu_if_open(&self, snapshot: &GpuSnapshot) {
-        if let Some(controller) = self.controller.borrow().as_ref() {
-            controller.update_from_gpu_snapshot(snapshot);
         }
     }
 }

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -12,8 +12,8 @@
 //! ├─────────────────────────────┤
 //! │ ┌───────────────────────────┤  (conditional: all GPUs in one card)
 //! │ │  GPU                      │
-//! │ │  GPU 1              76%  │
-//! │ │  GPU 2              41%  │
+//! │ │  AMD Radeon          76%  │
+//! │ │  NVIDIA RTX          41%  │
 //! │ └───────────────────────────┤
 //! ├─────────────────────────────┤
 //! │ ┌───────────┐ ┌───────────┐ │
@@ -37,9 +37,7 @@ use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::gpu::{GpuDeviceSnapshot, GpuPowerState, GpuService, GpuSnapshot};
 use crate::services::icons::{IconHandle, IconsService};
-use crate::services::system::{
-    SystemService, SystemSnapshot, format_bytes, format_bytes_long, format_speed,
-};
+use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long, format_speed};
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
 use crate::widgets::layer_shell_popover::animate_reveal;
 
@@ -145,7 +143,7 @@ impl SystemPopoverController {
 
     /// Update the GPU card from the latest GPU snapshot.
     pub fn update_from_gpu_snapshot(&self, snapshot: &GpuSnapshot) {
-        let devices = snapshot.devices_for_display();
+        let devices = &snapshot.devices;
         if devices.is_empty() {
             self.gpu_card.set_visible(false);
             return;
@@ -154,8 +152,8 @@ impl SystemPopoverController {
         self.sync_gpu_device_rows(devices.len());
 
         let rows = self.gpu_device_rows.borrow();
-        for (index, (row, device)) in rows.iter().zip(devices.iter()).enumerate() {
-            update_gpu_device_row(row, index, device);
+        for (row, device) in rows.iter().zip(devices.iter()) {
+            update_gpu_device_row(row, device, devices.len() > 1);
         }
     }
 
@@ -353,9 +351,9 @@ fn build_gpu_device_row() -> GpuDeviceRow {
     }
 }
 
-fn update_gpu_device_row(row: &GpuDeviceRow, index: usize, snapshot: &GpuDeviceSnapshot) {
+fn update_gpu_device_row(row: &GpuDeviceRow, snapshot: &GpuDeviceSnapshot, show_index: bool) {
     row.title_label
-        .set_label(&format_gpu_device_title(index, snapshot));
+        .set_label(&format_gpu_device_title(snapshot, show_index));
 
     if snapshot.power_state == GpuPowerState::Suspended {
         row.usage_label.set_label("Idle");
@@ -375,21 +373,27 @@ fn update_gpu_device_row(row: &GpuDeviceRow, index: usize, snapshot: &GpuDeviceS
     row.metrics_label.set_visible(!metrics.is_empty());
 }
 
-fn format_gpu_device_title(index: usize, snapshot: &GpuDeviceSnapshot) -> String {
-    snapshot
+fn format_gpu_device_title(snapshot: &GpuDeviceSnapshot, show_index: bool) -> String {
+    let name = snapshot
         .device_name
         .as_ref()
         .filter(|name| !name.trim().is_empty())
-        .cloned()
-        .unwrap_or_else(|| format!("GPU {}", index + 1))
+        .map(String::as_str);
+
+    match (show_index, name) {
+        (true, Some(name)) => format!("GPU {}: {name}", snapshot.device_index),
+        (true, None) => format!("GPU {}", snapshot.device_index),
+        (false, Some(name)) => name.to_string(),
+        (false, None) => "GPU".to_string(),
+    }
 }
 
 fn format_gpu_device_vram(snapshot: &GpuDeviceSnapshot) -> String {
     match (snapshot.vram_used, snapshot.vram_total) {
         (Some(used), Some(total)) => {
-            format!("{} / {}", format_bytes(used), format_bytes(total))
+            format!("{} / {}", format_bytes_long(used), format_bytes_long(total))
         }
-        (Some(used), None) => format!("{} used", format_bytes(used)),
+        (Some(used), None) => format!("{} used", format_bytes_long(used)),
         _ if snapshot.power_state == GpuPowerState::Suspended => "Suspended".to_string(),
         _ => "--".to_string(),
     }
@@ -507,7 +511,7 @@ pub fn build_system_popover_with_controller() -> (Widget, SystemPopoverControlle
     gpu_card.add_css_class(sp::SECTION_CARD);
     gpu_card.add_css_class(sp::GPU_CARD);
     gpu_card.set_margin_top(8);
-    gpu_card.set_visible(!gpu_snapshot.devices_for_display().is_empty());
+    gpu_card.set_visible(gpu_snapshot.available());
 
     let gpu_section = GtkBox::new(Orientation::Vertical, 8);
     let gpu_title = section_title("video-display-symbolic", "GPU", &icons);
@@ -685,7 +689,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(format_gpu_device_vram(&snapshot), "4.0G / 8.0G");
+        assert_eq!(format_gpu_device_vram(&snapshot), "4.0 GB / 8.0 GB");
         assert_eq!(
             format_gpu_device_metrics(&snapshot),
             "62°C · 119W · 2430MHz"
@@ -712,16 +716,23 @@ mod tests {
         };
 
         assert_eq!(
-            format_gpu_device_title(0, &snapshot),
+            format_gpu_device_title(&snapshot, false),
             "NVIDIA GeForce RTX 4090"
         );
     }
 
     #[test]
-    fn test_format_gpu_device_title_falls_back_to_index() {
-        let snapshot = GpuDeviceSnapshot::default();
+    fn test_format_gpu_device_title_uses_config_index_for_multiple_devices() {
+        let snapshot = GpuDeviceSnapshot {
+            device_index: 3,
+            device_name: Some("NVIDIA GeForce RTX 4090".to_string()),
+            ..Default::default()
+        };
 
-        assert_eq!(format_gpu_device_title(1, &snapshot), "GPU 2");
+        assert_eq!(
+            format_gpu_device_title(&snapshot, true),
+            "GPU 3: NVIDIA GeForce RTX 4090"
+        );
     }
 }
 


### PR DESCRIPTION
Adds support for monitoring multiple GPUs and improves the GPU presentation in vertical bars and the system popover.

- Supports automatic selection, all detected GPUs, a single index or an ordered list of indices.
- Shows each selected GPU in the bar tooltip and system popover.
- Adds GPU usage history and detailed VRAM, power and clock metrics to the system popover.
- Improves compact vertical formatting while keeping the widget width stable.
- Updates the selected GPUs when the config is reloaded.
- Avoids polling APIs while a GPU is suspended.

Also updated the vertical format of the widget to show units, if it bothers you, open an issue and we can add an option for it.

GPU selection can be configured like this:
```toml
[widgets.gpu]
devices = "all" # or "auto", 1, or [1, 0]
```

<img width="541" height="438" alt="image" src="https://github.com/user-attachments/assets/29c2c803-f708-4c90-a9f0-abd177ed2e25" />
<img width="576" height="608" alt="image" src="https://github.com/user-attachments/assets/40896fab-0445-4ef0-9eaa-1e15aecb3e6d" />
