### PR TITLE
fix(bar): improve popover dismissal

### DIFF
--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -279,6 +279,47 @@ fn install_edge_click_handler(
     outer_box.add_controller(motion);
 }
 
+fn install_bar_background_click_handler(outer_box: &gtk4::Box) {
+    let gesture = GestureClick::new();
+    gesture.set_button(0);
+    gesture.set_propagation_phase(gtk4::PropagationPhase::Bubble);
+    gesture.connect_pressed(move |gesture, _n_press, x, y| {
+        if click_inside_bar_widget(gesture, x, y) {
+            return;
+        }
+
+        TooltipManager::global().cancel_and_hide();
+        PopoverTracker::global().dismiss_active();
+        gesture.set_state(gtk4::EventSequenceState::Claimed);
+    });
+    outer_box.add_controller(gesture);
+}
+
+fn click_inside_bar_widget(gesture: &GestureClick, x: f64, y: f64) -> bool {
+    // Bar widget containers must keep one of these classes so background clicks
+    // don't dismiss popovers before widget handlers run.
+    let Some(root) = gesture.widget() else {
+        return false;
+    };
+    let Some(target) = root.pick(x, y, gtk4::PickFlags::DEFAULT) else {
+        return false;
+    };
+
+    let mut current = Some(target);
+    while let Some(widget) = current {
+        if widget.has_css_class(class::WIDGET_WRAPPER)
+            || widget.has_css_class(class::WIDGET_ITEM)
+            || widget.has_css_class(class::WIDGET)
+            || widget.has_css_class(class::WIDGET_MERGE_GROUP)
+        {
+            return true;
+        }
+        current = widget.parent();
+    }
+
+    false
+}
+
 /// Production-built bar content shared by the layer-shell window path and
 /// runtime UI regression tests.
 pub(crate) struct BuiltBarContent {
@@ -438,6 +479,7 @@ pub(crate) fn build_bar_content(
     );
     bar_box.set_end_widget(Some(&right_section));
 
+    install_bar_background_click_handler(&outer_box);
     install_edge_click_handler(&outer_box, position, &edge_targets);
 
     BuiltBarContent {
@@ -1149,6 +1191,7 @@ fn build_merge_group(
                 }
 
                 trigger_ripple_from_gesture(gesture, x, y, &ripple_for_press);
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
             }
         });
     }

--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -71,6 +71,25 @@ fn collect_descendants_with_class(root: &gtk4::Widget, class_name: &str) -> Vec<
     matches
 }
 
+fn has_bar_background_click_guard_ancestor(widget: &gtk4::Widget, stop_at: &gtk4::Widget) -> bool {
+    let mut current = Some(widget.clone());
+    while let Some(widget) = current {
+        if widget.has_css_class(crate::styles::class::WIDGET_WRAPPER)
+            || widget.has_css_class(crate::styles::class::WIDGET_ITEM)
+            || widget.has_css_class(crate::styles::class::WIDGET)
+            || widget.has_css_class(crate::styles::class::WIDGET_MERGE_GROUP)
+        {
+            return true;
+        }
+        if widget == *stop_at {
+            break;
+        }
+        current = widget.parent();
+    }
+
+    false
+}
+
 fn section_widget_class_names(
     bar: &SectionedBar,
     section_name: &str,
@@ -1519,6 +1538,46 @@ fn run_test_widgets_grouping_spacing_contract() {
     flush_gtk();
 }
 
+fn run_test_bar_background_click_guard_classes() {
+    let mut config = test_config();
+    config.widgets.left = vec![
+        vibepanel_core::config::WidgetPlacement::Single("custom-a".to_string()),
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["custom-b".to_string(), "custom-c".to_string()],
+        },
+        vibepanel_core::config::WidgetPlacement::Group {
+            group: vec!["cpu".to_string(), "memory".to_string()],
+        },
+    ];
+    config
+        .widgets
+        .widget_configs
+        .entry("custom-c".to_string())
+        .or_default()
+        .options
+        .insert("label".to_string(), toml::Value::String("C".to_string()));
+
+    let (window, bar, _state, _popover_registry_guard, _css_provider) = built_bar_fixture(&config);
+    let left_section = bar
+        .section("left")
+        .expect("bar should build a left section");
+    let contents = collect_descendants_with_class(&left_section, crate::styles::class::CONTENT);
+    assert!(
+        contents.len() >= 5,
+        "test config should render single, explicit-group, and merge-group content"
+    );
+
+    for content in contents {
+        assert!(
+            has_bar_background_click_guard_ancestor(&content, &left_section),
+            "bar widget content should have a guard class ancestor for background clicks"
+        );
+    }
+
+    window.close();
+    flush_gtk();
+}
+
 fn merge_group_child_label_gap(override_css: Option<&str>) -> i32 {
     let mut config = test_config();
     config.widgets.left = vec![
@@ -2484,6 +2543,11 @@ ui_regression_config_tests!(
         test_ui_regression_widgets_grouping_spacing,
         "widgets.grouping.spacing",
         run_test_widgets_grouping_spacing_contract
+    ),
+    (
+        test_ui_regression_bar_background_click_guard_classes,
+        "bar.background_click_guard_classes",
+        run_test_bar_background_click_guard_classes
     ),
     (
         test_ui_regression_widgets_grouping_merge_spacing,

--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -30,6 +30,7 @@ const DEFAULT_WORKSPACE_COUNT: i32 = 10;
 const RECONNECT_INITIAL_MS: u64 = 1000;
 const RECONNECT_MAX_MS: u64 = 30000;
 const RECONNECT_MULTIPLIER: f64 = 1.5;
+const POINTER_FOCUS_REFRESH_DELAY: Duration = Duration::from_millis(50);
 
 pub struct HyprlandBackend {
     allowed_outputs: RwLock<Vec<String>>,
@@ -145,6 +146,10 @@ impl HyprlandBackend {
         let socket_path = self.socket_path.read();
         let socket_path = socket_path.as_ref()?;
 
+        Self::send_command_to_socket(socket_path, command)
+    }
+
+    fn send_command_to_socket(socket_path: &str, command: &str) -> Option<String> {
         let mut stream = match UnixStream::connect(socket_path) {
             Ok(s) => s,
             Err(e) => {
@@ -343,6 +348,11 @@ impl HyprlandBackend {
         response.trim().eq_ignore_ascii_case("ok")
     }
 
+    fn parse_cursorpos(response: &str) -> Option<(i32, i32)> {
+        let (x, y) = response.trim().split_once(',')?;
+        Some((x.trim().parse().ok()?, y.trim().parse().ok()?))
+    }
+
     fn send_dispatch(&self, context: &str, lua: &str, legacy: &str) {
         // TODO: Remove the legacy hyprlang dispatch path once Hyprland drops hyprlang support.
         let command = if self.supports_lua_dispatch.load(Ordering::Relaxed) {
@@ -370,6 +380,60 @@ impl HyprlandBackend {
                 );
             }
         }
+    }
+
+    fn refresh_pointer_focus_impl(&self) {
+        // Workaround for Hyprland: after layer-shell popovers map, Hyprland
+        // does not recalculate pointer hover/focus until it processes cursor
+        // activity. Delay the no-op move until the newly mapped surface has
+        // been committed. A user cursor move inside this short window can be
+        // pulled back to the sampled position; avoiding that race would add IPC
+        // complexity for a very small, transient case.
+        let socket_path = self.socket_path.read().clone();
+        let use_lua = self.supports_lua_dispatch.load(Ordering::Relaxed);
+        thread::spawn(move || {
+            thread::sleep(POINTER_FOCUS_REFRESH_DELAY);
+            let Some(socket_path) = socket_path else {
+                return;
+            };
+
+            let Some(cursorpos) = Self::send_command_to_socket(&socket_path, "cursorpos") else {
+                debug!("Hyprland cursor position unavailable for pointer focus refresh");
+                return;
+            };
+            let Some((x, y)) = Self::parse_cursorpos(&cursorpos) else {
+                debug!(
+                    response = %cursorpos.trim(),
+                    "Hyprland cursor position parse failed for pointer focus refresh"
+                );
+                return;
+            };
+
+            let command = if use_lua {
+                format!("dispatch hl.dsp.cursor.move({{ x = {x}, y = {y} }})")
+            } else {
+                format!("dispatch movecursor {x} {y}")
+            };
+
+            match Self::send_command_to_socket(&socket_path, &command) {
+                Some(response) if Self::response_is_ok(&response) => {
+                    debug!(command, "Hyprland deferred pointer focus refresh succeeded");
+                }
+                Some(response) => {
+                    warn!(
+                        command,
+                        response = %response.trim(),
+                        "Hyprland deferred pointer focus refresh failed"
+                    );
+                }
+                None => {
+                    warn!(
+                        command,
+                        "Hyprland deferred pointer focus refresh failed without a response"
+                    );
+                }
+            }
+        });
     }
 
     /// Fetch monitor information from Hyprland.
@@ -1201,6 +1265,10 @@ impl CompositorBackend for HyprlandBackend {
             let _ = self.send_command("switchxkblayout all next");
         }
     }
+
+    fn refresh_pointer_focus(&self) {
+        self.refresh_pointer_focus_impl();
+    }
 }
 
 impl Drop for HyprlandBackend {
@@ -1384,6 +1452,20 @@ mod tests {
         assert!(!HyprlandBackend::response_is_ok("unknown dispatcher"));
         assert!(!HyprlandBackend::response_is_ok("workspace 1"));
         assert!(!HyprlandBackend::response_is_ok(""));
+    }
+
+    #[test]
+    fn parse_cursorpos_accepts_trimmed_coordinates() {
+        assert_eq!(
+            HyprlandBackend::parse_cursorpos("123,456"),
+            Some((123, 456))
+        );
+        assert_eq!(
+            HyprlandBackend::parse_cursorpos("  -12, 34\n"),
+            Some((-12, 34))
+        );
+        assert_eq!(HyprlandBackend::parse_cursorpos("123"), None);
+        assert_eq!(HyprlandBackend::parse_cursorpos("x,456"), None);
     }
 
     #[test]

--- a/crates/vibepanel/src/services/compositor/manager.rs
+++ b/crates/vibepanel/src/services/compositor/manager.rs
@@ -261,6 +261,13 @@ impl CompositorManager {
         }
     }
 
+    /// Ask the active compositor to refresh pointer focus, if supported.
+    pub fn refresh_pointer_focus(&self) {
+        if let Some(ref backend) = *self.backend.borrow() {
+            backend.refresh_pointer_focus();
+        }
+    }
+
     /// Get the list of all windows.
     pub fn list_windows(&self) -> Vec<super::Window> {
         if let Some(ref backend) = *self.backend.borrow() {

--- a/crates/vibepanel/src/services/compositor/types.rs
+++ b/crates/vibepanel/src/services/compositor/types.rs
@@ -260,6 +260,15 @@ pub trait CompositorBackend: Send + Sync {
         // Default no-op
     }
 
+    /// Ask the compositor to refresh pointer focus without changing UI state.
+    ///
+    /// Some compositors do not immediately re-hit-test the pointer when layer
+    /// surfaces map under a stationary cursor. Backends can use a compositor-
+    /// native no-op cursor move or similar mechanism when available.
+    fn refresh_pointer_focus(&self) {
+        // Default no-op
+    }
+
     /// Get the list of all windows.
     ///
     /// Returns a snapshot of all windows currently open across all workspaces.

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -255,18 +255,18 @@ impl MenuHandle {
 
     /// Get the anchor position for the popover.
     ///
-    /// Returns the widget's center X coordinate (in monitor-local coordinates)
+    /// Returns the widget's center X coordinate (in surface-relative coordinates)
     /// and the monitor it's on.
     ///
     /// # Coordinate Space
     ///
-    /// The returned `anchor_x` is relative to the monitor's origin (0,0 at top-left
-    /// of the monitor), NOT global screen coordinates. This is correct because:
+    /// The returned anchor is relative to the bar's layer-shell surface, NOT
+    /// global screen coordinates. This is correct because:
     ///
     /// 1. Layer-shell surfaces are per-monitor - the bar is anchored to a specific
     ///    monitor and its native surface coordinates are relative to that monitor.
     /// 2. `compute_bounds(&native)` returns coordinates relative to the native
-    ///    surface, which for layer-shell is the monitor-local coordinate space.
+    ///    surface, which for the bar is the bar surface coordinate space.
     /// 3. The popover is also a layer-shell surface on the same monitor, so it
     ///    uses the same coordinate space for its margin calculations.
     fn get_anchor_info(&self) -> (PopoverAnchor, Option<gtk4::gdk::Monitor>) {
@@ -282,7 +282,7 @@ impl MenuHandle {
         let widget_y = bounds.y() as i32;
         let widget_width = bounds.width() as i32;
         let widget_height = bounds.height() as i32;
-        // anchor_x is monitor-relative: the center X of the widget on its monitor
+        // Anchor is surface-relative: the center of the widget in the bar surface.
         let anchor = PopoverAnchor {
             x: widget_x + widget_width / 2,
             y: widget_y + widget_height / 2,
@@ -711,6 +711,7 @@ impl BaseWidget {
                         } else {
                             debug!("Closed own menu from BaseWidget press");
                         }
+                        gesture.set_state(gtk4::EventSequenceState::Claimed);
                     } else {
                         debug!("BaseWidget press: no menu registered");
                     }

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -295,7 +295,8 @@ pub fn reset_popover_margins(window: &ApplicationWindow) {
 /// All parameters use **monitor-local coordinates** (0,0 at the monitor's top-left).
 /// This is correct because:
 /// - Layer-shell surfaces are anchored to specific monitors
-/// - `anchor_x` comes from `compute_bounds()` which returns monitor-relative coords
+/// - horizontal bar surfaces span the monitor width, so surface-local X matches
+///   monitor-local X along the placement axis
 /// - `monitor_width` is from `monitor.geometry().width()` (the monitor's own width)
 /// - The resulting margin is applied to a layer-shell surface on the same monitor
 ///
@@ -406,8 +407,7 @@ where
     catcher.add_css_class(surface::LAYER_SHELL_CLICK_CATCHER);
     catcher.add_css_class(class::CLICK_CATCHER);
 
-    // Layer shell configuration - fullscreen surface behind the popover.
-    // Use Top layer (not Overlay) to avoid appearing on top of fullscreen apps.
+    // Layer shell configuration - fullscreen transparent surface around popovers.
     catcher.init_layer_shell();
     catcher.set_namespace(Some("vibepanel-click-catcher"));
     catcher.set_layer(Layer::Top);
@@ -416,14 +416,9 @@ where
     catcher.set_anchor(Edge::Bottom, true);
     catcher.set_anchor(Edge::Left, true);
     catcher.set_anchor(Edge::Right, true);
-    // Click-catcher should never take keyboard focus - its only purpose is
-    // catching clicks outside the popover. Keyboard focus belongs to the actual
-    // popover window which is shown after this.
     catcher.set_keyboard_mode(KeyboardMode::None);
 
-    // Leave the bar area uncovered so clicks/hovers pass through to bar widgets.
-    let bar_edge = popover_bar_edge();
-    catcher.set_margin(bar_edge, bar_zone);
+    catcher.set_margin(popover_bar_edge(), bar_zone);
 
     // Content - add CSS class to the child widget for background styling
     let overlay = GtkBox::new(Orientation::Vertical, 0);
@@ -435,13 +430,9 @@ where
     // Click handler
     let gesture = GestureClick::new();
     gesture.set_button(0); // All buttons
-    {
-        // Use connect_released to allow GTK to complete the gesture lifecycle
-        // before hiding windows. This avoids "Broken accounting of active state" warnings.
-        gesture.connect_released(move |_gesture, _, _x, _y| {
-            on_dismiss();
-        });
-    }
+    // Use connect_released to allow GTK to complete the gesture lifecycle
+    // before hiding windows. This avoids "Broken accounting of active state" warnings.
+    gesture.connect_released(move |_, _, _, _| on_dismiss());
     catcher.add_controller(gesture);
 
     // Note: No ESC handler on click-catcher. ESC handling is done by the actual
@@ -1021,6 +1012,7 @@ impl LayerShellPopover {
                     popover.update_position();
                     if let Some(ref window) = *popover.window.borrow() {
                         window.set_opacity(1.0);
+                        CompositorManager::global().refresh_pointer_focus();
                     }
                     popover.start_animation(AnimDirection::Opening, generation);
                 }
@@ -1042,6 +1034,7 @@ impl LayerShellPopover {
             );
             window.set_visible(true);
             window.present();
+            CompositorManager::global().refresh_pointer_focus();
 
             // present() may assign auto-focus, so install after mapping to clear
             // it and keep focus rings hidden until the first keynav press.
@@ -1082,7 +1075,6 @@ impl LayerShellPopover {
         window.add_css_class(surface::LAYER_SHELL_POPOVER);
 
         // Layer shell configuration.
-        // Use Top layer (not Overlay) to avoid appearing on top of fullscreen apps.
         window.init_layer_shell();
         window.set_namespace(Some(&format!("vibepanel-{}-popover", self.widget_name)));
         window.set_layer(Layer::Top);

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -22,6 +22,7 @@ use crate::services::audio::AudioService;
 use crate::services::bluetooth::BluetoothService;
 use crate::services::brightness::BrightnessService;
 use crate::services::callbacks::CallbackId;
+use crate::services::compositor::CompositorManager;
 use crate::services::config_manager::ConfigManager;
 use crate::services::idle_inhibitor::IdleInhibitorService;
 use crate::services::network::NetworkService;
@@ -1471,6 +1472,7 @@ impl QuickSettingsWindow {
             self.update_position();
             self.window.set_visible(true);
             self.window.present();
+            CompositorManager::global().refresh_pointer_focus();
 
             // Install deferred Tab controller for keyboard nav on first Tab.
             self.prepare_keyboard_nav();
@@ -1516,6 +1518,7 @@ impl QuickSettingsWindow {
                 {
                     qs.update_position();
                     qs.window.set_opacity(1.0);
+                    CompositorManager::global().refresh_pointer_focus();
 
                     if ConfigManager::global().animations_enabled() {
                         qs.start_animation(AnimDirection::Opening, generation);


### PR DESCRIPTION
Clicking "empty" areas of the bar will now dismiss a popover if open. 

Furthermore, Hyprland has required a mouse move before being able to close a popover, this branch adds a small no-op mouse move(to same coordinates) to get hyprland to refresh and users can click to close without moving their mouse.

Closes #164 