### PR TITLE
feat(cpu, memory, gpu): add stable width option to reduce visual jitter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,6 +57,10 @@ background_opacity = 1.0
 #   [widgets.media]
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)
 #
+#   [widgets.cpu]
+#   reserve_width = false # Disable reserved width for changing metric labels
+#   # Also supported by [widgets.memory] and [widgets.gpu]
+#
 #   [widgets.notifications]
 #   toast_position = "top-right"  # "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
 #

--- a/config.toml
+++ b/config.toml
@@ -58,7 +58,7 @@ background_opacity = 1.0
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)
 #
 #   [widgets.cpu]
-#   reserve_width = false # Disable reserved width for changing metric labels
+#   stable_width = false # Disable width stabilization; default stabilizes common 2-digit metric values
 #   # Also supported by [widgets.memory] and [widgets.gpu]
 #
 #   [widgets.notifications]

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -26,6 +26,7 @@ use crate::widgets::{WidgetConfig, warn_unknown_options};
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_SHOW_PERCENTAGE: bool = true;
+const DEFAULT_RESERVE_WIDTH: bool = true;
 
 /// CPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -62,11 +63,17 @@ pub struct CpuConfig {
     pub show_percentage: bool,
     /// Display format for CPU metrics.
     pub format: CpuFormat,
+    /// Reserve label width for common metric values to reduce layout jitter.
+    pub reserve_width: bool,
 }
 
 impl WidgetConfig for CpuConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("cpu", entry, &["show_icon", "show_percentage", "format"]);
+        warn_unknown_options(
+            "cpu",
+            entry,
+            &["show_icon", "show_percentage", "format", "reserve_width"],
+        );
 
         let show_icon = entry
             .options
@@ -87,10 +94,17 @@ impl WidgetConfig for CpuConfig {
             .map(CpuFormat::from_str)
             .unwrap_or_default();
 
+        let reserve_width = entry
+            .options
+            .get("reserve_width")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+
         Self {
             show_icon,
             show_percentage,
             format,
+            reserve_width,
         }
     }
 }
@@ -101,6 +115,7 @@ impl Default for CpuConfig {
             show_icon: DEFAULT_SHOW_ICON,
             show_percentage: DEFAULT_SHOW_PERCENTAGE,
             format: CpuFormat::default(),
+            reserve_width: DEFAULT_RESERVE_WIDTH,
         }
     }
 }
@@ -134,7 +149,13 @@ impl CpuWidget {
 
         let icon_handle = base.add_icon("cpu-symbolic", &[widget::CPU_ICON]);
 
+        let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let percentage_label = base.add_label(None, &[widget::CPU_LABEL, class::VCENTER_CAPS]);
+        if let Some(width_chars) =
+            cpu_label_width(&config.format, config.reserve_width, is_vertical)
+        {
+            percentage_label.set_width_chars(width_chars);
+        }
 
         icon_handle.widget().set_visible(config.show_icon);
         percentage_label.set_visible(config.show_percentage);
@@ -147,7 +168,6 @@ impl CpuWidget {
             let show_icon = config.show_icon;
             let show_percentage = config.show_percentage;
             let format = config.format.clone();
-            let is_vertical = ConfigManager::global().bar_position().is_vertical();
             let popover_binding = popover_binding.clone();
 
             system_service.connect(move |snapshot: &SystemSnapshot| {
@@ -179,6 +199,21 @@ impl CpuWidget {
     pub(crate) fn edge_interaction(&self) -> Option<crate::widgets::EdgeInteraction> {
         self.base.edge_interaction()
     }
+}
+
+fn cpu_label_width(format: &CpuFormat, reserve_width: bool, is_vertical: bool) -> Option<i32> {
+    if !reserve_width {
+        return None;
+    }
+
+    Some(match (format, is_vertical) {
+        (CpuFormat::Usage, false) => 3,       // 99%
+        (CpuFormat::Usage, true) => 2,        // 99
+        (CpuFormat::Temperature, false) => 4, // 99°C
+        (CpuFormat::Temperature, true) => 3,  // 99°
+        (CpuFormat::Both, false) => 8,        // 99% 99°C
+        (CpuFormat::Both, true) => 3,         // widest line: 99°
+    })
 }
 
 impl Drop for CpuWidget {
@@ -288,6 +323,7 @@ mod tests {
         assert!(config.show_icon);
         assert!(config.show_percentage);
         assert_eq!(config.format, CpuFormat::Usage);
+        assert!(config.reserve_width);
     }
 
     #[test]
@@ -295,6 +331,7 @@ mod tests {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
         options.insert("show_percentage".to_string(), toml::Value::Boolean(true));
+        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("both".to_string()),
@@ -308,6 +345,7 @@ mod tests {
         assert!(!config.show_icon);
         assert!(config.show_percentage);
         assert_eq!(config.format, CpuFormat::Both);
+        assert!(!config.reserve_width);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/cpu.rs
+++ b/crates/vibepanel/src/widgets/cpu.rs
@@ -26,7 +26,7 @@ use crate::widgets::{WidgetConfig, warn_unknown_options};
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
 const DEFAULT_SHOW_PERCENTAGE: bool = true;
-const DEFAULT_RESERVE_WIDTH: bool = true;
+const DEFAULT_STABLE_WIDTH: bool = true;
 
 /// CPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -63,8 +63,8 @@ pub struct CpuConfig {
     pub show_percentage: bool,
     /// Display format for CPU metrics.
     pub format: CpuFormat,
-    /// Reserve label width for common metric values to reduce layout jitter.
-    pub reserve_width: bool,
+    /// Stabilize label width for common metric values to reduce layout jitter.
+    pub stable_width: bool,
 }
 
 impl WidgetConfig for CpuConfig {
@@ -72,7 +72,7 @@ impl WidgetConfig for CpuConfig {
         warn_unknown_options(
             "cpu",
             entry,
-            &["show_icon", "show_percentage", "format", "reserve_width"],
+            &["show_icon", "show_percentage", "format", "stable_width"],
         );
 
         let show_icon = entry
@@ -94,17 +94,17 @@ impl WidgetConfig for CpuConfig {
             .map(CpuFormat::from_str)
             .unwrap_or_default();
 
-        let reserve_width = entry
+        let stable_width = entry
             .options
-            .get("reserve_width")
+            .get("stable_width")
             .and_then(|v| v.as_bool())
-            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+            .unwrap_or(DEFAULT_STABLE_WIDTH);
 
         Self {
             show_icon,
             show_percentage,
             format,
-            reserve_width,
+            stable_width,
         }
     }
 }
@@ -115,7 +115,7 @@ impl Default for CpuConfig {
             show_icon: DEFAULT_SHOW_ICON,
             show_percentage: DEFAULT_SHOW_PERCENTAGE,
             format: CpuFormat::default(),
-            reserve_width: DEFAULT_RESERVE_WIDTH,
+            stable_width: DEFAULT_STABLE_WIDTH,
         }
     }
 }
@@ -151,8 +151,7 @@ impl CpuWidget {
 
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let percentage_label = base.add_label(None, &[widget::CPU_LABEL, class::VCENTER_CAPS]);
-        if let Some(width_chars) =
-            cpu_label_width(&config.format, config.reserve_width, is_vertical)
+        if let Some(width_chars) = cpu_label_width(&config.format, config.stable_width, is_vertical)
         {
             percentage_label.set_width_chars(width_chars);
         }
@@ -201,8 +200,8 @@ impl CpuWidget {
     }
 }
 
-fn cpu_label_width(format: &CpuFormat, reserve_width: bool, is_vertical: bool) -> Option<i32> {
-    if !reserve_width {
+fn cpu_label_width(format: &CpuFormat, stable_width: bool, is_vertical: bool) -> Option<i32> {
+    if !stable_width {
         return None;
     }
 
@@ -323,7 +322,7 @@ mod tests {
         assert!(config.show_icon);
         assert!(config.show_percentage);
         assert_eq!(config.format, CpuFormat::Usage);
-        assert!(config.reserve_width);
+        assert!(config.stable_width);
     }
 
     #[test]
@@ -331,7 +330,7 @@ mod tests {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
         options.insert("show_percentage".to_string(), toml::Value::Boolean(true));
-        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
+        options.insert("stable_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("both".to_string()),
@@ -345,7 +344,7 @@ mod tests {
         assert!(!config.show_icon);
         assert!(config.show_percentage);
         assert_eq!(config.format, CpuFormat::Both);
-        assert!(!config.reserve_width);
+        assert!(!config.stable_width);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -205,7 +205,7 @@ fn gpu_label_width(format: &GpuFormat, stable_width: bool, is_vertical: bool) ->
     }
 
     Some(match (format, is_vertical) {
-        (GpuFormat::Usage, false) => 4,       // 99% / Idle
+        (GpuFormat::Usage, false) => 3,       // 99%
         (GpuFormat::Usage, true) => 2,        // 99
         (GpuFormat::Temperature, false) => 4, // 99°C
         (GpuFormat::Temperature, true) => 3,  // 99°
@@ -383,6 +383,12 @@ mod tests {
         assert!(!config.show_icon);
         assert_eq!(config.format, GpuFormat::Temperature);
         assert!(!config.stable_width);
+    }
+
+    #[test]
+    fn test_gpu_label_width_usage_matches_percentage_width() {
+        assert_eq!(gpu_label_width(&GpuFormat::Usage, true, false), Some(3));
+        assert_eq!(gpu_label_width(&GpuFormat::Usage, false, false), None);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -25,6 +25,7 @@ use crate::widgets::system_popover::SystemPopoverBinding;
 use crate::widgets::{WidgetConfig, warn_unknown_options};
 
 const DEFAULT_SHOW_ICON: bool = true;
+const DEFAULT_RESERVE_WIDTH: bool = true;
 
 /// GPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -55,11 +56,17 @@ pub struct GpuConfig {
     pub show_icon: bool,
     /// Display format for GPU metrics.
     pub format: GpuFormat,
+    /// Reserve label width for common metric values to reduce layout jitter.
+    pub reserve_width: bool,
 }
 
 impl WidgetConfig for GpuConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("gpu", entry, &["show_icon", "format", "device"]);
+        warn_unknown_options(
+            "gpu",
+            entry,
+            &["show_icon", "format", "device", "reserve_width"],
+        );
 
         let show_icon = entry
             .options
@@ -74,7 +81,17 @@ impl WidgetConfig for GpuConfig {
             .map(GpuFormat::from_str)
             .unwrap_or_default();
 
-        Self { show_icon, format }
+        let reserve_width = entry
+            .options
+            .get("reserve_width")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+
+        Self {
+            show_icon,
+            format,
+            reserve_width,
+        }
     }
 }
 
@@ -83,6 +100,7 @@ impl Default for GpuConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             format: GpuFormat::default(),
+            reserve_width: DEFAULT_RESERVE_WIDTH,
         }
     }
 }
@@ -117,7 +135,13 @@ impl GpuWidget {
 
         let icon_handle = base.add_icon("video-display-symbolic", &[widget::GPU_ICON]);
 
+        let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let gpu_label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
+        if let Some(width_chars) =
+            gpu_label_width(&config.format, config.reserve_width, is_vertical)
+        {
+            gpu_label.set_width_chars(width_chars);
+        }
 
         icon_handle.widget().set_visible(config.show_icon);
 
@@ -132,7 +156,6 @@ impl GpuWidget {
             let gpu_label = gpu_label.clone();
             let show_icon = config.show_icon;
             let format = config.format.clone();
-            let is_vertical = ConfigManager::global().bar_position().is_vertical();
             let popover_binding = popover_binding.clone();
 
             gpu_service.connect(move |snapshot: &GpuSnapshot| {
@@ -175,6 +198,21 @@ impl GpuWidget {
     pub(crate) fn edge_interaction(&self) -> Option<crate::widgets::EdgeInteraction> {
         self.base.edge_interaction()
     }
+}
+
+fn gpu_label_width(format: &GpuFormat, reserve_width: bool, is_vertical: bool) -> Option<i32> {
+    if !reserve_width {
+        return None;
+    }
+
+    Some(match (format, is_vertical) {
+        (GpuFormat::Usage, false) => 4,       // 99% / Idle
+        (GpuFormat::Usage, true) => 2,        // 99
+        (GpuFormat::Temperature, false) => 4, // 99°C
+        (GpuFormat::Temperature, true) => 3,  // 99°
+        (GpuFormat::Both, false) => 8,        // 99% 99°C
+        (GpuFormat::Both, true) => 3,         // widest line: 99°
+    })
 }
 
 impl Drop for GpuWidget {
@@ -325,12 +363,14 @@ mod tests {
         let config = GpuConfig::from_entry(&entry);
         assert!(config.show_icon);
         assert_eq!(config.format, GpuFormat::Usage);
+        assert!(config.reserve_width);
     }
 
     #[test]
     fn test_gpu_config_custom() {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
+        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("temperature".to_string()),
@@ -343,6 +383,7 @@ mod tests {
         let config = GpuConfig::from_entry(&entry);
         assert!(!config.show_icon);
         assert_eq!(config.format, GpuFormat::Temperature);
+        assert!(!config.reserve_width);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/gpu.rs
+++ b/crates/vibepanel/src/widgets/gpu.rs
@@ -25,7 +25,7 @@ use crate::widgets::system_popover::SystemPopoverBinding;
 use crate::widgets::{WidgetConfig, warn_unknown_options};
 
 const DEFAULT_SHOW_ICON: bool = true;
-const DEFAULT_RESERVE_WIDTH: bool = true;
+const DEFAULT_STABLE_WIDTH: bool = true;
 
 /// GPU display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -56,8 +56,8 @@ pub struct GpuConfig {
     pub show_icon: bool,
     /// Display format for GPU metrics.
     pub format: GpuFormat,
-    /// Reserve label width for common metric values to reduce layout jitter.
-    pub reserve_width: bool,
+    /// Stabilize label width for common metric values to reduce layout jitter.
+    pub stable_width: bool,
 }
 
 impl WidgetConfig for GpuConfig {
@@ -65,7 +65,7 @@ impl WidgetConfig for GpuConfig {
         warn_unknown_options(
             "gpu",
             entry,
-            &["show_icon", "format", "device", "reserve_width"],
+            &["show_icon", "format", "device", "stable_width"],
         );
 
         let show_icon = entry
@@ -81,16 +81,16 @@ impl WidgetConfig for GpuConfig {
             .map(GpuFormat::from_str)
             .unwrap_or_default();
 
-        let reserve_width = entry
+        let stable_width = entry
             .options
-            .get("reserve_width")
+            .get("stable_width")
             .and_then(|v| v.as_bool())
-            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+            .unwrap_or(DEFAULT_STABLE_WIDTH);
 
         Self {
             show_icon,
             format,
-            reserve_width,
+            stable_width,
         }
     }
 }
@@ -100,7 +100,7 @@ impl Default for GpuConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             format: GpuFormat::default(),
-            reserve_width: DEFAULT_RESERVE_WIDTH,
+            stable_width: DEFAULT_STABLE_WIDTH,
         }
     }
 }
@@ -137,8 +137,7 @@ impl GpuWidget {
 
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let gpu_label = base.add_label(None, &[widget::GPU_LABEL, class::VCENTER_CAPS]);
-        if let Some(width_chars) =
-            gpu_label_width(&config.format, config.reserve_width, is_vertical)
+        if let Some(width_chars) = gpu_label_width(&config.format, config.stable_width, is_vertical)
         {
             gpu_label.set_width_chars(width_chars);
         }
@@ -200,8 +199,8 @@ impl GpuWidget {
     }
 }
 
-fn gpu_label_width(format: &GpuFormat, reserve_width: bool, is_vertical: bool) -> Option<i32> {
-    if !reserve_width {
+fn gpu_label_width(format: &GpuFormat, stable_width: bool, is_vertical: bool) -> Option<i32> {
+    if !stable_width {
         return None;
     }
 
@@ -363,14 +362,14 @@ mod tests {
         let config = GpuConfig::from_entry(&entry);
         assert!(config.show_icon);
         assert_eq!(config.format, GpuFormat::Usage);
-        assert!(config.reserve_width);
+        assert!(config.stable_width);
     }
 
     #[test]
     fn test_gpu_config_custom() {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
-        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
+        options.insert("stable_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("temperature".to_string()),
@@ -383,7 +382,7 @@ mod tests {
         let config = GpuConfig::from_entry(&entry);
         assert!(!config.show_icon);
         assert_eq!(config.format, GpuFormat::Temperature);
-        assert!(!config.reserve_width);
+        assert!(!config.stable_width);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -25,7 +25,7 @@ use crate::widgets::{WidgetConfig, warn_unknown_options};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
-const DEFAULT_RESERVE_WIDTH: bool = true;
+const DEFAULT_STABLE_WIDTH: bool = true;
 
 /// Memory display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -57,13 +57,13 @@ pub struct MemoryConfig {
     pub show_icon: bool,
     /// Display format for memory usage.
     pub format: MemoryFormat,
-    /// Reserve label width for common metric values to reduce layout jitter.
-    pub reserve_width: bool,
+    /// Stabilize label width for common metric values to reduce layout jitter.
+    pub stable_width: bool,
 }
 
 impl WidgetConfig for MemoryConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("memory", entry, &["show_icon", "format", "reserve_width"]);
+        warn_unknown_options("memory", entry, &["show_icon", "format", "stable_width"]);
 
         let show_icon = entry
             .options
@@ -78,16 +78,16 @@ impl WidgetConfig for MemoryConfig {
             .map(MemoryFormat::from_str)
             .unwrap_or_default();
 
-        let reserve_width = entry
+        let stable_width = entry
             .options
-            .get("reserve_width")
+            .get("stable_width")
             .and_then(|v| v.as_bool())
-            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+            .unwrap_or(DEFAULT_STABLE_WIDTH);
 
         Self {
             show_icon,
             format,
-            reserve_width,
+            stable_width,
         }
     }
 }
@@ -97,7 +97,7 @@ impl Default for MemoryConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             format: MemoryFormat::default(),
-            reserve_width: DEFAULT_RESERVE_WIDTH,
+            stable_width: DEFAULT_STABLE_WIDTH,
         }
     }
 }
@@ -138,7 +138,7 @@ impl MemoryWidget {
         let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let memory_label = base.add_label(None, &[widget::MEMORY_LABEL, class::VCENTER_CAPS]);
         if let Some(width_chars) =
-            memory_label_width(&config.format, config.reserve_width, is_vertical)
+            memory_label_width(&config.format, config.stable_width, is_vertical)
         {
             memory_label.set_width_chars(width_chars);
         }
@@ -185,12 +185,8 @@ impl MemoryWidget {
     }
 }
 
-fn memory_label_width(
-    format: &MemoryFormat,
-    reserve_width: bool,
-    is_vertical: bool,
-) -> Option<i32> {
-    if !reserve_width {
+fn memory_label_width(format: &MemoryFormat, stable_width: bool, is_vertical: bool) -> Option<i32> {
+    if !stable_width {
         return None;
     }
 
@@ -288,14 +284,14 @@ mod tests {
         let config = MemoryConfig::from_entry(&entry);
         assert!(config.show_icon);
         assert_eq!(config.format, MemoryFormat::Percentage);
-        assert!(config.reserve_width);
+        assert!(config.stable_width);
     }
 
     #[test]
     fn test_memory_config_custom() {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
-        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
+        options.insert("stable_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("absolute".to_string()),
@@ -308,7 +304,7 @@ mod tests {
         let config = MemoryConfig::from_entry(&entry);
         assert!(!config.show_icon);
         assert_eq!(config.format, MemoryFormat::Absolute);
-        assert!(!config.reserve_width);
+        assert!(!config.stable_width);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -193,8 +193,8 @@ fn memory_label_width(format: &MemoryFormat, stable_width: bool, is_vertical: bo
     Some(match (format, is_vertical) {
         (_, true) => 2, // vertical mode always renders percentage without %
         (MemoryFormat::Percentage, _) => 3, // 99%
-        (MemoryFormat::Absolute, _) => 4, // 8.2G / 999M
-        (MemoryFormat::Both, _) => 9, // 8.2/16.0G
+        (MemoryFormat::Absolute, _) => 5, // 10.0G / 999M
+        (MemoryFormat::Both, _) => 10, // 10.0/16.0G
     })
 }
 
@@ -213,11 +213,12 @@ fn format_memory(snapshot: &SystemSnapshot, format: &MemoryFormat, is_vertical: 
     match format {
         MemoryFormat::Percentage => format!("{:.0}%", snapshot.memory_percent),
         MemoryFormat::Absolute => format_bytes(snapshot.memory_used),
-        MemoryFormat::Both => format!(
-            "{}/{}",
-            format_bytes(snapshot.memory_used),
-            format_bytes(snapshot.memory_total)
-        ),
+        MemoryFormat::Both => {
+            let used = format_bytes(snapshot.memory_used);
+            let total = format_bytes(snapshot.memory_total);
+            let used_without_unit = used.trim_end_matches(|c: char| c.is_ascii_alphabetic());
+            format!("{used_without_unit}/{total}")
+        }
     }
 }
 
@@ -347,5 +348,44 @@ mod tests {
             "76"
         );
         assert_eq!(format_memory(&snapshot, &MemoryFormat::Both, true), "76");
+    }
+
+    #[test]
+    fn test_format_memory_both_shows_unit_once() {
+        let snapshot = SystemSnapshot {
+            available: true,
+            memory_percent: 62.5,
+            memory_used: 10 * 1024 * 1024 * 1024,
+            memory_total: 16 * 1024 * 1024 * 1024,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            format_memory(&snapshot, &MemoryFormat::Both, false),
+            "10.0/16.0G"
+        );
+    }
+
+    #[test]
+    fn test_memory_label_width_covers_two_digit_gib() {
+        let snapshot = SystemSnapshot {
+            available: true,
+            memory_percent: 62.5,
+            memory_used: 10 * 1024 * 1024 * 1024,
+            memory_total: 16 * 1024 * 1024 * 1024,
+            ..Default::default()
+        };
+
+        let absolute = format_memory(&snapshot, &MemoryFormat::Absolute, false);
+        let both = format_memory(&snapshot, &MemoryFormat::Both, false);
+
+        assert!(
+            absolute.chars().count()
+                <= memory_label_width(&MemoryFormat::Absolute, true, false).unwrap() as usize
+        );
+        assert!(
+            both.chars().count()
+                <= memory_label_width(&MemoryFormat::Both, true, false).unwrap() as usize
+        );
     }
 }

--- a/crates/vibepanel/src/widgets/memory.rs
+++ b/crates/vibepanel/src/widgets/memory.rs
@@ -25,6 +25,7 @@ use crate::widgets::{WidgetConfig, warn_unknown_options};
 
 /// Default configuration values
 const DEFAULT_SHOW_ICON: bool = true;
+const DEFAULT_RESERVE_WIDTH: bool = true;
 
 /// Memory display format options.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -56,11 +57,13 @@ pub struct MemoryConfig {
     pub show_icon: bool,
     /// Display format for memory usage.
     pub format: MemoryFormat,
+    /// Reserve label width for common metric values to reduce layout jitter.
+    pub reserve_width: bool,
 }
 
 impl WidgetConfig for MemoryConfig {
     fn from_entry(entry: &WidgetEntry) -> Self {
-        warn_unknown_options("memory", entry, &["show_icon", "format"]);
+        warn_unknown_options("memory", entry, &["show_icon", "format", "reserve_width"]);
 
         let show_icon = entry
             .options
@@ -75,7 +78,17 @@ impl WidgetConfig for MemoryConfig {
             .map(MemoryFormat::from_str)
             .unwrap_or_default();
 
-        Self { show_icon, format }
+        let reserve_width = entry
+            .options
+            .get("reserve_width")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(DEFAULT_RESERVE_WIDTH);
+
+        Self {
+            show_icon,
+            format,
+            reserve_width,
+        }
     }
 }
 
@@ -84,6 +97,7 @@ impl Default for MemoryConfig {
         Self {
             show_icon: DEFAULT_SHOW_ICON,
             format: MemoryFormat::default(),
+            reserve_width: DEFAULT_RESERVE_WIDTH,
         }
     }
 }
@@ -121,7 +135,13 @@ impl MemoryWidget {
 
         let icon_handle = base.add_icon("ram-symbolic", &[widget::MEMORY_ICON]);
 
+        let is_vertical = ConfigManager::global().bar_position().is_vertical();
         let memory_label = base.add_label(None, &[widget::MEMORY_LABEL, class::VCENTER_CAPS]);
+        if let Some(width_chars) =
+            memory_label_width(&config.format, config.reserve_width, is_vertical)
+        {
+            memory_label.set_width_chars(width_chars);
+        }
 
         icon_handle.widget().set_visible(config.show_icon);
 
@@ -132,7 +152,6 @@ impl MemoryWidget {
             let memory_label = memory_label.clone();
             let show_icon = config.show_icon;
             let format = config.format.clone();
-            let is_vertical = ConfigManager::global().bar_position().is_vertical();
             let popover_binding = popover_binding.clone();
 
             system_service.connect(move |snapshot: &SystemSnapshot| {
@@ -164,6 +183,23 @@ impl MemoryWidget {
     pub(crate) fn edge_interaction(&self) -> Option<crate::widgets::EdgeInteraction> {
         self.base.edge_interaction()
     }
+}
+
+fn memory_label_width(
+    format: &MemoryFormat,
+    reserve_width: bool,
+    is_vertical: bool,
+) -> Option<i32> {
+    if !reserve_width {
+        return None;
+    }
+
+    Some(match (format, is_vertical) {
+        (_, true) => 2, // vertical mode always renders percentage without %
+        (MemoryFormat::Percentage, _) => 3, // 99%
+        (MemoryFormat::Absolute, _) => 4, // 8.2G / 999M
+        (MemoryFormat::Both, _) => 9, // 8.2/16.0G
+    })
 }
 
 impl Drop for MemoryWidget {
@@ -252,12 +288,14 @@ mod tests {
         let config = MemoryConfig::from_entry(&entry);
         assert!(config.show_icon);
         assert_eq!(config.format, MemoryFormat::Percentage);
+        assert!(config.reserve_width);
     }
 
     #[test]
     fn test_memory_config_custom() {
         let mut options = std::collections::HashMap::new();
         options.insert("show_icon".to_string(), toml::Value::Boolean(false));
+        options.insert("reserve_width".to_string(), toml::Value::Boolean(false));
         options.insert(
             "format".to_string(),
             toml::Value::String("absolute".to_string()),
@@ -270,6 +308,7 @@ mod tests {
         let config = MemoryConfig::from_entry(&entry);
         assert!(!config.show_icon);
         assert_eq!(config.format, MemoryFormat::Absolute);
+        assert!(!config.reserve_width);
     }
 
     #[test]


### PR DESCRIPTION
Adds a `stable_width` option to the memory, cpu and gpu widgets that will reserve space for 2 digits in the label at all times so the widgets doesnt shift size when going from a single digit to double digit value.  This is the new default behaviour. Fixes #166 

```toml
[widgets.gpu]
stable_width = true
```

<img width="235" height="77" alt="image" src="https://github.com/user-attachments/assets/98e19efb-9087-4b09-8332-b1b1ef75fe5a" />
