### PR TITLE
fix(media): show mpv-mpris embedded art and crisp fallback icon

### DIFF
--- a/crates/vibepanel/src/services/media.rs
+++ b/crates/vibepanel/src/services/media.rs
@@ -104,7 +104,8 @@ pub struct MediaMetadata {
     pub artist: Option<String>,
     /// Album name (xesam:album).
     pub album: Option<String>,
-    /// Album art URL (mpris:artUrl) - can be file:// or http(s)://.
+    /// Album art URL (mpris:artUrl) - can be file://, http(s)://, or a
+    /// data: URI (e.g. base64-encoded embedded cover art from mpv-mpris).
     pub art_url: Option<String>,
     /// Track URL (xesam:url) - useful for identifying web players.
     pub url: Option<String>,

--- a/crates/vibepanel/src/widgets/media.rs
+++ b/crates/vibepanel/src/widgets/media.rs
@@ -418,6 +418,7 @@ struct WidgetUpdateContext<'a> {
     status_icon: &'a Option<IconHandle>,
     player_icon: &'a Option<Image>,
     art_picture: &'a Option<RoundedPicture>,
+    art_fallback_icon: &'a Option<Image>,
     text_labels: &'a Vec<Rc<MarqueeLabel>>,
     controls: &'a Option<ControlsHandle>,
     template_elements: &'a [TemplateElement],
@@ -434,6 +435,7 @@ struct CallbackWidgetRefs {
     status_icon: Option<IconHandle>,
     player_icon: Option<Image>,
     art_picture: Option<RoundedPicture>,
+    art_fallback_icon: Option<Image>,
     text_labels: Vec<Rc<MarqueeLabel>>,
     controls: Option<ControlsHandle>,
     template_elements: Vec<TemplateElement>,
@@ -450,6 +452,7 @@ impl CallbackWidgetRefs {
             status_icon: &self.status_icon,
             player_icon: &self.player_icon,
             art_picture: &self.art_picture,
+            art_fallback_icon: &self.art_fallback_icon,
             text_labels: &self.text_labels,
             controls: &self.controls,
             template_elements: &self.template_elements,
@@ -550,6 +553,8 @@ impl MediaWidget {
         let template_elements = template_elements_for_orientation(&config.template, is_vertical);
 
         let mut art_picture: Option<RoundedPicture> = None;
+        let mut art_fallback_icon: Option<Image> = None;
+        let mut art_overlay: Option<Overlay> = None;
         let mut player_icon: Option<Image> = None;
         let mut status_icon: Option<IconHandle> = None;
         let mut controls: Option<ControlsHandle> = None;
@@ -566,9 +571,27 @@ impl MediaWidget {
             let picture = RoundedPicture::new();
             picture.set_pixel_size(art_size);
             picture.set_corner_radius(corner_radius);
-            picture.add_css_class(media::ART_SMALL);
             picture.set_visible(false);
+
+            // Fallback app icon (shown when no art): a live icon-theme `Image`
+            // resolves crisply at the bar's pixel size/scale, unlike a baked
+            // paintable upscaled inside RoundedPicture. See show_player_icon_in_art.
+            let fallback_icon = Image::new();
+            fallback_icon.set_pixel_size(art_size);
+            fallback_icon.set_visible(false);
+
+            // Overlay both in one slot, toggling visibility. The size-request
+            // stops the slot collapsing when only the overlay child is shown.
+            let overlay = Overlay::new();
+            overlay.add_css_class(media::ART_SMALL);
+            overlay.set_size_request(art_size, art_size);
+            overlay.set_child(Some(&picture));
+            overlay.add_overlay(&fallback_icon);
+            overlay.set_measure_overlay(&fallback_icon, true);
+
             art_picture = Some(picture);
+            art_fallback_icon = Some(fallback_icon);
+            art_overlay = Some(overlay);
         }
 
         if template_elements
@@ -637,8 +660,8 @@ impl MediaWidget {
                             }
                         }
                         WidgetToken::Art => {
-                            if let Some(picture) = &art_picture {
-                                base.content().append(picture);
+                            if let Some(overlay) = &art_overlay {
+                                base.content().append(overlay);
                             }
                         }
                         WidgetToken::PlayerIcon => {
@@ -867,6 +890,7 @@ impl MediaWidget {
             status_icon: status_icon.clone(),
             player_icon: player_icon.clone(),
             art_picture: art_picture.clone(),
+            art_fallback_icon: art_fallback_icon.clone(),
             text_labels,
             controls: controls.clone(),
             template_elements,
@@ -886,6 +910,7 @@ impl MediaWidget {
             widget_refs.status_icon.as_ref(),
             widget_refs.player_icon.as_ref(),
             widget_refs.art_picture.as_ref(),
+            widget_refs.art_fallback_icon.as_ref(),
             widget_refs.controls.as_ref(),
         );
 
@@ -947,6 +972,7 @@ impl Drop for MediaWidget {
 }
 
 /// Actually hide the media bar widget (called from timeout or startup).
+#[allow(clippy::too_many_arguments)]
 fn perform_hide(
     container: &gtk4::Box,
     text_labels: &[Rc<MarqueeLabel>],
@@ -954,6 +980,7 @@ fn perform_hide(
     status_icon: Option<&IconHandle>,
     player_icon: Option<&Image>,
     art_picture: Option<&RoundedPicture>,
+    art_fallback_icon: Option<&Image>,
     controls: Option<&ControlsHandle>,
 ) {
     if empty_text.is_empty() {
@@ -976,6 +1003,9 @@ fn perform_hide(
         }
         if let Some(image) = art_picture {
             image.set_visible(false);
+        }
+        if let Some(icon) = art_fallback_icon {
+            icon.set_visible(false);
         }
         if let Some(ctrl) = controls {
             ctrl.container.set_visible(false);
@@ -1024,6 +1054,7 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
         let status_icon = ctx.status_icon.clone();
         let player_icon = ctx.player_icon.clone();
         let art_picture = ctx.art_picture.clone();
+        let art_fallback_icon = ctx.art_fallback_icon.clone();
         let controls = ctx.controls.clone();
         let bar_viz = ctx.bar_visualizer.clone();
 
@@ -1047,6 +1078,7 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
                     status_icon.as_ref(),
                     player_icon.as_ref(),
                     art_picture.as_ref(),
+                    art_fallback_icon.as_ref(),
                     controls.as_ref(),
                 );
             });
@@ -1133,9 +1165,8 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
     // updates below — stale-but-recent track info is preferable to blank content
     // during the brief transition window.
     //
-    // Note: this also prevents art_url=None from reaching `prepare_art_load`,
-    // which has its own None-refusal logic as a second layer of defense against
-    // flashing fallback art during track switches.
+    // Album art has its own debounce, so genuine no-art tracks can still clear
+    // stale art to the fallback without flashing during brief track switches.
     if !has_metadata {
         return;
     }
@@ -1153,9 +1184,16 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
     if let Some(picture) = ctx.art_picture {
         let art_url = snapshot.metadata.art_url.as_deref();
 
-        let on_success = || {};
+        // Hide the fallback icon on success so it doesn't overlay the art.
+        let fallback_for_success = ctx.art_fallback_icon.clone();
+        let on_success = move || {
+            if let Some(icon) = &fallback_for_success {
+                icon.set_visible(false);
+            }
+        };
 
         let picture_for_failure = picture.clone();
+        let fallback_for_failure = ctx.art_fallback_icon.clone();
         let player_id = snapshot.player_id.clone();
         let art_state_for_failure = ctx.art_state.clone();
         let on_failure = move || {
@@ -1164,6 +1202,7 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
             let generation = art_state_for_failure.borrow().generation;
             show_player_icon_in_art(
                 &picture_for_failure,
+                fallback_for_failure.as_ref(),
                 player_id.as_deref(),
                 &art_state_for_failure,
                 generation,
@@ -1210,8 +1249,14 @@ fn update_widgets_from_snapshot_impl(ctx: &WidgetUpdateContext<'_>, snapshot: &M
 }
 
 /// Show the player's app icon as fallback for album art.
+///
+/// Renders into a live icon-theme [`Image`] (mirroring the window_title widget)
+/// rather than baking a fixed-size paintable into the [`RoundedPicture`]. GTK
+/// re-resolves the icon at the widget's actual pixel size and scale factor, so
+/// the result stays crisp on HiDPI instead of being upscaled (issue #172).
 fn show_player_icon_in_art(
     art_picture: &RoundedPicture,
+    fallback_icon: Option<&Image>,
     player_id: Option<&str>,
     art_state: &Rc<RefCell<ArtState>>,
     generation: u64,
@@ -1224,27 +1269,18 @@ fn show_player_icon_in_art(
         .map(|id| resolve_app_icon_name(id, media::ICON_AUDIO_GENERIC))
         .unwrap_or_else(|| media::ICON_AUDIO_GENERIC.to_string());
 
-    let Some(display) = gtk4::gdk::Display::default() else {
-        warn!("No display available for icon lookup");
-        art_picture.set_visible(false);
+    art_picture.set_visible(false);
+
+    let Some(icon) = fallback_icon else {
         return;
     };
-    let icon_theme = gtk4::IconTheme::for_display(&display);
 
     let config = ConfigManager::global();
     let art_size = (config.bar_size() as f64 * ART_DISPLAY_SCALE) as i32;
 
-    let paintable = icon_theme.lookup_icon(
-        &icon_name,
-        &[],
-        art_size,
-        1,
-        gtk4::TextDirection::None,
-        gtk4::IconLookupFlags::empty(),
-    );
-
-    art_picture.set_paintable(Some(&paintable));
-    art_picture.set_visible(true);
+    icon.set_pixel_size(art_size);
+    icon.set_icon_name(Some(&icon_name));
+    icon.set_visible(true);
 }
 
 fn build_tooltip(snapshot: &MediaSnapshot) -> String {

--- a/crates/vibepanel/src/widgets/media_components.rs
+++ b/crates/vibepanel/src/widgets/media_components.rs
@@ -175,9 +175,9 @@ impl ArtState {
     /// any cached URL is invalidated so that a `None` art URL correctly clears
     /// stale art from the previous player.
     ///
-    /// Within the same player, returns `false` when the URL is unchanged or when
-    /// it momentarily became `None` (e.g. during a track switch) — in that case
-    /// we keep showing the previous album art to avoid flashing a placeholder.
+    /// Within the same player, returns `false` when the URL is unchanged. A
+    /// `Some -> None` transition is still scheduled through the debounce timer
+    /// so tracks that genuinely lack album art clear stale art to the fallback.
     pub fn prepare_art_load(&mut self, new_url: Option<&str>, player_id: Option<&str>) -> bool {
         let player_changed = self.current_player_id.as_deref() != player_id;
         if player_changed {
@@ -191,9 +191,6 @@ impl ArtState {
         }
 
         if self.current_url.as_deref() == new_url {
-            return false;
-        }
-        if new_url.is_none() && self.current_url.is_some() {
             return false;
         }
         self.cancellable.cancel();
@@ -799,9 +796,69 @@ pub fn load_art_from_url<S, F>(
                 }
             }
         });
+    } else if url.starts_with("data:") {
+        // mpv-mpris emits embedded cover art as a base64 data URI. Decoded
+        // synchronously — cover art is small enough not to stall the main loop.
+        // load_texture_from_bytes has no generation guard, so check here.
+        if art_state.borrow().generation != generation {
+            return;
+        }
+
+        match decode_data_uri(url) {
+            Some(bytes) => {
+                load_texture_from_bytes(
+                    &bytes,
+                    &picture,
+                    &truncate_uri(url),
+                    &on_success,
+                    &on_failure,
+                );
+            }
+            None => {
+                debug!("Unsupported or malformed data URI: {}", truncate_uri(url));
+                on_failure();
+            }
+        }
     } else {
         warn!("Unknown album art URL scheme: {}", url);
         on_failure();
+    }
+}
+
+/// Decode a base64 `data:` URI into raw bytes, or `None` if it isn't a usable
+/// base64 data URI. Image-format validity is left to the decoder downstream.
+fn decode_data_uri(url: &str) -> Option<Vec<u8>> {
+    let rest = url.strip_prefix("data:")?;
+    let comma_idx = rest.find(',')?;
+    let (header, payload_with_comma) = rest.split_at(comma_idx);
+    let payload = &payload_with_comma[1..]; // skip the comma
+
+    // The mediatype may carry params (e.g. `image/jpeg;charset=utf-8;base64`),
+    // so look for a `base64` token among the `;`-separated segments.
+    let is_base64 = header
+        .split(';')
+        .any(|tok| tok.eq_ignore_ascii_case("base64"));
+    if !is_base64 || payload.is_empty() {
+        return None;
+    }
+
+    // glib::base64_decode returns Vec<u8> with no error channel; empty == fail.
+    let bytes = glib::base64_decode(payload);
+    if bytes.is_empty() { None } else { Some(bytes) }
+}
+
+/// Truncate a (potentially huge) URI for safe logging — data URIs can be
+/// megabytes of base64.
+fn truncate_uri(url: &str) -> String {
+    const MAX: usize = 64;
+    if url.len() <= MAX {
+        url.to_string()
+    } else {
+        let mut end = MAX;
+        while !url.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…({} bytes)", &url[..end], url.len())
     }
 }
 
@@ -891,15 +948,11 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_art_load_ignores_none_transition() {
+    fn test_prepare_art_load_some_to_none_clears_art() {
         let mut state = ArtState::new();
         state.current_url = Some("http://example.com/art.jpg".into());
-        assert!(!state.prepare_art_load(None, None));
-        assert_eq!(
-            state.current_url.as_deref(),
-            Some("http://example.com/art.jpg"),
-            "stale art URL should be preserved"
-        );
+        assert!(state.prepare_art_load(None, None));
+        assert_eq!(state.current_url, None);
     }
 
     #[test]
@@ -948,16 +1001,49 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_art_load_same_player_ignores_none() {
+    fn test_prepare_art_load_same_player_clears_none() {
         let mut state = ArtState::new();
         state.current_url = Some("http://example.com/art.jpg".into());
         state.current_player_id = Some("spotify".into());
 
-        // Same player, art momentarily None — should keep stale art.
-        assert!(!state.prepare_art_load(None, Some("spotify")));
+        // Same player, genuine no-art track should clear stale art after debounce.
+        assert!(state.prepare_art_load(None, Some("spotify")));
+        assert_eq!(state.current_url, None);
+    }
+
+    #[test]
+    fn test_decode_data_uri_basic_base64() {
+        // base64("hello") = "aGVsbG8="
         assert_eq!(
-            state.current_url.as_deref(),
-            Some("http://example.com/art.jpg"),
+            decode_data_uri("data:image/jpeg;base64,aGVsbG8=").unwrap(),
+            b"hello"
         );
+    }
+
+    #[test]
+    fn test_decode_data_uri_base64_token_not_last_and_mixed_case() {
+        // Guards the `;`-split scan: `base64` is neither the final token nor
+        // lowercase, so a naive `ends_with("base64")` would wrongly reject it.
+        assert_eq!(
+            decode_data_uri("data:image/jpeg;charset=utf-8;BASE64,aGVsbG8=").unwrap(),
+            b"hello"
+        );
+    }
+
+    #[test]
+    fn test_decode_data_uri_rejects_non_base64() {
+        // Percent-encoded (non-base64) data URIs are unsupported.
+        assert!(decode_data_uri("data:image/jpeg,hello").is_none());
+    }
+
+    #[test]
+    fn test_decode_data_uri_rejects_no_comma() {
+        // Guards the `find(',')?` — without it, `[1..]` would panic.
+        assert!(decode_data_uri("data:image/jpeg;base64").is_none());
+    }
+
+    #[test]
+    fn test_decode_data_uri_rejects_empty_payload() {
+        assert!(decode_data_uri("data:image/jpeg;base64,").is_none());
     }
 }


### PR DESCRIPTION
Loads embedded art from mpv-mpris and makes the fallback app icon crisper. Closes #172 

<img width="493" height="153" alt="image" src="https://github.com/user-attachments/assets/0a14daa8-a264-4c56-af84-b43541fa8c43" />

<img width="508" height="147" alt="image" src="https://github.com/user-attachments/assets/e3a9c6f4-f239-4799-b99d-7f269e1a93db" />
