### PR TITLE
ci: add AUR source and git packages

### DIFF
--- a/.github/aur/vibepanel-bin/PKGBUILD.template
+++ b/.github/aur/vibepanel-bin/PKGBUILD.template
@@ -1,4 +1,5 @@
 # Maintainer: prankstr <https://github.com/prankstr>
+# Keep depends/optdepends/options in sync across vibepanel, vibepanel-bin, and vibepanel-git.
 pkgname=vibepanel-bin
 pkgver=${VERSION}
 pkgrel=1
@@ -6,8 +7,12 @@ pkgdesc="A GTK4 panel for Wayland with notifications, OSD, and quick settings"
 arch=('x86_64')
 url="https://github.com/prankstr/vibepanel"
 license=('MIT')
-depends=('gtk4' 'gtk4-layer-shell' 'libpulse' 'upower' 'networkmanager' 'bluez')
-optdepends=('power-profiles-daemon: power profile switching in battery popover')
+# systemd-libs provides libudev used by the brightness service.
+depends=('gtk4' 'gtk4-layer-shell' 'libpulse' 'upower' 'networkmanager' 'bluez' 'systemd-libs')
+optdepends=('power-profiles-daemon: power profile switching in battery popover'
+            'modemmanager: cellular/mobile network support'
+            'cava: audio visualizer in the media widget'
+            'iwd: alternative to NetworkManager for Wi-Fi')
 provides=('vibepanel')
 conflicts=('vibepanel' 'vibepanel-git')
 options=(!debug)

--- a/.github/aur/vibepanel-git/PKGBUILD
+++ b/.github/aur/vibepanel-git/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: prankstr <prankstr@users.noreply.github.com>
+# Keep depends/optdepends/options in sync across vibepanel, vibepanel-bin, and vibepanel-git.
+pkgname=vibepanel-git
+_pkgname=vibepanel
+pkgver=0.15.0.r5.g02e9777
+pkgrel=1
+pkgdesc="A GTK4 panel for Wayland with notifications, OSD, and quick settings (git version)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/prankstr/vibepanel"
+license=('MIT')
+# systemd-libs provides libudev used by the brightness service.
+depends=('gtk4' 'gtk4-layer-shell' 'libpulse' 'upower' 'networkmanager' 'bluez' 'systemd-libs')
+makedepends=('git' 'cargo' 'rust' 'pkg-config')
+optdepends=('power-profiles-daemon: power profile switching in battery popover'
+            'modemmanager: cellular/mobile network support'
+            'cava: audio visualizer in the media widget'
+            'iwd: alternative to NetworkManager for Wi-Fi')
+# ring native code fails with makepkg's default LTO flags.
+options=(!lto !debug)
+provides=("${_pkgname}")
+conflicts=("${_pkgname}" "${_pkgname}-bin")
+source=("${_pkgname}::git+https://github.com/prankstr/vibepanel.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${_pkgname}"
+  git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g' | sed 's/^v//'
+}
+
+prepare() {
+  cd "${_pkgname}"
+  export CARGO_HOME="${srcdir}/cargo"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${_pkgname}"
+  export CARGO_HOME="${srcdir}/cargo"
+  cargo build --release --frozen -p "${_pkgname}"
+}
+
+package() {
+  cd "${_pkgname}"
+  install -Dm755 "target/release/${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
+  # Font is embedded in the binary and extracted to cache on first run; no system font install needed.
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/.github/aur/vibepanel/PKGBUILD.template
+++ b/.github/aur/vibepanel/PKGBUILD.template
@@ -1,0 +1,40 @@
+# Maintainer: prankstr <prankstr@users.noreply.github.com>
+# Keep depends/optdepends/options in sync across vibepanel, vibepanel-bin, and vibepanel-git.
+pkgname=vibepanel
+pkgver=${VERSION}
+pkgrel=1
+pkgdesc="A GTK4 panel for Wayland with notifications, OSD, and quick settings"
+arch=('x86_64' 'aarch64')
+url="https://github.com/prankstr/vibepanel"
+license=('MIT')
+# systemd-libs provides libudev used by the brightness service.
+depends=('gtk4' 'gtk4-layer-shell' 'libpulse' 'upower' 'networkmanager' 'bluez' 'systemd-libs')
+makedepends=('cargo' 'rust' 'pkg-config')
+optdepends=('power-profiles-daemon: power profile switching in battery popover'
+            'modemmanager: cellular/mobile network support'
+            'cava: audio visualizer in the media widget'
+            'iwd: alternative to NetworkManager for Wi-Fi')
+# ring native code fails with makepkg's default LTO flags.
+options=(!lto !debug)
+conflicts=('vibepanel-bin' 'vibepanel-git')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/prankstr/vibepanel/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('${SHA256_SOURCE}')
+
+prepare() {
+  cd "${pkgname}-${pkgver}"
+  export CARGO_HOME="${srcdir}/cargo"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  export CARGO_HOME="${srcdir}/cargo"
+  cargo build --release --frozen -p "${pkgname}"
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+  install -Dm755 "target/release/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+  # Font is embedded in the binary and extracted to cache on first run; no system font install needed.
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Install dependencies (native)
         if: ${{ !matrix.cross }}
@@ -111,6 +113,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -161,19 +165,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-aur:
-    name: Publish to AUR
+    name: Publish binary package to AUR
     needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Generate PKGBUILD
         run: |
           TAG="${{ inputs.tag_name || github.ref_name }}"
           VERSION="${TAG#v}"
           
-          curl -sL "https://github.com/prankstr/vibepanel/releases/download/${TAG}/vibepanel-x86_64-unknown-linux-gnu" -o vibepanel
-          curl -sL "https://raw.githubusercontent.com/prankstr/vibepanel/${TAG}/LICENSE" -o LICENSE
+          curl -fsSL "https://github.com/prankstr/vibepanel/releases/download/${TAG}/vibepanel-x86_64-unknown-linux-gnu" -o vibepanel
+          curl -fsSL "https://raw.githubusercontent.com/prankstr/vibepanel/${TAG}/LICENSE" -o LICENSE
           
           SHA256_BIN=$(sha256sum vibepanel | cut -d' ' -f1)
           SHA256_LICENSE=$(sha256sum LICENSE | cut -d' ' -f1)
@@ -182,6 +188,15 @@ jobs:
               -e "s/\${SHA256_BIN}/${SHA256_BIN}/g" \
               -e "s/\${SHA256_LICENSE}/${SHA256_LICENSE}/g" \
               .github/aur/vibepanel-bin/PKGBUILD.template > PKGBUILD
+
+      - name: Validate PKGBUILD
+        run: |
+          docker run --rm \
+            --platform linux/amd64 \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            archlinux:base-devel \
+            bash -lc 'useradd -m builder && su builder -c "makepkg --printsrcinfo -p PKGBUILD >/dev/null"'
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
@@ -192,6 +207,89 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update to ${{ inputs.tag_name || github.ref_name }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+          allow_empty_commits: false
+
+  publish-aur-source:
+    name: Publish source package to AUR
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
+
+      - name: Generate PKGBUILD
+        run: |
+          TAG="${{ inputs.tag_name || github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          curl -fsSL "https://github.com/prankstr/vibepanel/archive/refs/tags/${TAG}.tar.gz" -o "vibepanel-${VERSION}.tar.gz"
+          SHA256_SOURCE=$(sha256sum "vibepanel-${VERSION}.tar.gz" | cut -d' ' -f1)
+
+          mkdir -p generated/aur/vibepanel
+          sed -e "s/\${VERSION}/${VERSION}/g" \
+              -e "s/\${SHA256_SOURCE}/${SHA256_SOURCE}/g" \
+              .github/aur/vibepanel/PKGBUILD.template > generated/aur/vibepanel/PKGBUILD
+
+      - name: Validate PKGBUILD
+        run: |
+          docker run --rm \
+            --platform linux/amd64 \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            archlinux:base-devel \
+            bash -lc 'useradd -m builder && su builder -c "makepkg --printsrcinfo -p generated/aur/vibepanel/PKGBUILD >/dev/null"'
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: vibepanel
+          pkgbuild: ./generated/aur/vibepanel/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ inputs.tag_name || github.ref_name }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+          allow_empty_commits: false
+
+  publish-aur-git:
+    name: Publish git package to AUR
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Generate PKGBUILD
+        run: |
+          pkgver="$(git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g' | sed 's/^v//')"
+          mkdir -p generated/aur/vibepanel-git
+          cp .github/aur/vibepanel-git/PKGBUILD generated/aur/vibepanel-git/PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=${pkgver}/" generated/aur/vibepanel-git/PKGBUILD
+
+      - name: Validate PKGBUILD
+        run: |
+          docker run --rm \
+            --platform linux/amd64 \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            archlinux:base-devel \
+            bash -lc 'useradd -m builder && su builder -c "makepkg --printsrcinfo -p generated/aur/vibepanel-git/PKGBUILD >/dev/null"'
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: vibepanel-git
+          pkgbuild: ./generated/aur/vibepanel-git/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update vibepanel-git package"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+          allow_empty_commits: false
 
   publish-copr:
     name: Publish to Copr
@@ -201,6 +299,8 @@ jobs:
       image: fedora:latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Install copr-cli
         run: dnf install -y copr-cli


### PR DESCRIPTION
Adds AUR packaging for the full package trio:
- vibepanel-bin keeps publishing the prebuilt release binary
- vibepanel builds tagged releases from source
- vibepanel-git tracks latest git source