### PR TITLE
feat(widgets): automaticallty merge clock+weather group and enable popover weather

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,8 @@ background_opacity = 1.0
 #   [widgets.clock]
 #   format = "%H:%M"
 #   show_weather = true # Embed weather content in the clock/calendar popover
+#   # When "clock" and "weather" are in the same explicit group, they merge
+#   # into one calendar/weather button unless show_weather = false is set.
 #   outline_color = "accent"  # Per-widget outline color: "subtle" | "accent" | "foreground" | "#rrggbb"
 #
 #   [widgets.battery]

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -840,6 +840,7 @@ fn build_widget_or_group(
             // on_click_right / on_click_middle commands aren't silently lost.
             // Spacers are tracked as MergeKind::Spacer so they can be absorbed
             // into adjacent runs rather than breaking merges.
+            let group_has_weather = group.iter().any(|e| e.name == "weather");
             let kinds: Vec<MergeKind> = group
                 .iter()
                 .map(|e| {
@@ -848,7 +849,8 @@ fn build_widget_or_group(
                     } else {
                         let (right, middle) = ConfigManager::global().get_click_handlers(&e.name);
                         let has_custom_click = right.is_some() || middle.is_some();
-                        let clock_weather_opt_out = e.name == "clock"
+                        let clock_weather_opt_out = group_has_weather
+                            && e.name == "clock"
                             && e.options.get("show_weather").and_then(|v| v.as_bool())
                                 == Some(false);
                         if has_custom_click || clock_weather_opt_out {
@@ -909,11 +911,11 @@ fn build_widget_or_group(
                 let run_entries = &group[*start..*end];
                 let run_len = end - start;
                 let real_in_run = run_entries.iter().filter(|e| e.name != "spacer").count();
+                let run_has_clock = run_entries.iter().any(|e| e.name == "clock");
+                let supports_merge = *kind != PopoverKind::Unmergeable
+                    && (*kind != PopoverKind::CalendarWeather || run_has_clock);
 
-                if run_len >= 2
-                    && *kind != PopoverKind::Unmergeable
-                    && (real_in_run >= 2 || total_real == 1)
-                {
+                if run_len >= 2 && supports_merge && (real_in_run >= 2 || total_real == 1) {
                     let merged = build_merge_group(
                         run_entries,
                         *kind,
@@ -1095,7 +1097,10 @@ fn build_merge_group(
     wrapper.add_overlay(&ripple_clip);
     wrapper.set_measure_overlay(&ripple_clip, true);
 
-    let widget_name = representative.name.clone();
+    let widget_name = match kind {
+        PopoverKind::CalendarWeather => "clock".to_string(),
+        _ => representative.name.clone(),
+    };
     let menu_handle = MenuHandle::new_placeholder(widget_name, wrapper.clone());
 
     // Primary click toggles the shared popover. Right/middle-click handlers
@@ -1142,9 +1147,12 @@ fn build_merge_group(
                     return 0;
                 };
                 let clock_config = ClockConfig::from_entry(clock_entry);
+                let has_weather_widget = entries.iter().any(|entry| entry.name == "weather");
+                let show_weather = has_weather_widget || clock_config.show_weather;
                 let binding = CalendarWeatherPopoverBinding::new_for_menu(
                     &menu_handle,
                     clock_config.show_week_numbers,
+                    show_weather,
                 );
                 let built_widgets = entries
                     .iter()

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -769,6 +769,21 @@ fn collect_island_bounds(
     result
 }
 
+/// Return true when a resolved entry's `width` option is a positive
+/// integer, mirroring `SpacerConfig::from_entry`.
+///
+/// Invalid or non-integer `width` values fall through to the flexible
+/// branch, keeping group expansion policy in sync with what the spacer
+/// widget itself does at build time.
+fn entry_has_fixed_width_option(entry: &WidgetEntry) -> bool {
+    entry
+        .options
+        .get("width")
+        .and_then(|v| v.as_integer())
+        .and_then(|n| u32::try_from(n).ok())
+        .is_some()
+}
+
 /// Build a single widget or a group of widgets sharing one island.
 ///
 /// Returns the number of widgets built (for counting purposes).
@@ -798,9 +813,18 @@ fn build_widget_or_group(
                 return 0;
             }
 
+            let group_has_flexible_spacer = group
+                .iter()
+                .any(|entry| entry.name == "spacer" && !entry_has_fixed_width_option(entry));
+
             // Create a shared island container for the group
             let island = gtk4::Box::new(orientation, 0);
             island.add_css_class(class::WIDGET_WRAPPER);
+            if orientation == gtk4::Orientation::Vertical {
+                island.set_vexpand(group_has_flexible_spacer);
+            } else {
+                island.set_hexpand(group_has_flexible_spacer);
+            }
 
             // Create inner content box (matching BaseWidget structure)
             let content = gtk4::Box::new(orientation, 0);

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -17,9 +17,9 @@ use crate::services::config_manager::{ConfigManager, ThemeCallbackGuard};
 use crate::services::tooltip::TooltipManager;
 use crate::styles::{class, state, widget as style_widget};
 use crate::widgets::{
-    self, BarState, EdgeInteraction, MenuHandle, PopoverKind, QuickSettingsConfig, RippleHandle,
-    SystemPopoverBinding, WidgetConfig, WidgetFactory, popover_kind_for,
-    trigger_ripple_from_gesture,
+    self, BarState, CalendarWeatherPopoverBinding, ClockConfig, EdgeInteraction, MenuHandle,
+    PopoverKind, QuickSettingsConfig, RippleHandle, SystemPopoverBinding, WidgetConfig,
+    WidgetFactory, popover_kind_for, trigger_ripple_from_gesture,
 };
 
 /// Total bar window/content height reserved for the shell.
@@ -847,7 +847,11 @@ fn build_widget_or_group(
                         MergeKind::Spacer
                     } else {
                         let (right, middle) = ConfigManager::global().get_click_handlers(&e.name);
-                        if right.is_some() || middle.is_some() {
+                        let has_custom_click = right.is_some() || middle.is_some();
+                        let clock_weather_opt_out = e.name == "clock"
+                            && e.options.get("show_weather").and_then(|v| v.as_bool())
+                                == Some(false);
+                        if has_custom_click || clock_weather_opt_out {
                             MergeKind::Popover(PopoverKind::Unmergeable)
                         } else {
                             MergeKind::Popover(popover_kind_for(&e.name))
@@ -1094,18 +1098,6 @@ fn build_merge_group(
     let widget_name = representative.name.clone();
     let menu_handle = MenuHandle::new_placeholder(widget_name, wrapper.clone());
 
-    let binding = match kind {
-        PopoverKind::System => Some(SystemPopoverBinding::new_for_menu(&menu_handle)),
-        _ => {
-            warn!("Merge group for {:?} popover not yet supported", kind);
-            None
-        }
-    };
-
-    let Some(binding) = binding else {
-        return 0;
-    };
-
     // Primary click toggles the shared popover. Right/middle-click handlers
     // are not forwarded — the merge group is a single button, and per-widget
     // click commands don't have a meaningful target here.
@@ -1134,12 +1126,37 @@ fn build_merge_group(
 
     wrapper.add_controller(gesture_click.clone());
 
-    let mut built_widgets: Vec<widgets::BuiltWidget> = Vec::new();
-    for entry in entries {
-        if let Some(built) = WidgetFactory::build_passive(entry, &binding) {
-            built_widgets.push(built);
-        }
-    }
+    let (binding_handle, built_widgets): (Box<dyn std::any::Any>, Vec<widgets::BuiltWidget>) =
+        match kind {
+            PopoverKind::System => {
+                let binding = SystemPopoverBinding::new_for_menu(&menu_handle);
+                let built_widgets = entries
+                    .iter()
+                    .filter_map(|entry| WidgetFactory::build_passive(entry, &binding))
+                    .collect();
+                (Box::new(binding), built_widgets)
+            }
+            PopoverKind::CalendarWeather => {
+                let Some(clock_entry) = entries.iter().find(|entry| entry.name == "clock") else {
+                    warn!("Calendar/weather merge group requires a clock widget");
+                    return 0;
+                };
+                let clock_config = ClockConfig::from_entry(clock_entry);
+                let binding = CalendarWeatherPopoverBinding::new_for_menu(
+                    &menu_handle,
+                    clock_config.show_week_numbers,
+                );
+                let built_widgets = entries
+                    .iter()
+                    .filter_map(WidgetFactory::build_calendar_weather_passive)
+                    .collect();
+                (Box::new(binding), built_widgets)
+            }
+            PopoverKind::Unmergeable => {
+                warn!("Merge group for {:?} popover not supported", kind);
+                return 0;
+            }
+        };
 
     // If only 0–1 widgets survived (e.g. GPU unavailable), don't wrap in a
     // merge group — return 0 so the caller rebuilds via the normal active path.
@@ -1177,6 +1194,7 @@ fn build_merge_group(
     }
 
     // Keep the menu handle, gesture, and ripple alive
+    state.add_handle(binding_handle);
     state.add_handle(Box::new(menu_handle));
     state.add_handle(Box::new(gesture_click));
     state.add_handle(Box::new(ripple_handle));

--- a/crates/vibepanel/src/bar_tests.rs
+++ b/crates/vibepanel/src/bar_tests.rs
@@ -872,3 +872,38 @@ fn find_user_css_finds_existing_file() {
 
     assert_eq!(found, Some(style_path));
 }
+
+fn entry_with_width(name: &str, width: Option<toml::Value>) -> WidgetEntry {
+    let mut entry = WidgetEntry::new(name);
+    if let Some(value) = width {
+        entry.options.insert("width".to_string(), value);
+    }
+    entry
+}
+
+#[test]
+fn entry_has_fixed_width_option_matches_spacer_config_parsing() {
+    let positive = entry_with_width("spacer", Some(toml::Value::Integer(50)));
+    assert!(
+        entry_has_fixed_width_option(&positive),
+        "positive integer width must count as fixed"
+    );
+
+    let flexible = entry_with_width("spacer", None);
+    assert!(
+        !entry_has_fixed_width_option(&flexible),
+        "missing width must count as flexible"
+    );
+
+    let invalid_string = entry_with_width("spacer", Some(toml::Value::String("oops".to_string())));
+    assert!(
+        !entry_has_fixed_width_option(&invalid_string),
+        "non-integer width must count as flexible, matching SpacerConfig::from_entry"
+    );
+
+    let negative = entry_with_width("spacer", Some(toml::Value::Integer(-5)));
+    assert!(
+        !entry_has_fixed_width_option(&negative),
+        "negative width must count as flexible, matching SpacerConfig::from_entry"
+    );
+}

--- a/crates/vibepanel/src/layout_math.rs
+++ b/crates/vibepanel/src/layout_math.rs
@@ -152,19 +152,28 @@ pub struct LinearAllocation {
 /// * `interior` - Total usable width (after edge margins)
 /// * `spacing` - Gap between left and right sections
 /// * `left` - Size requirements for left section (None if not present)
+/// * `left_expand` - Whether left section should expand to fill available space
 /// * `right` - Size requirements for right section (None if not present)
+/// * `right_expand` - Whether right section should expand to fill available space
 pub fn compute_linear_allocation(
     interior: i32,
     spacing: i32,
     left: Option<SectionSizes>,
+    left_expand: bool,
     right: Option<SectionSizes>,
+    right_expand: bool,
 ) -> LinearAllocation {
     let (left_min, left_nat) = left.map_or((0, 0), |s| (s.min, s.natural));
     let (right_min, right_nat) = right.map_or((0, 0), |s| (s.min, s.natural));
 
-    let (left_width, right_width) = match (left.is_some(), right.is_some()) {
+    let available = match (left.is_some(), right.is_some()) {
+        (true, true) => (interior - spacing).max(0),
+        (true, false) | (false, true) => interior.max(0),
+        (false, false) => 0,
+    };
+
+    let (mut left_width, mut right_width) = match (left.is_some(), right.is_some()) {
         (true, true) => {
-            let available = (interior - spacing).max(0);
             let total_natural = left_nat + right_nat;
             if total_natural <= available {
                 (left_nat, right_nat)
@@ -175,15 +184,30 @@ pub fn compute_linear_allocation(
             }
         }
         (true, false) => {
-            let lw = clamp_width(interior, left_min, left_nat);
+            let lw = clamp_width(available, left_min, left_nat);
             (lw, 0)
         }
         (false, true) => {
-            let rw = clamp_width(interior, right_min, right_nat);
+            let rw = clamp_width(available, right_min, right_nat);
             (0, rw)
         }
         (false, false) => (0, 0),
     };
+
+    let extra = (available - left_width - right_width).max(0);
+    match (
+        left.is_some() && left_expand,
+        right.is_some() && right_expand,
+    ) {
+        (true, true) => {
+            let left_extra = extra / 2;
+            left_width += left_extra;
+            right_width += extra - left_extra;
+        }
+        (true, false) => left_width += extra,
+        (false, true) => right_width += extra,
+        (false, false) => {}
+    }
 
     LinearAllocation {
         left_x: 0,
@@ -409,10 +433,12 @@ mod tests {
                 min: 50,
                 natural: 100,
             }),
+            false,
             Some(SectionSizes {
                 min: 50,
                 natural: 100,
             }),
+            false,
         );
 
         assert_eq!(alloc.right_width, 100);
@@ -430,10 +456,12 @@ mod tests {
                 min: 50,
                 natural: 300,
             }),
+            false,
             Some(SectionSizes {
                 min: 50,
                 natural: 100,
             }),
+            false,
         );
 
         assert_eq!(alloc.right_width, 100);
@@ -451,7 +479,9 @@ mod tests {
                 min: 50,
                 natural: 100,
             }),
+            false,
             None,
+            false,
         );
 
         assert_eq!(alloc.left_width, 100);
@@ -465,10 +495,12 @@ mod tests {
             400,
             8,
             None,
+            false,
             Some(SectionSizes {
                 min: 50,
                 natural: 100,
             }),
+            false,
         );
 
         assert_eq!(alloc.left_width, 0);
@@ -485,10 +517,12 @@ mod tests {
                 min: 50,
                 natural: 100,
             }),
+            false,
             Some(SectionSizes {
                 min: 50,
                 natural: 100,
             }),
+            false,
         );
 
         assert_eq!(alloc.right_width, 100);
@@ -497,9 +531,85 @@ mod tests {
 
     #[test]
     fn test_linear_empty() {
-        let alloc = compute_linear_allocation(400, 8, None, None);
+        let alloc = compute_linear_allocation(400, 8, None, false, None, false);
 
         assert_eq!(alloc.left_width, 0);
         assert_eq!(alloc.right_width, 0);
+    }
+
+    #[test]
+    fn test_linear_right_expand_fills_remaining_space() {
+        let alloc = compute_linear_allocation(
+            400,
+            8,
+            Some(SectionSizes {
+                min: 50,
+                natural: 100,
+            }),
+            false,
+            Some(SectionSizes { min: 0, natural: 0 }),
+            true,
+        );
+
+        assert_eq!(alloc.left_width, 100);
+        assert_eq!(alloc.right_width, 292);
+        assert_eq!(alloc.right_x, 108);
+    }
+
+    #[test]
+    fn test_linear_left_expand_fills_remaining_space() {
+        let alloc = compute_linear_allocation(
+            400,
+            8,
+            Some(SectionSizes { min: 0, natural: 0 }),
+            true,
+            Some(SectionSizes {
+                min: 50,
+                natural: 100,
+            }),
+            false,
+        );
+
+        assert_eq!(alloc.left_width, 292);
+        assert_eq!(alloc.right_width, 100);
+        assert_eq!(alloc.right_x, 300);
+    }
+
+    #[test]
+    fn test_linear_both_expand_share_remaining_space() {
+        let alloc = compute_linear_allocation(
+            400,
+            8,
+            Some(SectionSizes {
+                min: 50,
+                natural: 100,
+            }),
+            true,
+            Some(SectionSizes {
+                min: 50,
+                natural: 100,
+            }),
+            true,
+        );
+
+        assert_eq!(alloc.left_width, 196);
+        assert_eq!(alloc.right_width, 196);
+        assert_eq!(alloc.right_x, 204);
+    }
+
+    #[test]
+    fn test_linear_single_expander_fills_section() {
+        let alloc = compute_linear_allocation(
+            400,
+            8,
+            None,
+            false,
+            Some(SectionSizes { min: 0, natural: 0 }),
+            true,
+        );
+
+        assert_eq!(alloc.left_width, 0);
+        assert_eq!(alloc.right_width, 400);
+        assert_eq!(alloc.right_x, 0);
     }
 }

--- a/crates/vibepanel/src/sectioned_bar.rs
+++ b/crates/vibepanel/src/sectioned_bar.rs
@@ -179,7 +179,9 @@ mod imp {
                     interior,
                     spacing,
                     measure_section(left.as_ref(), orientation),
+                    self.left_expand.get(),
                     measure_section(right.as_ref(), orientation),
+                    self.right_expand.get(),
                 );
 
                 // Record last allocation for snapshot/clipping

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1322,6 +1322,57 @@ fn run_test_widgets_grouping_clock_weather_explicit_opt_out() {
     assert!(weather > 0);
 }
 
+fn clock_spacer_group_counts(show_weather: Option<bool>) -> (usize, usize, usize, usize, usize) {
+    let mut config = test_config();
+    config.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Group {
+        group: vec!["clock".to_string(), "spacer".to_string()],
+    }];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+    if let Some(show_weather) = show_weather {
+        config
+            .widgets
+            .widget_configs
+            .entry("clock".to_string())
+            .or_default()
+            .options
+            .insert(
+                "show_weather".to_string(),
+                toml::Value::Boolean(show_weather),
+            );
+    }
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let counts = (
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_GROUP),
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_MERGE_GROUP),
+        count_descendants_with_class(&left_section, crate::styles::class::PASSIVE),
+        count_descendants_with_class(&left_section, "clock"),
+        count_descendants_with_class(&left_section, "spacer"),
+    );
+
+    window.close();
+    flush_gtk();
+    counts
+}
+
+fn run_test_widgets_grouping_clock_spacer_merge() {
+    let (groups, merge_groups, passive, clock, spacer) = clock_spacer_group_counts(None);
+    assert_eq!((groups, merge_groups, passive), (1, 1, 2));
+    assert!(clock > 0);
+    assert!(spacer > 0);
+}
+
+fn run_test_widgets_grouping_clock_spacer_merge_opt_out_ignored() {
+    let (groups, merge_groups, passive, clock, spacer) = clock_spacer_group_counts(Some(false));
+    assert_eq!((groups, merge_groups, passive), (1, 1, 2));
+    assert!(clock > 0);
+    assert!(spacer > 0);
+}
+
 fn run_test_widgets_grouping_spacing_contract() {
     let mut config = test_config();
     config.bar.spacing = 18;
@@ -2328,6 +2379,16 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_grouping_clock_weather_opt_out,
         "widgets.grouping.clock-weather-opt-out",
         run_test_widgets_grouping_clock_weather_explicit_opt_out
+    ),
+    (
+        test_ui_regression_widgets_grouping_clock_spacer_merge,
+        "widgets.grouping.clock-spacer-merge",
+        run_test_widgets_grouping_clock_spacer_merge
+    ),
+    (
+        test_ui_regression_widgets_grouping_clock_spacer_merge_opt_out_ignored,
+        "widgets.grouping.clock-spacer-merge-opt-out-ignored",
+        run_test_widgets_grouping_clock_spacer_merge_opt_out_ignored
     ),
     (
         test_ui_regression_widgets_grouping_spacing,

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1436,6 +1436,23 @@ fn run_test_widgets_grouping_spacer_does_not_expand_sibling_group() {
     );
 }
 
+fn run_test_widgets_empty_center_spacer_expands_side_section() {
+    let mut config = config_with_quick_settings_group();
+    config.widgets.right.insert(
+        0,
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["clock".to_string(), "spacer".to_string()],
+        },
+    );
+
+    let widths = right_section_child_widths(&config);
+    assert_eq!(widths.len(), 2);
+    assert!(
+        widths.iter().sum::<i32>() > 300,
+        "with no center section, a bare spacer should still expand the side section"
+    );
+}
+
 fn run_test_widgets_grouping_spacing_contract() {
     let mut config = test_config();
     config.bar.spacing = 18;
@@ -2457,6 +2474,11 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_grouping_spacer_does_not_expand_sibling_group,
         "widgets.grouping.spacer-does-not-expand-sibling-group",
         run_test_widgets_grouping_spacer_does_not_expand_sibling_group
+    ),
+    (
+        test_ui_regression_widgets_empty_center_spacer_expands_side_section,
+        "widgets.empty-center-spacer-expands-side-section",
+        run_test_widgets_empty_center_spacer_expands_side_section
     ),
     (
         test_ui_regression_widgets_grouping_spacing,

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1271,6 +1271,57 @@ fn run_test_widgets_grouping_system_merge() {
     flush_gtk();
 }
 
+fn clock_weather_group_counts(show_weather: Option<bool>) -> (usize, usize, usize, usize, usize) {
+    let mut config = test_config();
+    config.widgets.left = vec![vibepanel_core::config::WidgetPlacement::Group {
+        group: vec!["clock".to_string(), "weather".to_string()],
+    }];
+    config.widgets.center = Vec::new();
+    config.widgets.right = Vec::new();
+    if let Some(show_weather) = show_weather {
+        config
+            .widgets
+            .widget_configs
+            .entry("clock".to_string())
+            .or_default()
+            .options
+            .insert(
+                "show_weather".to_string(),
+                toml::Value::Boolean(show_weather),
+            );
+    }
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let counts = (
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_GROUP),
+        count_descendants_with_class(&left_section, crate::styles::class::WIDGET_MERGE_GROUP),
+        count_descendants_with_class(&left_section, crate::styles::class::PASSIVE),
+        count_descendants_with_class(&left_section, "clock"),
+        count_descendants_with_class(&left_section, "weather"),
+    );
+
+    window.close();
+    flush_gtk();
+    counts
+}
+
+fn run_test_widgets_grouping_clock_weather_merge() {
+    let (groups, merge_groups, passive, clock, weather) = clock_weather_group_counts(None);
+    assert_eq!((groups, merge_groups, passive), (1, 1, 2));
+    assert!(clock > 0);
+    assert!(weather > 0);
+}
+
+fn run_test_widgets_grouping_clock_weather_explicit_opt_out() {
+    let (groups, merge_groups, passive, clock, weather) = clock_weather_group_counts(Some(false));
+    assert_eq!((groups, merge_groups, passive), (1, 0, 0));
+    assert!(clock > 0);
+    assert!(weather > 0);
+}
+
 fn run_test_widgets_grouping_spacing_contract() {
     let mut config = test_config();
     config.bar.spacing = 18;
@@ -2267,6 +2318,16 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_grouping_system_merge,
         "widgets.grouping.system-merge",
         run_test_widgets_grouping_system_merge
+    ),
+    (
+        test_ui_regression_widgets_grouping_clock_weather_merge,
+        "widgets.grouping.clock-weather-merge",
+        run_test_widgets_grouping_clock_weather_merge
+    ),
+    (
+        test_ui_regression_widgets_grouping_clock_weather_opt_out,
+        "widgets.grouping.clock-weather-opt-out",
+        run_test_widgets_grouping_clock_weather_explicit_opt_out
     ),
     (
         test_ui_regression_widgets_grouping_spacing,

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1373,6 +1373,69 @@ fn run_test_widgets_grouping_clock_spacer_merge_opt_out_ignored() {
     assert!(spacer > 0);
 }
 
+fn right_section_child_widths(config: &Config) -> Vec<i32> {
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(config);
+    let right_section = bar
+        .section("right")
+        .expect("bar should build a right section");
+    let mut widths = Vec::new();
+    let mut child = right_section.first_child();
+    while let Some(widget) = child {
+        widths.push(bounds_in_window(&widget, &window).2);
+        child = widget.next_sibling();
+    }
+
+    window.close();
+    flush_gtk();
+    widths
+}
+
+fn config_with_quick_settings_group() -> Config {
+    let mut config = test_config();
+    config.widgets.left = Vec::new();
+    config.widgets.center = Vec::new();
+    config.widgets.right = vec![vibepanel_core::config::WidgetPlacement::Group {
+        group: vec!["quick_settings".to_string(), "custom-vpn".to_string()],
+    }];
+
+    let mut custom_vpn = vibepanel_core::config::WidgetOptions::default();
+    custom_vpn
+        .options
+        .insert("label".to_string(), toml::Value::String("VPN".to_string()));
+    config
+        .widgets
+        .widget_configs
+        .insert("custom-vpn".to_string(), custom_vpn);
+
+    config
+}
+
+fn run_test_widgets_grouping_spacer_does_not_expand_sibling_group() {
+    let compact_config = config_with_quick_settings_group();
+    let compact_widths = right_section_child_widths(&compact_config);
+    assert_eq!(compact_widths.len(), 1);
+    let compact_quick_settings_width = compact_widths[0];
+
+    let mut spaced_config = config_with_quick_settings_group();
+    spaced_config.widgets.right.insert(
+        0,
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["clock".to_string(), "spacer".to_string()],
+        },
+    );
+
+    let spaced_widths = right_section_child_widths(&spaced_config);
+    assert_eq!(spaced_widths.len(), 2);
+    assert!(
+        spaced_widths[0] > compact_quick_settings_width,
+        "the group containing the flexible spacer should absorb spare width"
+    );
+    assert_eq!(
+        spaced_widths[1], compact_quick_settings_width,
+        "a sibling group without spacer should stay at its natural width"
+    );
+}
+
 fn run_test_widgets_grouping_spacing_contract() {
     let mut config = test_config();
     config.bar.spacing = 18;
@@ -2389,6 +2452,11 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_grouping_clock_spacer_merge_opt_out_ignored,
         "widgets.grouping.clock-spacer-merge-opt-out-ignored",
         run_test_widgets_grouping_clock_spacer_merge_opt_out_ignored
+    ),
+    (
+        test_ui_regression_widgets_grouping_spacer_does_not_expand_sibling_group,
+        "widgets.grouping.spacer-does-not-expand-sibling-group",
+        run_test_widgets_grouping_spacer_does_not_expand_sibling_group
     ),
     (
         test_ui_regression_widgets_grouping_spacing,

--- a/crates/vibepanel/src/widgets/calendar_popover.rs
+++ b/crates/vibepanel/src/widgets/calendar_popover.rs
@@ -300,10 +300,11 @@ pub fn build_clock_calendar_popover(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::styles::weather_popover as wp;
     use crate::ui_regression_test_support::{find_descendant_with_class, init_gtk_or_skip};
 
     #[test]
-    fn clock_calendar_week_number_header_tracks_config() {
+    fn clock_calendar_popover_tracks_config() {
         if !init_gtk_or_skip("clock calendar popover test", None) {
             return;
         }
@@ -321,5 +322,14 @@ mod tests {
             find_descendant_with_class(&without_week_numbers, "week-number-header").is_none(),
             "calendar popover should omit the week-number header when week numbers are disabled"
         );
+
+        let (without_weather, _refresh, weather_refresh) =
+            build_clock_calendar_popover(false, false);
+        assert!(weather_refresh.is_none());
+        assert!(find_descendant_with_class(&without_weather, wp::EMPTY).is_none());
+
+        let (with_weather, _refresh, weather_refresh) = build_clock_calendar_popover(false, true);
+        assert!(weather_refresh.is_some());
+        assert!(find_descendant_with_class(&with_weather, wp::EMPTY).is_some());
     }
 }

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -117,8 +117,12 @@ pub(crate) struct CalendarWeatherPopoverBinding {
 }
 
 impl CalendarWeatherPopoverBinding {
-    pub(crate) fn new_for_menu(menu_handle: &Rc<MenuHandle>, show_week_numbers: bool) -> Self {
-        let weather_callback_id = wire_clock_popover(menu_handle, show_week_numbers, true);
+    pub(crate) fn new_for_menu(
+        menu_handle: &Rc<MenuHandle>,
+        show_week_numbers: bool,
+        show_weather: bool,
+    ) -> Self {
+        let weather_callback_id = wire_clock_popover(menu_handle, show_week_numbers, show_weather);
         Self {
             weather_callback_id,
         }

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -21,7 +21,7 @@ use crate::services::sleep_watcher::SleepWatcher;
 use crate::services::weather::WeatherService;
 use crate::styles::widget as wgt;
 use crate::widgets::WidgetConfig;
-use crate::widgets::base::BaseWidget;
+use crate::widgets::base::{BaseWidget, MenuHandle};
 use crate::widgets::calendar_popover::build_clock_calendar_popover;
 use crate::widgets::warn_unknown_options;
 
@@ -111,6 +111,28 @@ impl Default for ClockConfig {
     }
 }
 
+/// Shared calendar/weather popover binding used by clock+weather merge groups.
+pub(crate) struct CalendarWeatherPopoverBinding {
+    weather_callback_id: Option<CallbackId>,
+}
+
+impl CalendarWeatherPopoverBinding {
+    pub(crate) fn new_for_menu(menu_handle: &Rc<MenuHandle>, show_week_numbers: bool) -> Self {
+        let weather_callback_id = wire_clock_popover(menu_handle, show_week_numbers, true);
+        Self {
+            weather_callback_id,
+        }
+    }
+}
+
+impl Drop for CalendarWeatherPopoverBinding {
+    fn drop(&mut self) {
+        if let Some(id) = self.weather_callback_id.take() {
+            WeatherService::global().disconnect(id);
+        }
+    }
+}
+
 /// Clock widget that displays and updates the current time.
 pub struct ClockWidget {
     /// Shared base widget container.
@@ -135,6 +157,16 @@ impl ClockWidget {
     /// Create a new clock widget with the given configuration.
     pub fn new(config: ClockConfig) -> Self {
         let base = BaseWidget::new(&[wgt::CLOCK]);
+        Self::build(config, base, true)
+    }
+
+    /// Create a passive clock widget for use in a merge group.
+    pub fn new_passive(config: ClockConfig) -> Self {
+        let base = BaseWidget::new_passive(&[wgt::CLOCK]);
+        Self::build(config, base, false)
+    }
+
+    fn build(config: ClockConfig, base: BaseWidget, create_popover: bool) -> Self {
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
 
         let label = base.add_label(Some("--:--"), &[wgt::CLOCK_LABEL]);
@@ -146,44 +178,9 @@ impl ClockWidget {
         }
 
         let show_week_numbers = config.show_week_numbers;
-        let show_weather = config.show_weather;
-
-        // Shared slots populated by the popover builder on first open. Calendar
-        // refresh runs on show; weather refresh runs on weather service updates
-        // so the calendar month is not reset while the popover is open.
-        type RefreshSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
-        let calendar_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
-        let weather_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
-
-        let calendar_refresh_for_builder = calendar_refresh_slot.clone();
-        let weather_refresh_for_builder = weather_refresh_slot.clone();
-        let menu_handle = base.create_menu(move || {
-            let (widget, calendar_refresh, weather_refresh) =
-                build_clock_calendar_popover(show_week_numbers, show_weather);
-            *calendar_refresh_for_builder.borrow_mut() = Some(calendar_refresh);
-            *weather_refresh_for_builder.borrow_mut() = weather_refresh;
-            widget
-        });
-
-        // Reuse the calendar widget across open/close cycles to avoid
-        // unbounded memory growth from GTK4.
-        menu_handle.set_reuse_content(true);
-        menu_handle.set_on_show(move || {
-            if let Some(ref cb) = *calendar_refresh_slot.borrow() {
-                cb();
-            }
-        });
-
-        let weather_callback_id = if show_weather {
-            let menu_handle = Rc::clone(&menu_handle);
-            let weather_refresh_slot = weather_refresh_slot.clone();
-            Some(WeatherService::global().connect(move |_| {
-                if menu_handle.is_visible()
-                    && let Some(ref cb) = *weather_refresh_slot.borrow()
-                {
-                    cb();
-                }
-            }))
+        let weather_callback_id = if create_popover {
+            let menu_handle = base.create_menu(|| gtk4::Label::new(None).upcast());
+            wire_clock_popover(&menu_handle, show_week_numbers, config.show_weather)
         } else {
             None
         };
@@ -268,6 +265,51 @@ impl ClockWidget {
             self.scheduling_mode,
             Rc::clone(&self.timer_source),
         );
+    }
+}
+
+type RefreshSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+
+fn wire_clock_popover(
+    menu_handle: &Rc<MenuHandle>,
+    show_week_numbers: bool,
+    show_weather: bool,
+) -> Option<CallbackId> {
+    let calendar_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
+    let weather_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
+
+    let calendar_refresh_for_builder = calendar_refresh_slot.clone();
+    let weather_refresh_for_builder = weather_refresh_slot.clone();
+    menu_handle.set_builder(move || {
+        let (widget, calendar_refresh, weather_refresh) =
+            build_clock_calendar_popover(show_week_numbers, show_weather);
+        *calendar_refresh_for_builder.borrow_mut() = Some(calendar_refresh);
+        *weather_refresh_for_builder.borrow_mut() = weather_refresh;
+        widget
+    });
+
+    // Reuse the calendar widget across open/close cycles to avoid
+    // unbounded memory growth from GTK4.
+    menu_handle.set_reuse_content(true);
+    let calendar_refresh_for_show = calendar_refresh_slot.clone();
+    menu_handle.set_on_show(move || {
+        if let Some(ref cb) = *calendar_refresh_for_show.borrow() {
+            cb();
+        }
+    });
+
+    if show_weather {
+        let menu_handle = Rc::clone(menu_handle);
+        let weather_refresh_slot = weather_refresh_slot.clone();
+        Some(WeatherService::global().connect(move |_| {
+            if menu_handle.is_visible()
+                && let Some(ref cb) = *weather_refresh_slot.borrow()
+            {
+                cb();
+            }
+        }))
+    } else {
+        None
     }
 }
 
@@ -518,6 +560,12 @@ mod tests {
         let entry = make_widget_entry("clock", options);
         let config = ClockConfig::from_entry(&entry);
         assert!(config.show_weather);
+
+        let mut options = HashMap::new();
+        options.insert("show_weather".to_string(), Value::Boolean(false));
+        let entry = make_widget_entry("clock", options);
+        let config = ClockConfig::from_entry(&entry);
+        assert!(!config.show_weather);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/mod.rs
+++ b/crates/vibepanel/src/widgets/mod.rs
@@ -57,6 +57,7 @@ pub mod quick_settings;
 pub use base::BaseWidget;
 pub(crate) use base::{MenuHandle, RippleHandle, trigger_ripple_from_gesture};
 pub use battery::{BatteryConfig, BatteryWidget};
+pub(crate) use clock::CalendarWeatherPopoverBinding;
 pub use clock::{ClockConfig, ClockWidget};
 pub use media::{MediaConfig, MediaWidget};
 pub use notifications::{NotificationsConfig, NotificationsWidget};
@@ -104,6 +105,7 @@ pub(crate) struct EdgeInteraction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PopoverKind {
     System,
+    CalendarWeather,
     /// Widget has no popover or its popover is not mergeable.
     Unmergeable,
 }
@@ -112,6 +114,7 @@ pub(crate) enum PopoverKind {
 pub(crate) fn popover_kind_for(widget_name: &str) -> PopoverKind {
     match widget_name {
         "cpu" | "memory" | "gpu" | "network_speed" => PopoverKind::System,
+        "clock" | "weather" => PopoverKind::CalendarWeather,
         _ => PopoverKind::Unmergeable,
     }
 }
@@ -416,17 +419,7 @@ impl WidgetFactory {
                 let root = network.widget().clone().upcast::<Widget>();
                 Some(BuiltWidget::new(root, network))
             }
-            "spacer" => {
-                let cfg = SpacerConfig::from_entry(entry);
-                let spacer = SpacerWidget::new(cfg);
-                let widget = spacer.widget().clone();
-                // Passive spacers inside merge groups need the same structural
-                // classes as other passive widgets so margin / hover rules apply.
-                widget.add_css_class(class::WIDGET_ITEM);
-                widget.add_css_class(class::PASSIVE);
-                let root = widget.upcast::<Widget>();
-                Some(BuiltWidget::new(root, spacer))
-            }
+            "spacer" => Self::build_passive_spacer(entry),
             name => {
                 warn!(
                     "build_passive called for unsupported widget type: '{}'",
@@ -435,6 +428,44 @@ impl WidgetFactory {
                 None
             }
         }
+    }
+
+    /// Build a clock/weather widget in passive mode for a calendar/weather merge group.
+    pub(crate) fn build_calendar_weather_passive(entry: &WidgetEntry) -> Option<BuiltWidget> {
+        match entry.name.as_str() {
+            "clock" => {
+                let cfg = ClockConfig::from_entry(entry);
+                let clock = ClockWidget::new_passive(cfg);
+                let root = clock.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget::new(root, clock))
+            }
+            "weather" => {
+                let cfg = WeatherConfig::from_entry(entry);
+                let weather = WeatherWidget::new_passive(cfg);
+                let root = weather.widget().clone().upcast::<Widget>();
+                Some(BuiltWidget::new(root, weather))
+            }
+            "spacer" => Self::build_passive_spacer(entry),
+            name => {
+                warn!(
+                    "build_calendar_weather_passive called for unsupported widget type: '{}'",
+                    name
+                );
+                None
+            }
+        }
+    }
+
+    fn build_passive_spacer(entry: &WidgetEntry) -> Option<BuiltWidget> {
+        let cfg = SpacerConfig::from_entry(entry);
+        let spacer = SpacerWidget::new(cfg);
+        let widget = spacer.widget().clone();
+        // Passive spacers inside merge groups need the same structural classes
+        // as other passive widgets so margin / hover rules apply.
+        widget.add_css_class(class::WIDGET_ITEM);
+        widget.add_css_class(class::PASSIVE);
+        let root = widget.upcast::<Widget>();
+        Some(BuiltWidget::new(root, spacer))
     }
 }
 
@@ -486,7 +517,8 @@ mod tests {
 
     #[test]
     fn popover_kind_non_system_widgets() {
-        assert_eq!(popover_kind_for("clock"), PopoverKind::Unmergeable);
+        assert_eq!(popover_kind_for("clock"), PopoverKind::CalendarWeather);
+        assert_eq!(popover_kind_for("weather"), PopoverKind::CalendarWeather);
         assert_eq!(popover_kind_for("battery"), PopoverKind::Unmergeable);
         assert_eq!(popover_kind_for("media"), PopoverKind::Unmergeable);
         assert_eq!(popover_kind_for("unknown"), PopoverKind::Unmergeable);

--- a/crates/vibepanel/src/widgets/weather.rs
+++ b/crates/vibepanel/src/widgets/weather.rs
@@ -5,7 +5,6 @@
 
 use gtk4::Label;
 use gtk4::prelude::*;
-use std::rc::Rc;
 use std::time::{Duration, SystemTime};
 use vibepanel_core::config::{WeatherUnits, WeatherWindUnits, WidgetEntry};
 
@@ -68,6 +67,16 @@ impl WeatherWidget {
     /// Create a new weather widget with the given presentation config.
     pub fn new(config: WeatherConfig) -> Self {
         let base = BaseWidget::new(&[widget::WEATHER]);
+        Self::build(config, base, true)
+    }
+
+    /// Create a passive weather widget for use in a merge group.
+    pub fn new_passive(config: WeatherConfig) -> Self {
+        let base = BaseWidget::new_passive(&[widget::WEATHER]);
+        Self::build(config, base, false)
+    }
+
+    fn build(config: WeatherConfig, base: BaseWidget, create_popover: bool) -> Self {
         base.set_tooltip("Weather: loading...");
 
         let icon_handle = base.add_icon("weather-unknown", &[widget::WEATHER_ICON]);
@@ -76,10 +85,15 @@ impl WeatherWidget {
 
         icon_handle.widget().set_visible(config.show_icon);
 
-        let menu_handle = base.create_menu(move || {
-            crate::widgets::weather_popover::build_weather_content_reactive().0
-        });
-        menu_handle.set_reuse_content(true);
+        let menu_handle = if create_popover {
+            let menu_handle = base.create_menu(move || {
+                crate::widgets::weather_popover::build_weather_content_reactive().0
+            });
+            menu_handle.set_reuse_content(true);
+            Some(menu_handle)
+        } else {
+            None
+        };
 
         let service = WeatherService::global();
         let weather_callback_id = {
@@ -88,7 +102,7 @@ impl WeatherWidget {
             let label = label.clone();
             let show_icon = config.show_icon;
             let format = config.format.clone();
-            let menu_handle = Rc::clone(&menu_handle);
+            let menu_handle = menu_handle.clone();
 
             service.connect(move |snapshot: &WeatherSnapshot| {
                 update_weather_widget(
@@ -100,7 +114,9 @@ impl WeatherWidget {
                     is_vertical,
                     snapshot,
                 );
-                menu_handle.refresh_if_visible();
+                if let Some(menu_handle) = menu_handle.as_ref() {
+                    menu_handle.refresh_if_visible();
+                }
             })
         };
 


### PR DESCRIPTION
Automatically merges the group when clock and weather is in the same group, as well as enabling the weather data in the calendar popover. I.e
```toml
center = [ { group = ["clock", "weather"] } ]
```
If you don't want them merged for some reason you can opt out with

```toml
[widgets.clock]
show_weather = false
```

Also a couple of spacer related bugs:
- Spacers in a group would mark all groups in that section as "flexible" so they would expand even if they didn't have spacers
- Spacers in bars with no center section wouldn't automatically take all available space. 

Closes #167 