### PR TITLE
feat(clock): add DankCalendar event support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,7 @@ background_opacity = 1.0
 #   [widgets.clock]
 #   format = "%H:%M"
 #   show_weather = true # Embed weather content in the clock/calendar popover
+#   calendar_events = false # Disable automatic DankCalendar event discovery
 #   # When "clock" and "weather" are in the same explicit group, they merge
 #   # into one calendar/weather button unless show_weather = false is set.
 #   outline_color = "accent"  # Per-widget outline color: "subtle" | "accent" | "foreground" | "#rrggbb"

--- a/crates/vibepanel/src/bar.rs
+++ b/crates/vibepanel/src/bar.rs
@@ -1220,6 +1220,7 @@ fn build_merge_group(
                     &menu_handle,
                     clock_config.show_week_numbers,
                     show_weather,
+                    clock_config.calendar_events,
                 );
                 let built_widgets = entries
                     .iter()

--- a/crates/vibepanel/src/bar_tests.rs
+++ b/crates/vibepanel/src/bar_tests.rs
@@ -316,6 +316,41 @@ fn run_layer_shell_popover_position_contract(position: &str) {
     flush_gtk();
 }
 
+fn run_layer_shell_popover_on_show_reversal_contract() {
+    let Some(context) = layer_shell_context_or_skip() else {
+        return;
+    };
+
+    let mut config = layer_shell_test_config();
+    config.theme.animations = true;
+    apply_layer_shell_config(&config, true);
+    let show_count = Rc::new(Cell::new(0));
+    let close_count = Rc::new(Cell::new(0));
+    let popover = LayerShellPopover::new(&context.app, "contract", || {
+        gtk4::Label::new(Some("contract popover")).upcast::<gtk4::Widget>()
+    });
+    let show_count_for_callback = show_count.clone();
+    popover.set_on_show(move || show_count_for_callback.set(show_count_for_callback.get() + 1));
+    let close_count_for_callback = close_count.clone();
+    popover.set_on_close(move || close_count_for_callback.set(close_count_for_callback.get() + 1));
+    let anchor = PopoverAnchor { x: 160, y: 160 };
+
+    popover.show_at(anchor, Some(context.monitor.clone()));
+    assert_eq!(show_count.get(), 1);
+    popover.hide();
+    popover.show_at(anchor, Some(context.monitor.clone()));
+    assert_eq!(show_count.get(), 2);
+    assert_eq!(close_count.get(), 0);
+
+    if let Some(window) = popover.test_window() {
+        window.close();
+    }
+    if let Some(catcher) = popover.test_click_catcher() {
+        catcher.close();
+    }
+    flush_gtk();
+}
+
 fn run_layer_shell_popover_offset_contract(position: &str, background_opacity: f64) {
     let Some(context) = layer_shell_context_or_skip() else {
         return;
@@ -543,6 +578,11 @@ layer_shell_contract_tests!(
         test_layer_shell_popover_position_right,
         "popover.position.right",
         run_layer_shell_popover_position_contract("right")
+    ),
+    (
+        test_layer_shell_popover_on_show_reversal,
+        "popover.on-show-reversal",
+        run_layer_shell_popover_on_show_reversal_contract()
     ),
     (
         test_layer_shell_popover_offset_top,

--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -30,6 +30,7 @@ pub mod battery;
 pub mod battery_alert;
 pub mod bluetooth;
 pub mod brightness;
+pub mod calendar;
 pub mod callbacks;
 pub mod cava;
 pub mod compositor;

--- a/crates/vibepanel/src/services/calendar.rs
+++ b/crates/vibepanel/src/services/calendar.rs
@@ -1,0 +1,995 @@
+//! DankCalendar-backed event service.
+
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, HashMap};
+use std::env;
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Datelike, Local, NaiveDate, Utc};
+use gtk4::glib;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use super::callbacks::{CallbackId, Callbacks};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+const EVENT_LIMIT: usize = 5000;
+const GTK_CALENDAR_GRID_PADDING_DAYS: i64 = 14;
+const FETCH_ERROR_MESSAGE: &str = "Error fetching calendar events. Check logs for details.";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CalendarEvent {
+    pub calendar_name: String,
+    pub color: Option<String>,
+    pub title: String,
+    pub location: String,
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+    pub all_day: bool,
+}
+
+impl CalendarEvent {
+    /// Last local day occupied by this event; calendar end times are exclusive.
+    pub(crate) fn final_day(&self) -> NaiveDate {
+        if self.end > self.start {
+            (self.end - chrono::Duration::nanoseconds(1)).date_naive()
+        } else {
+            self.start.date_naive()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CalendarSnapshot {
+    pub focus_month: Option<NaiveDate>,
+    pub loading: bool,
+    pub error: Option<String>,
+    pub backend_available: bool,
+    pub events_by_date: BTreeMap<NaiveDate, Vec<Arc<CalendarEvent>>>,
+}
+
+impl CalendarSnapshot {
+    pub fn matches_focus_month(&self, date: NaiveDate) -> bool {
+        self.focus_month == Some(month_start(date))
+    }
+}
+
+pub struct CalendarService {
+    snapshot: RefCell<CalendarSnapshot>,
+    callbacks: Callbacks<CalendarSnapshot>,
+    generation: Cell<u64>,
+    worker_active: Cell<bool>,
+    pending_refresh: RefCell<Option<RefreshRequest>>,
+}
+
+#[derive(Clone, Copy)]
+struct RefreshRequest {
+    generation: u64,
+    focus_date: NaiveDate,
+}
+
+impl CalendarService {
+    fn new() -> Rc<Self> {
+        Rc::new(Self {
+            snapshot: RefCell::new(CalendarSnapshot::default()),
+            callbacks: Callbacks::new(),
+            generation: Cell::new(0),
+            worker_active: Cell::new(false),
+            pending_refresh: RefCell::new(None),
+        })
+    }
+
+    pub fn global() -> Rc<Self> {
+        thread_local! {
+            static INSTANCE: Rc<CalendarService> = CalendarService::new();
+        }
+        INSTANCE.with(|s| s.clone())
+    }
+
+    pub fn connect<F>(&self, callback: F) -> CallbackId
+    where
+        F: Fn(&CalendarSnapshot) + 'static,
+    {
+        let id = self.callbacks.register(callback);
+        let snapshot = self.snapshot();
+        self.callbacks.notify_single(id, &snapshot);
+        id
+    }
+
+    pub fn disconnect(&self, id: CallbackId) -> bool {
+        self.callbacks.unregister(id)
+    }
+
+    pub fn snapshot(&self) -> CalendarSnapshot {
+        self.snapshot.borrow().clone()
+    }
+
+    pub fn ensure_discovery(&self, focus_date: NaiveDate) {
+        if self.worker_active.get() || self.snapshot.borrow().backend_available {
+            return;
+        }
+        self.refresh(focus_date);
+    }
+
+    pub fn refresh(&self, focus_date: NaiveDate) {
+        let generation = self.generation.get().wrapping_add(1);
+        self.generation.set(generation);
+
+        let snapshot = {
+            let mut snapshot = self.snapshot.borrow_mut();
+            prepare_refresh_snapshot(&mut snapshot, focus_date);
+            snapshot.clone()
+        };
+
+        // Keep one blocking socket worker active and replace queued work with the
+        // latest navigation request. Queue before notifying because callbacks may
+        // re-enter refresh() with newer work.
+        self.pending_refresh.replace(Some(RefreshRequest {
+            generation,
+            focus_date,
+        }));
+        self.start_pending_refresh();
+        self.callbacks.notify(&snapshot);
+    }
+
+    fn start_pending_refresh(&self) {
+        if self.worker_active.get() {
+            return;
+        }
+        let Some(request) = self.pending_refresh.borrow_mut().take() else {
+            return;
+        };
+        self.worker_active.set(true);
+        std::thread::spawn(move || {
+            let result = fetch_dankcalendar_events(request.focus_date);
+            glib::idle_add_once(move || {
+                CalendarService::global().complete_refresh(request.generation, result);
+            });
+        });
+    }
+
+    fn complete_refresh(&self, generation: u64, result: Result<CalendarSnapshot, CalendarError>) {
+        self.apply_refresh_result(generation, result);
+        self.worker_active.set(false);
+        self.start_pending_refresh();
+    }
+
+    fn apply_refresh_result(
+        &self,
+        generation: u64,
+        result: Result<CalendarSnapshot, CalendarError>,
+    ) {
+        if generation != self.generation.get() {
+            return;
+        }
+        match result {
+            Ok(mut snapshot) => {
+                snapshot.loading = false;
+                self.set_snapshot(snapshot);
+            }
+            Err(CalendarError::Unavailable(error)) => {
+                debug!("CalendarService: {error}");
+                let mut snapshot = self.snapshot.borrow().clone();
+                snapshot.loading = false;
+                snapshot.error = None;
+                snapshot.backend_available = false;
+                snapshot.events_by_date.clear();
+                self.set_snapshot(snapshot);
+            }
+            Err(CalendarError::Fetch(error)) => {
+                warn!("CalendarService: {error}");
+                let mut snapshot = self.snapshot.borrow().clone();
+                snapshot.loading = false;
+                snapshot.backend_available = true;
+                snapshot.error = Some(FETCH_ERROR_MESSAGE.to_string());
+                self.set_snapshot(snapshot);
+            }
+        }
+    }
+
+    fn set_snapshot(&self, snapshot: CalendarSnapshot) {
+        self.snapshot.replace(snapshot.clone());
+        self.callbacks.notify(&snapshot);
+    }
+}
+
+#[derive(Debug)]
+enum CalendarError {
+    Unavailable(String),
+    Fetch(String),
+}
+
+fn fetch_dankcalendar_events(focus_date: NaiveDate) -> Result<CalendarSnapshot, CalendarError> {
+    let mut client = connect_dankcalendar().map_err(CalendarError::Unavailable)?;
+    let calendars = client.calendars_list().map_err(CalendarError::Fetch)?;
+    let (window_start, window_end) =
+        event_fetch_window(focus_date).map_err(CalendarError::Fetch)?;
+    let events = client
+        .events_list(window_start, window_end)
+        .map_err(CalendarError::Fetch)?;
+    Ok(CalendarSnapshot {
+        focus_month: Some(month_start(focus_date)),
+        loading: false,
+        error: None,
+        backend_available: true,
+        events_by_date: bucket_events(events, &calendars, window_start.date(), window_end.date()),
+    })
+}
+
+fn prepare_refresh_snapshot(snapshot: &mut CalendarSnapshot, focus_date: NaiveDate) {
+    let focus_month = month_start(focus_date);
+    if snapshot.focus_month != Some(focus_month) {
+        snapshot.events_by_date.clear();
+    }
+    snapshot.focus_month = Some(focus_month);
+    snapshot.loading = true;
+    snapshot.error = None;
+}
+
+fn month_start(date: NaiveDate) -> NaiveDate {
+    NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap_or(date)
+}
+
+struct DankCalendarClient {
+    reader: BufReader<UnixStream>,
+    next_id: i64,
+}
+
+impl DankCalendarClient {
+    fn connect(path: &Path) -> Result<Self, String> {
+        let stream = UnixStream::connect(path)
+            .map_err(|e| format!("connect DankCalendar socket {}: {e}", path.display()))?;
+        stream
+            .set_read_timeout(Some(REQUEST_TIMEOUT))
+            .map_err(|e| format!("set read timeout: {e}"))?;
+        stream
+            .set_write_timeout(Some(REQUEST_TIMEOUT))
+            .map_err(|e| format!("set write timeout: {e}"))?;
+
+        let mut reader = BufReader::new(stream);
+        let mut capabilities = String::new();
+        let read = reader
+            .read_line(&mut capabilities)
+            .map_err(|e| format!("read DankCalendar capabilities: {e}"))?;
+        if read == 0 {
+            return Err("DankCalendar socket closed before capabilities".to_string());
+        }
+        debug!("DankCalendar capabilities: {}", capabilities.trim());
+        Ok(Self { reader, next_id: 1 })
+    }
+
+    fn calendars_list(&mut self) -> Result<HashMap<String, DankCalendar>, String> {
+        let value = self.request("calendars.list", None)?;
+        let calendars: Vec<DankCalendar> = serde_json::from_value(value)
+            .map_err(|e| format!("parse DankCalendar calendars: {e}"))?;
+        Ok(calendars
+            .into_iter()
+            .map(|calendar| (calendar.id.clone(), calendar))
+            .collect())
+    }
+
+    fn events_list(
+        &mut self,
+        window_start: chrono::NaiveDateTime,
+        window_end: chrono::NaiveDateTime,
+    ) -> Result<Vec<DankEvent>, String> {
+        let from = window_start
+            .and_local_timezone(Local)
+            .single()
+            .unwrap_or_else(|| {
+                DateTime::<Utc>::from_naive_utc_and_offset(window_start, Utc).with_timezone(&Local)
+            });
+        let to = window_end
+            .and_local_timezone(Local)
+            .single()
+            .unwrap_or_else(|| {
+                DateTime::<Utc>::from_naive_utc_and_offset(window_end, Utc).with_timezone(&Local)
+            });
+
+        let value = self.request(
+            "events.list",
+            // DankCalendar uses this range to expand recurring events server-side.
+            Some(json!({
+                "from": from.to_rfc3339(),
+                "to": to.to_rfc3339(),
+                "limit": EVENT_LIMIT,
+            })),
+        )?;
+        let response: DankEventsResponse =
+            serde_json::from_value(value).map_err(|e| format!("parse DankCalendar events: {e}"))?;
+        Ok(response.events)
+    }
+
+    fn request(&mut self, method: &str, params: Option<Value>) -> Result<Value, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let request = match params {
+            Some(params) => json!({"id": id, "method": method, "params": params}),
+            None => json!({"id": id, "method": method}),
+        };
+        let stream = self.reader.get_mut();
+        writeln!(stream, "{request}").map_err(|e| format!("write DankCalendar request: {e}"))?;
+        stream
+            .flush()
+            .map_err(|e| format!("flush DankCalendar request: {e}"))?;
+
+        loop {
+            let mut line = String::new();
+            let read = self
+                .reader
+                .read_line(&mut line)
+                .map_err(|e| format!("read DankCalendar response: {e}"))?;
+            if read == 0 {
+                return Err("DankCalendar socket closed".to_string());
+            }
+            let response: DankResponse = serde_json::from_str(line.trim())
+                .map_err(|e| format!("parse DankCalendar response: {e}"))?;
+            if response.id != Some(id) {
+                continue;
+            }
+            if let Some(error) = response.error {
+                return Err(error);
+            }
+            return Ok(response.result.unwrap_or(Value::Null));
+        }
+    }
+}
+
+fn event_fetch_window(
+    focus_date: NaiveDate,
+) -> Result<(chrono::NaiveDateTime, chrono::NaiveDateTime), String> {
+    let month_start = month_start(focus_date);
+    let next_month = if month_start.month() == 12 {
+        NaiveDate::from_ymd_opt(month_start.year() + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(month_start.year(), month_start.month() + 1, 1)
+    }
+    .ok_or_else(|| "invalid focus date".to_string())?;
+
+    // GtkCalendar always renders a 6x7 grid; this covers adjacent-month spillover.
+    let start = month_start - chrono::Duration::days(GTK_CALENDAR_GRID_PADDING_DAYS);
+    let end = next_month + chrono::Duration::days(GTK_CALENDAR_GRID_PADDING_DAYS);
+    Ok((
+        start
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| "invalid fetch window".to_string())?,
+        end.and_hms_opt(0, 0, 0)
+            .ok_or_else(|| "invalid fetch window".to_string())?,
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+struct DankResponse {
+    id: Option<i64>,
+    result: Option<Value>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DankCalendar {
+    id: String,
+    name: String,
+    #[serde(default)]
+    color: Option<String>,
+    #[serde(default)]
+    hidden: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct DankEventsResponse {
+    events: Vec<DankEvent>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DankEvent {
+    #[serde(default)]
+    calendar_id: String,
+    #[serde(default)]
+    summary: String,
+    #[serde(default)]
+    location: String,
+    start: String,
+    end: String,
+    #[serde(default)]
+    all_day: bool,
+    #[serde(default)]
+    status: String,
+}
+
+fn bucket_events(
+    events: Vec<DankEvent>,
+    calendars: &HashMap<String, DankCalendar>,
+    window_start: NaiveDate,
+    window_end: NaiveDate,
+) -> BTreeMap<NaiveDate, Vec<Arc<CalendarEvent>>> {
+    let mut by_date: BTreeMap<NaiveDate, Vec<Arc<CalendarEvent>>> = BTreeMap::new();
+    let Some(last_window_day) = window_end.pred_opt() else {
+        return by_date;
+    };
+    for event in events {
+        if event.status == "cancelled" {
+            continue;
+        }
+        let calendar = calendars.get(&event.calendar_id);
+        if calendar.is_some_and(|calendar| calendar.hidden) {
+            continue;
+        }
+        let Some(normalized) = normalize_event(&event, calendar).map(Arc::new) else {
+            continue;
+        };
+        let Some((event_start_day, event_end_day)) = event_day_range(&event, &normalized) else {
+            continue;
+        };
+        let start_day = event_start_day.max(window_start);
+        let end_day = event_end_day.min(last_window_day);
+        if start_day > end_day {
+            continue;
+        }
+        let mut day = start_day;
+        while day <= end_day {
+            by_date
+                .entry(day)
+                .or_default()
+                .push(Arc::clone(&normalized));
+            if day == end_day {
+                break;
+            }
+            let Some(next_day) = day.succ_opt() else {
+                break;
+            };
+            day = next_day;
+        }
+    }
+    for events in by_date.values_mut() {
+        events.sort_by_key(|event| (!event.all_day, event.start));
+    }
+    by_date
+}
+
+fn normalize_event(event: &DankEvent, calendar: Option<&DankCalendar>) -> Option<CalendarEvent> {
+    let start = parse_event_time(&event.start)?;
+    let end = parse_event_time(&event.end)?;
+    Some(CalendarEvent {
+        calendar_name: calendar.map(|c| c.name.clone()).unwrap_or_default(),
+        color: calendar.and_then(|c| c.color.clone()),
+        title: if event.summary.is_empty() {
+            "(untitled)".to_string()
+        } else {
+            event.summary.clone()
+        },
+        location: event.location.clone(),
+        start,
+        end,
+        all_day: event.all_day,
+    })
+}
+
+fn parse_event_time(value: &str) -> Option<DateTime<Local>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|time| time.with_timezone(&Local))
+}
+
+fn event_day_range(
+    event: &DankEvent,
+    normalized: &CalendarEvent,
+) -> Option<(NaiveDate, NaiveDate)> {
+    if !event.all_day {
+        let start_day = normalized.start.date_naive();
+        let end_day = normalized.final_day().max(start_day);
+        return Some((start_day, end_day));
+    }
+
+    // All-day timestamps are civil dates from the daemon; local timezone conversion
+    // can shift their date, so bucket them from the raw RFC3339 values.
+    let start_day = DateTime::parse_from_rfc3339(&event.start)
+        .ok()?
+        .date_naive();
+    let mut end_day = DateTime::parse_from_rfc3339(&event.end).ok()?.date_naive();
+    if end_day > start_day {
+        end_day = end_day.pred_opt().unwrap_or(start_day);
+    }
+    Some((start_day, end_day.max(start_day)))
+}
+
+fn connect_dankcalendar() -> Result<DankCalendarClient, String> {
+    if cfg!(test) {
+        return Err("DankCalendar I/O disabled in tests".to_string());
+    }
+
+    let explicit_path = env::var_os("DANKCAL_SOCKET")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from);
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
+    connect_dankcalendar_with_paths(
+        explicit_path.as_deref(),
+        runtime_dir.as_deref(),
+        Path::new("/tmp"),
+    )
+}
+
+fn connect_dankcalendar_with_paths(
+    explicit_path: Option<&Path>,
+    runtime_dir: Option<&Path>,
+    fallback_dir: &Path,
+) -> Result<DankCalendarClient, String> {
+    if let Some(path) = explicit_path {
+        match DankCalendarClient::connect(path) {
+            Ok(client) => return Ok(client),
+            Err(error) => {
+                warn!("DANKCAL_SOCKET connect failed, falling back to discovery: {error}");
+            }
+        }
+    }
+
+    if let Some(runtime_dir) = &runtime_dir {
+        let flatpak_dir = runtime_dir.join("app/com.danklinux.dankcalendar");
+        if let Some(client) = connect_to_socket_in_dir(&flatpak_dir) {
+            return Ok(client);
+        }
+    }
+    for dir in runtime_dir.into_iter().chain([fallback_dir]) {
+        if let Some(client) = connect_to_socket_in_dir(dir) {
+            return Ok(client);
+        }
+    }
+    Err("DankCalendar socket not found".to_string())
+}
+
+fn connect_to_socket_in_dir(dir: &Path) -> Option<DankCalendarClient> {
+    let entries = fs::read_dir(dir).ok()?;
+    let mut candidates: Vec<_> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| is_dankcalendar_socket_name(path) && is_current_user_socket(path))
+        .collect();
+    candidates.sort();
+
+    for path in candidates {
+        if let Ok(client) = DankCalendarClient::connect(&path) {
+            return Some(client);
+        }
+    }
+    None
+}
+
+fn is_current_user_socket(path: &Path) -> bool {
+    path.metadata()
+        .map(|metadata| {
+            metadata.file_type().is_socket() && metadata.uid() == unsafe { libc::geteuid() }
+        })
+        .unwrap_or(false)
+}
+
+fn is_dankcalendar_socket_name(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(id) = name
+        .strip_prefix("dankcal-")
+        .and_then(|name| name.strip_suffix(".sock"))
+    else {
+        return false;
+    };
+    !id.is_empty() && id.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+    use std::os::unix::net::UnixListener;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_SOCKET_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestSocketDir {
+        path: PathBuf,
+    }
+
+    impl TestSocketDir {
+        fn new() -> Self {
+            let id = NEXT_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "vibepanel-calendar-dir-test-{}-{id}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create test socket directory");
+            Self { path }
+        }
+    }
+
+    impl Drop for TestSocketDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct TestSocket {
+        path: PathBuf,
+    }
+
+    impl TestSocket {
+        fn bind() -> (Self, UnixListener) {
+            let id = NEXT_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "vibepanel-calendar-test-{}-{id}.sock",
+                std::process::id()
+            ));
+            let listener = UnixListener::bind(&path).expect("bind test calendar socket");
+            (Self { path }, listener)
+        }
+    }
+
+    impl Drop for TestSocket {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn read_request(reader: &mut BufReader<UnixStream>) -> Value {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read client request");
+        assert!(line.ends_with('\n'), "request must be newline-delimited");
+        serde_json::from_str(line.trim()).expect("parse client request")
+    }
+
+    #[test]
+    fn buckets_all_day_end_exclusive() {
+        let event = DankEvent {
+            calendar_id: "cal".to_string(),
+            summary: "event".to_string(),
+            location: String::new(),
+            start: "2026-06-22T00:00:00Z".to_string(),
+            end: "2026-06-24T00:00:00Z".to_string(),
+            all_day: true,
+            status: String::new(),
+        };
+        let buckets = bucket_events(
+            vec![event],
+            &HashMap::new(),
+            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+        );
+        assert!(buckets.contains_key(&NaiveDate::from_ymd_opt(2026, 6, 22).unwrap()));
+        assert!(buckets.contains_key(&NaiveDate::from_ymd_opt(2026, 6, 23).unwrap()));
+        assert!(!buckets.contains_key(&NaiveDate::from_ymd_opt(2026, 6, 24).unwrap()));
+    }
+
+    #[test]
+    fn hidden_calendars_are_filtered() {
+        let event = DankEvent {
+            calendar_id: "cal".to_string(),
+            summary: "event".to_string(),
+            location: String::new(),
+            start: "2026-06-22T12:00:00Z".to_string(),
+            end: "2026-06-22T13:00:00Z".to_string(),
+            all_day: false,
+            status: String::new(),
+        };
+        let calendars = HashMap::from([(
+            "cal".to_string(),
+            DankCalendar {
+                id: "cal".to_string(),
+                name: "Hidden".to_string(),
+                color: None,
+                hidden: true,
+            },
+        )]);
+        assert!(
+            bucket_events(
+                vec![event],
+                &calendars,
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn fetch_window_covers_visible_month_grid_spillover() {
+        let (start, end) = event_fetch_window(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap())
+            .expect("valid fetch window");
+
+        assert_eq!(start.date(), NaiveDate::from_ymd_opt(2026, 1, 18).unwrap());
+        assert_eq!(end.date(), NaiveDate::from_ymd_opt(2026, 3, 15).unwrap());
+    }
+
+    #[test]
+    fn timed_event_ending_at_midnight_stays_on_start_day() {
+        let start = Local.with_ymd_and_hms(2026, 6, 22, 23, 0, 0).unwrap();
+        let end = Local.with_ymd_and_hms(2026, 6, 23, 0, 0, 0).unwrap();
+        let event = DankEvent {
+            calendar_id: "cal".to_string(),
+            summary: "event".to_string(),
+            location: String::new(),
+            start: start.to_rfc3339(),
+            end: end.to_rfc3339(),
+            all_day: false,
+            status: String::new(),
+        };
+        let buckets = bucket_events(
+            vec![event],
+            &HashMap::new(),
+            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+        );
+        assert!(buckets.contains_key(&NaiveDate::from_ymd_opt(2026, 6, 22).unwrap()));
+        assert!(!buckets.contains_key(&NaiveDate::from_ymd_opt(2026, 6, 23).unwrap()));
+    }
+
+    #[test]
+    fn buckets_long_events_only_inside_fetch_window() {
+        let event = DankEvent {
+            calendar_id: "cal".to_string(),
+            summary: "event".to_string(),
+            location: String::new(),
+            start: "2020-01-01T00:00:00Z".to_string(),
+            end: "2030-01-01T00:00:00Z".to_string(),
+            all_day: true,
+            status: String::new(),
+        };
+        let window_start = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let window_end = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+
+        let buckets = bucket_events(vec![event], &HashMap::new(), window_start, window_end);
+
+        assert_eq!(buckets.len(), 30);
+        assert_eq!(
+            buckets.first_key_value().map(|(date, _)| *date),
+            Some(window_start)
+        );
+        assert_eq!(
+            buckets.last_key_value().map(|(date, _)| *date),
+            window_end.pred_opt()
+        );
+    }
+
+    #[test]
+    fn refresh_snapshot_clears_events_only_when_focus_month_changes() {
+        let june = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let july = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+        let mut snapshot = CalendarSnapshot {
+            focus_month: Some(june),
+            loading: false,
+            error: Some("old error".to_string()),
+            backend_available: true,
+            events_by_date: BTreeMap::from([(june, Vec::new())]),
+        };
+
+        prepare_refresh_snapshot(&mut snapshot, NaiveDate::from_ymd_opt(2026, 6, 20).unwrap());
+        assert!(snapshot.events_by_date.contains_key(&june));
+        assert!(snapshot.matches_focus_month(june));
+        assert!(snapshot.loading);
+        assert!(snapshot.error.is_none());
+
+        prepare_refresh_snapshot(&mut snapshot, NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+        assert!(snapshot.events_by_date.is_empty());
+        assert!(snapshot.matches_focus_month(july));
+        assert!(!snapshot.matches_focus_month(june));
+    }
+
+    #[test]
+    fn refresh_results_distinguish_absent_and_fetch_errors() {
+        let service = CalendarService::new();
+
+        service.apply_refresh_result(
+            0,
+            Err(CalendarError::Fetch(
+                "socket /tmp/dankcal-123.sock closed".to_string(),
+            )),
+        );
+
+        assert_eq!(
+            service.snapshot().error.as_deref(),
+            Some("Error fetching calendar events. Check logs for details.")
+        );
+        assert!(service.snapshot().backend_available);
+        service.snapshot.borrow_mut().events_by_date =
+            BTreeMap::from([(NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(), Vec::new())]);
+
+        service.apply_refresh_result(
+            0,
+            Err(CalendarError::Unavailable(
+                "DankCalendar socket not found".to_string(),
+            )),
+        );
+
+        assert!(service.snapshot().error.is_none());
+        assert!(!service.snapshot().backend_available);
+        assert!(service.snapshot().events_by_date.is_empty());
+    }
+
+    #[test]
+    fn refresh_coalesces_pending_work_to_latest_request() {
+        let service = CalendarService::new();
+        service.worker_active.set(true);
+        let june = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let july = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+        let august = NaiveDate::from_ymd_opt(2026, 8, 1).unwrap();
+
+        service.refresh(june);
+        service.refresh(july);
+        service.refresh(august);
+
+        let pending = service
+            .pending_refresh
+            .borrow()
+            .expect("latest request queued");
+        assert_eq!(pending.generation, service.generation.get());
+        assert_eq!(pending.focus_date, august);
+        assert!(service.snapshot().matches_focus_month(august));
+    }
+
+    #[test]
+    fn reentrant_refresh_keeps_newest_pending_request() {
+        let service = CalendarService::new();
+        service.worker_active.set(true);
+        let june = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let july = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+        let reentered = Rc::new(Cell::new(false));
+        let service_for_callback = service.clone();
+        let reentered_for_callback = reentered.clone();
+        let callback_id = service.connect(move |snapshot| {
+            if snapshot.loading && !reentered_for_callback.replace(true) {
+                service_for_callback.refresh(july);
+            }
+        });
+
+        service.refresh(june);
+
+        let pending = service
+            .pending_refresh
+            .borrow()
+            .expect("reentrant request queued");
+        assert_eq!(pending.generation, service.generation.get());
+        assert_eq!(pending.focus_date, july);
+        assert!(service.snapshot().matches_focus_month(july));
+        assert!(service.disconnect(callback_id));
+    }
+
+    #[test]
+    fn discovery_skips_stale_socket_before_live_socket() {
+        let dir = TestSocketDir::new();
+        let mut live_pids = [unsafe { libc::getppid() } as u32, std::process::id()];
+        live_pids.sort_by_key(u32::to_string);
+
+        let stale_path = dir.path.join(format!("dankcal-{}.sock", live_pids[0]));
+        drop(UnixListener::bind(stale_path).expect("bind stale socket"));
+
+        let live_path = dir.path.join(format!("dankcal-{}.sock", live_pids[1]));
+        let listener = UnixListener::bind(live_path).expect("bind live socket");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept discovered client");
+            writeln!(stream, "capabilities").unwrap();
+        });
+
+        let client = connect_to_socket_in_dir(&dir.path).expect("discover live socket");
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn invalid_explicit_socket_falls_back_to_discovery() {
+        let dir = TestSocketDir::new();
+        let live_path = dir
+            .path
+            .join(format!("dankcal-{}.sock", std::process::id()));
+        let listener = UnixListener::bind(live_path).expect("bind discovered socket");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept discovered client");
+            writeln!(stream, "capabilities").unwrap();
+        });
+        let missing_path = dir.path.join("missing.sock");
+
+        let client = connect_dankcalendar_with_paths(
+            Some(&missing_path),
+            Some(&dir.path),
+            Path::new("/nonexistent-vibepanel-calendar-test-dir"),
+        )
+        .expect("fall back to discovered socket");
+
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn client_frames_requests_and_discards_nonmatching_response_ids() {
+        let (socket, listener) = TestSocket::bind();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept client");
+            writeln!(stream, r#"{{"protocol":"dankcalendar"}}"#).unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+            let calendars_request = read_request(&mut reader);
+            assert_eq!(calendars_request["id"], 1);
+            assert_eq!(calendars_request["method"], "calendars.list");
+            assert!(calendars_request.get("params").is_none());
+            // A future response arriving before its request is not this call's result.
+            writeln!(stream, r#"{{"id":2,"result":{{"events":["premature"]}}}}"#).unwrap();
+            writeln!(stream, r#"{{"id":1,"result":[]}}"#).unwrap();
+
+            let events_request = read_request(&mut reader);
+            assert_eq!(events_request["id"], 2);
+            assert_eq!(events_request["method"], "events.list");
+            assert_eq!(events_request["params"]["limit"], EVENT_LIMIT);
+            assert!(events_request["params"]["from"].as_str().is_some());
+            assert!(events_request["params"]["to"].as_str().is_some());
+            writeln!(stream, r#"{{"id":2,"result":{{"events":[]}}}}"#).unwrap();
+        });
+
+        let mut client = DankCalendarClient::connect(&socket.path).unwrap();
+        assert!(client.calendars_list().unwrap().is_empty());
+        let from = NaiveDate::from_ymd_opt(2026, 6, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let to = NaiveDate::from_ymd_opt(2026, 7, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        assert!(client.events_list(from, to).unwrap().is_empty());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn client_reports_eof_before_capabilities() {
+        let (socket, listener) = TestSocket::bind();
+        let server = std::thread::spawn(move || drop(listener.accept().expect("accept client")));
+
+        let error = DankCalendarClient::connect(&socket.path)
+            .err()
+            .expect("EOF must fail connection");
+
+        assert!(error.contains("closed before capabilities"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn client_reports_eof_while_waiting_for_response() {
+        let (socket, listener) = TestSocket::bind();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept client");
+            writeln!(stream, "capabilities").unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            read_request(&mut reader);
+        });
+
+        let mut client = DankCalendarClient::connect(&socket.path).unwrap();
+        let error = client.calendars_list().unwrap_err();
+
+        assert_eq!(error, "DankCalendar socket closed");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn client_propagates_matching_response_errors() {
+        let (socket, listener) = TestSocket::bind();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept client");
+            writeln!(stream, "capabilities").unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let request = read_request(&mut reader);
+            writeln!(
+                stream,
+                r#"{{"id":{},"error":"calendar unavailable"}}"#,
+                request["id"]
+            )
+            .unwrap();
+        });
+
+        let mut client = DankCalendarClient::connect(&socket.path).unwrap();
+        assert_eq!(client.calendars_list().unwrap_err(), "calendar unavailable");
+        server.join().unwrap();
+    }
+}

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -1056,6 +1056,9 @@ pub mod calendar {
     /// Calendar card container (`.calendar-popover-card`).
     pub const CARD: &str = "calendar-popover-card";
 
+    /// Calendar and event side-by-side row (`.calendar-events-layout`).
+    pub const EVENTS_LAYOUT: &str = "calendar-events-layout";
+
     /// Calendar header (`.calendar-header`).
     pub const HEADER: &str = "calendar-header";
 
@@ -1070,6 +1073,30 @@ pub mod calendar {
 
     /// Show today state (`.show-today`).
     pub const SHOW_TODAY: &str = "show-today";
+
+    /// Calendar events enabled state (`.calendar-events-enabled`).
+    pub const EVENTS_ENABLED: &str = "calendar-events-enabled";
+
+    /// Event list card (`.calendar-events-card`).
+    pub const EVENTS_CARD: &str = "calendar-events-card";
+
+    /// Event list container (`.calendar-events-list`).
+    pub const EVENTS_LIST: &str = "calendar-events-list";
+
+    /// Empty/loading/error event state (`.calendar-events-state`).
+    pub const EVENTS_STATE: &str = "calendar-events-state";
+
+    /// Single event row (`.calendar-event-row`).
+    pub const EVENT_ROW: &str = "calendar-event-row";
+
+    /// Event color marker (`.calendar-event-marker`).
+    pub const EVENT_MARKER: &str = "calendar-event-marker";
+
+    /// Event title (`.calendar-event-title`).
+    pub const EVENT_TITLE: &str = "calendar-event-title";
+
+    /// Event metadata (`.calendar-event-detail`).
+    pub const EVENT_DETAIL: &str = "calendar-event-detail";
 }
 
 /// Weather popover classes.

--- a/crates/vibepanel/src/widgets/base.rs
+++ b/crates/vibepanel/src/widgets/base.rs
@@ -229,7 +229,9 @@ impl MenuHandle {
     /// Set a callback to be invoked every time the popover is shown.
     ///
     /// If the popover hasn't been created yet (lazy init), the callback is
-    /// stored and forwarded when `ensure_popover()` creates it.
+    /// stored and forwarded when `ensure_popover()` creates it. This includes
+    /// close-animation reversals before `on_close`, so resource acquisition must
+    /// remain idempotent until `on_close` runs.
     pub fn set_on_show<F: Fn() + 'static>(&self, callback: F) {
         let cb = Rc::new(callback);
         *self.on_show.borrow_mut() = Some(cb.clone());

--- a/crates/vibepanel/src/widgets/calendar_popover.rs
+++ b/crates/vibepanel/src/widgets/calendar_popover.rs
@@ -1,15 +1,30 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::Once;
 
-use chrono::{Datelike, Local, NaiveDate};
+use chrono::{Datelike, Local, NaiveDate, Timelike};
+use gtk4::cairo;
+use gtk4::gdk::RGBA;
+use gtk4::glib::markup_escape_text;
+use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Calendar, Label, Orientation, Overlay, Widget};
+use gtk4::{
+    Align, Box as GtkBox, Calendar, DrawingArea, Label, Orientation, Overlay, PolicyType,
+    ScrolledWindow, SizeGroup, SizeGroupMode, Widget,
+};
 
+use crate::services::calendar::{CalendarEvent, CalendarService, CalendarSnapshot};
 use crate::services::icons::IconsService;
-use crate::styles::{calendar as cal, icon, surface};
+use crate::styles::{calendar as cal, color, icon, surface};
 use crate::widgets::weather_popover::build_weather_content_reactive;
 
 pub type ClockPopoverRefresh = Rc<dyn Fn()>;
+pub type CalendarSnapshotRefresh = Rc<dyn Fn(&CalendarSnapshot)>;
+
+const EVENTS_LIST_MAX_HEIGHT: i32 = 360;
+const EVENT_LABEL_WIDTH_CHARS: i32 = 26;
+const GTK_CALENDAR_DAY_COUNT: usize = 42;
+static INVALID_CALENDAR_GRID_WARNING: Once = Once::new();
 
 /// Build a calendar popover for the clock widget.
 ///
@@ -23,11 +38,18 @@ pub type ClockPopoverRefresh = Rc<dyn Fn()>;
 pub fn build_clock_calendar_popover(
     show_week_numbers: bool,
     show_weather: bool,
-) -> (Widget, ClockPopoverRefresh, Option<ClockPopoverRefresh>) {
+    events_enabled: bool,
+) -> (
+    Widget,
+    ClockPopoverRefresh,
+    Option<ClockPopoverRefresh>,
+    Option<CalendarSnapshotRefresh>,
+) {
     // "Today" is stored in a Cell so the on_show refresh callback can update
     // it when the popover is reused across midnight boundaries.
     let today = Rc::new(Cell::new(Local::now().date_naive()));
-    let current_date = Rc::new(RefCell::new(today.get()));
+    let visible_month = Rc::new(Cell::new(today.get()));
+    let selected_date = Rc::new(Cell::new(today.get()));
     // Flag to prevent signal handler from interfering during programmatic updates
     let updating = Rc::new(Cell::new(false));
 
@@ -35,9 +57,19 @@ pub fn build_clock_calendar_popover(
     let container = GtkBox::new(Orientation::Vertical, 12);
     container.add_css_class(cal::POPOVER);
 
+    let compact_size_groups = (show_weather && events_enabled).then(|| {
+        (
+            SizeGroup::new(SizeGroupMode::Horizontal),
+            SizeGroup::new(SizeGroupMode::Horizontal),
+        )
+    });
+
     let calendar_card = GtkBox::new(Orientation::Vertical, 0);
-    if show_weather {
+    if show_weather || events_enabled {
         calendar_card.add_css_class(cal::CARD);
+    }
+    if let Some((left_size_group, _)) = &compact_size_groups {
+        left_size_group.add_widget(&calendar_card);
     }
 
     // Header: left-aligned label + right-aligned navigation buttons
@@ -93,37 +125,144 @@ pub fn build_clock_calendar_popover(
     calendar.set_halign(Align::Fill);
     // Initially show today styling since we start in the current month
     calendar.add_css_class(cal::SHOW_TODAY);
+    if events_enabled {
+        calendar.add_css_class(cal::EVENTS_ENABLED);
+    }
 
-    // Wrapper to center the calendar+overlay in the popover
+    // GtkCalendar owns selection, navigation, locale, and accessibility; this overlay
+    // only paints event dots above its existing day labels.
+    let event_dot_state = Rc::new(RefCell::new(CalendarEventDotState::default()));
+    let event_dots = DrawingArea::new();
+    event_dots.set_hexpand(true);
+    event_dots.set_vexpand(true);
+    event_dots.set_halign(Align::Fill);
+    event_dots.set_valign(Align::Fill);
+    event_dots.set_can_target(false);
+    {
+        let calendar = calendar.downgrade();
+        let event_dot_state = event_dot_state.clone();
+        event_dots.set_draw_func(move |area, cr, _width, _height| {
+            let Some(calendar) = calendar.upgrade() else {
+                return;
+            };
+            draw_event_dots(area, &calendar, cr, &event_dot_state.borrow());
+        });
+    }
+
+    // Wrapper to center the calendar overlay in the popover.
     let wrapper = GtkBox::new(Orientation::Vertical, 0);
     wrapper.set_halign(Align::Center);
 
-    if show_week_numbers {
-        // Week number header "w"
-        // We use an Overlay to position the "w" label precisely over the top-left corner
-        // of the calendar, aligning it with the week number column.
-        let overlay = Overlay::new();
-        overlay.set_child(Some(&calendar));
+    let overlay = Overlay::new();
+    overlay.set_child(Some(&calendar));
+    overlay.add_overlay(&event_dots);
 
+    if show_week_numbers {
+        // Align the week-number header with GtkCalendar's internal week-number column.
         let w_label = Label::new(Some("w"));
         w_label.add_css_class("week-number-header");
         w_label.set_halign(Align::Start);
         w_label.set_valign(Align::Start);
 
         overlay.add_overlay(&w_label);
-        wrapper.append(&overlay);
-    } else {
-        // No week numbers, just append calendar directly
-        wrapper.append(&calendar);
     }
+    wrapper.append(&overlay);
 
     calendar_card.append(&wrapper);
-    container.append(&calendar_card);
 
-    let weather_refresh = if show_weather {
-        let (weather, refresh) = build_weather_content_reactive();
-        container.append(&weather);
-        Some(refresh)
+    let calendar_events_layout = if events_enabled {
+        let layout = GtkBox::new(Orientation::Horizontal, 12);
+        layout.add_css_class(cal::EVENTS_LAYOUT);
+        layout.append(&calendar_card);
+        Some(layout)
+    } else {
+        container.append(&calendar_card);
+        None
+    };
+
+    let (events_content, events_title) = if events_enabled {
+        let events_card = GtkBox::new(Orientation::Vertical, 8);
+        events_card.add_css_class(cal::EVENTS_CARD);
+        if let Some((_, right_size_group)) = &compact_size_groups {
+            right_size_group.add_widget(&events_card);
+        }
+
+        let title = Label::new(None);
+        title.add_css_class(surface::POPOVER_TITLE);
+        title.set_xalign(0.0);
+        events_card.append(&title);
+
+        let content = GtkBox::new(Orientation::Vertical, 6);
+        content.add_css_class(cal::EVENTS_LIST);
+        let scroller = ScrolledWindow::new();
+        scroller.set_policy(PolicyType::Never, PolicyType::Automatic);
+        scroller.set_child(Some(&content));
+        scroller.set_max_content_height(EVENTS_LIST_MAX_HEIGHT);
+        scroller.set_propagate_natural_height(true);
+        events_card.append(&scroller);
+        if let Some(layout) = &calendar_events_layout {
+            layout.append(&events_card);
+        }
+        (Some(content), Some(title))
+    } else {
+        (None, None)
+    };
+
+    let weather_result = if show_weather {
+        let (weather, refresh) = build_weather_content_reactive(compact_size_groups);
+        Some((weather, refresh))
+    } else {
+        None
+    };
+
+    let weather_refresh = match (calendar_events_layout, weather_result) {
+        (Some(layout), Some((weather, refresh))) => {
+            container.append(&layout);
+            container.append(&weather);
+            Some(refresh)
+        }
+        (Some(layout), None) => {
+            container.append(&layout);
+            None
+        }
+        (None, Some((weather, refresh))) => {
+            container.append(&weather);
+            Some(refresh)
+        }
+        (None, None) => None,
+    };
+
+    let update_events = {
+        let events_content = events_content.clone();
+        let selected_date = selected_date.clone();
+        let visible_month = visible_month.clone();
+        let calendar = calendar.downgrade();
+        let event_dots = event_dots.clone();
+        let event_dot_state = event_dot_state.clone();
+        move |snapshot: &CalendarSnapshot| {
+            let Some(calendar) = calendar.upgrade() else {
+                return;
+            };
+            let visible_month = visible_month.get();
+            if !snapshot.matches_focus_month(visible_month) {
+                return;
+            }
+            apply_event_marks(&calendar, visible_month, snapshot);
+            *event_dot_state.borrow_mut() =
+                CalendarEventDotState::from_snapshot(visible_month, snapshot);
+            event_dots.queue_draw();
+            if let Some(content) = &events_content {
+                rebuild_event_list(content, selected_date.get(), snapshot);
+            }
+        }
+    };
+
+    let events_refresh = if events_enabled {
+        let update_events = update_events.clone();
+        Some(
+            Rc::new(move |snapshot: &CalendarSnapshot| update_events(snapshot))
+                as CalendarSnapshotRefresh,
+        )
     } else {
         None
     };
@@ -138,32 +277,35 @@ pub fn build_clock_calendar_popover(
         }
     };
 
-    // Sync the GtkCalendar display and the `show-today` CSS class based on
-    // the logical date representing the visible month.
-    let update_calendar = {
-        let calendar = calendar.clone();
+    let set_calendar_date = {
+        let calendar = calendar.downgrade();
         let updating = updating.clone();
-        let today = today.clone();
         move |date: NaiveDate| {
-            let today = today.get();
-            let is_current_month = date.month() == today.month() && date.year() == today.year();
-
-            // Set flag to prevent signal handler from interfering
-            updating.set(true);
-
-            // Always set day to 1 first to avoid invalid intermediate states (e.g., Feb 30).
-            // This ensures month/year changes never fail due to the current day being invalid.
-            calendar.set_day(1);
-            calendar.set_year(date.year());
-            // GtkCalendar expects month in the 0-11 range (i32)
-            calendar.set_month(date.month0() as i32);
-            // Now set the actual day (today's day if current month, otherwise keep at 1)
-            if is_current_month {
-                calendar.set_day(today.day() as i32);
+            let Some(calendar) = calendar.upgrade() else {
+                return;
+            };
+            if calendar_selected_date(&calendar) == Some(date) {
+                return;
             }
 
+            updating.set(true);
+            calendar.set_day(1);
+            calendar.set_year(date.year());
+            calendar.set_month(date.month0() as i32);
+            calendar.set_day(date.day() as i32);
             updating.set(false);
+        }
+    };
 
+    let update_calendar_style = {
+        let calendar = calendar.downgrade();
+        let today = today.clone();
+        move |date: NaiveDate| {
+            let Some(calendar) = calendar.upgrade() else {
+                return;
+            };
+            let today = today.get();
+            let is_current_month = date.month() == today.month() && date.year() == today.year();
             if is_current_month {
                 calendar.add_css_class(cal::SHOW_TODAY);
             } else {
@@ -172,107 +314,100 @@ pub fn build_clock_calendar_popover(
         }
     };
 
+    let sync_calendar_state: Rc<dyn Fn(NaiveDate)> = {
+        let visible_month = visible_month.clone();
+        let selected_date = selected_date.clone();
+        let events_title = events_title.clone();
+        let update_header = update_header.clone();
+        let update_calendar_style = update_calendar_style.clone();
+        Rc::new(move |date| {
+            let month = date.with_day(1).unwrap_or(date);
+            selected_date.set(date);
+            visible_month.set(month);
+            if let Some(title) = &events_title {
+                title.set_label(&date.format("%A, %B %-d").to_string());
+            }
+            update_header(month);
+            update_calendar_style(month);
+        })
+    };
+
+    let navigate_calendar: Rc<dyn Fn(NaiveDate)> = {
+        let sync_calendar_state = sync_calendar_state.clone();
+        Rc::new(move |date| {
+            sync_calendar_state(date);
+            set_calendar_date(date);
+        })
+    };
+
     // Initial sync to today's month.
-    {
-        let date = *current_date.borrow();
-        update_header(date);
-        update_calendar(date);
-    }
+    let initial_date = visible_month.get();
+    navigate_calendar(initial_date);
 
     // Navigation button handlers ---------------------------------------------
 
-    {
-        let current_date = current_date.clone();
-        let update_header = update_header.clone();
-        let update_calendar = update_calendar.clone();
-        prev_button.connect_clicked(move |_| {
-            let new_date = {
-                let date = current_date.borrow();
-                let mut year = date.year();
-                let mut month = date.month();
-                if month == 1 {
-                    month = 12;
-                    year -= 1;
-                } else {
-                    month -= 1;
-                }
-                NaiveDate::from_ymd_opt(year, month, 1)
-            };
-            if let Some(new_date) = new_date {
-                *current_date.borrow_mut() = new_date;
-                update_header(new_date);
-                update_calendar(new_date);
+    let change_month: Rc<dyn Fn(i32)> = {
+        let selected_date = selected_date.clone();
+        let navigate_calendar = navigate_calendar.clone();
+        Rc::new(move |delta| {
+            let new_date = add_months(selected_date.get(), delta);
+            navigate_calendar(new_date);
+            if events_enabled {
+                CalendarService::global().refresh(new_date);
             }
-        });
+        })
+    };
+
+    {
+        let change_month = change_month.clone();
+        prev_button.connect_clicked(move |_| change_month(-1));
     }
 
     {
-        let current_date = current_date.clone();
-        let update_header = update_header.clone();
-        let update_calendar = update_calendar.clone();
+        let navigate_calendar = navigate_calendar.clone();
         let today = today.clone();
         today_button.connect_clicked(move |_| {
             let today = today.get();
-            let today_month = NaiveDate::from_ymd_opt(today.year(), today.month(), 1);
-            if let Some(new_date) = today_month {
-                *current_date.borrow_mut() = new_date;
-                update_header(new_date);
-                update_calendar(new_date);
+            navigate_calendar(today);
+            if events_enabled {
+                CalendarService::global().refresh(today);
             }
         });
     }
 
     {
-        let current_date = current_date.clone();
-        let update_header = update_header.clone();
-        let update_calendar = update_calendar.clone();
-        next_button.connect_clicked(move |_| {
-            let new_date = {
-                let date = current_date.borrow();
-                let mut year = date.year();
-                let mut month = date.month();
-                if month == 12 {
-                    month = 1;
-                    year += 1;
-                } else {
-                    month += 1;
-                }
-                NaiveDate::from_ymd_opt(year, month, 1)
-            };
-            if let Some(new_date) = new_date {
-                *current_date.borrow_mut() = new_date;
-                update_header(new_date);
-                update_calendar(new_date);
-            }
-        });
+        let change_month = change_month.clone();
+        next_button.connect_clicked(move |_| change_month(1));
     }
 
-    // Calendar internal navigation (e.g., selecting a day that moves between
-    // months) should also keep `current_date` and the header / CSS in sync.
+    // GtkCalendar can change months through scrolling or spillover-day clicks
+    // without emitting day-selected. The date property covers every such change.
     {
-        let current_date = current_date.clone();
-        let update_header = update_header.clone();
-        let update_calendar = update_calendar.clone();
+        let visible_month = visible_month.clone();
+        let sync_calendar_state = sync_calendar_state.clone();
         let updating = updating.clone();
-        calendar.connect_day_selected(move |cal: &Calendar| {
-            // Skip if we're in a programmatic update
+        let update_events = update_events.clone();
+        calendar.connect_date_notify(move |calendar| {
             if updating.get() {
                 return;
             }
 
-            let year = cal.year();
-            // GtkCalendar months are 0-11
-            let month = (cal.month() + 1) as u32;
-            let current = *current_date.borrow();
-
-            // Only update if the calendar's month/year differs from our tracked state
-            // (i.e., user clicked a day in a different month)
-            if (month != current.month() || year != current.year())
-                && let Some(date) = NaiveDate::from_ymd_opt(year, month, 1)
-            {
-                *current_date.borrow_mut() = date;
-                update_header(date);
-                update_calendar(date);
+            let Some(date) = calendar_selected_date(calendar) else {
+                return;
+            };
+            let current = visible_month.get();
+            let Some(notified_month) = NaiveDate::from_ymd_opt(date.year(), date.month(), 1) else {
+                return;
+            };
+            let month_changed = notified_month != current;
+            sync_calendar_state(date);
+            if !events_enabled {
+                return;
+            }
+            if month_changed {
+                CalendarService::global().refresh(notified_month);
+            } else {
+                update_events(&CalendarService::global().snapshot());
             }
         });
     }
@@ -281,20 +416,345 @@ pub fn build_clock_calendar_popover(
     // Called by on_show when the popover is reused across open/close cycles.
     let weather_refresh_for_show = weather_refresh.clone();
     let refresh: ClockPopoverRefresh = {
+        let navigate_calendar = navigate_calendar.clone();
         Rc::new(move || {
             let new_today = Local::now().date_naive();
             today.set(new_today);
-            let new_date = NaiveDate::from_ymd_opt(new_today.year(), new_today.month(), 1).unwrap();
-            *current_date.borrow_mut() = new_date;
-            update_header(new_date);
-            update_calendar(new_date);
+            navigate_calendar(new_today);
+            if events_enabled {
+                CalendarService::global().refresh(new_today);
+            }
             if let Some(refresh_weather) = &weather_refresh_for_show {
                 refresh_weather();
             }
         })
     };
 
-    (container.upcast::<Widget>(), refresh, weather_refresh)
+    (
+        container.upcast::<Widget>(),
+        refresh,
+        weather_refresh,
+        events_refresh,
+    )
+}
+
+fn rebuild_event_list(content: &GtkBox, date: NaiveDate, snapshot: &CalendarSnapshot) {
+    while let Some(child) = content.first_child() {
+        content.remove(&child);
+    }
+
+    if let Some(error) = &snapshot.error {
+        append_state_label(content, error);
+        return;
+    }
+
+    let Some(events) = snapshot
+        .events_by_date
+        .get(&date)
+        .filter(|events| !events.is_empty())
+    else {
+        append_state_label(
+            content,
+            if snapshot.loading {
+                "Loading events..."
+            } else {
+                "No events"
+            },
+        );
+        return;
+    };
+
+    for event in events {
+        append_event_row(content, event, date);
+    }
+}
+
+fn apply_event_marks(calendar: &Calendar, visible_month: NaiveDate, snapshot: &CalendarSnapshot) {
+    calendar.clear_marks();
+    if snapshot.error.is_some() {
+        return;
+    }
+
+    for date in snapshot.events_by_date.keys() {
+        if date.year() == visible_month.year() && date.month() == visible_month.month() {
+            calendar.mark_day(date.day());
+        }
+    }
+}
+
+#[derive(Default)]
+struct CalendarEventDotState {
+    visible_month: Option<NaiveDate>,
+    dots_by_date: std::collections::BTreeMap<NaiveDate, Vec<RGBA>>,
+}
+
+impl CalendarEventDotState {
+    fn from_snapshot(visible_month: NaiveDate, snapshot: &CalendarSnapshot) -> Self {
+        let mut dots_by_date = std::collections::BTreeMap::new();
+        if snapshot.error.is_some() {
+            return Self {
+                visible_month: Some(visible_month),
+                dots_by_date,
+            };
+        }
+
+        for (date, events) in &snapshot.events_by_date {
+            let mut colors = Vec::new();
+            for event in events {
+                let Some(color) = event.color.as_deref().and_then(parse_event_dot_color) else {
+                    continue;
+                };
+                if !colors.contains(&color) {
+                    colors.push(color);
+                }
+                if colors.len() == 3 {
+                    break;
+                }
+            }
+            dots_by_date.insert(*date, colors);
+        }
+
+        Self {
+            visible_month: Some(visible_month),
+            dots_by_date,
+        }
+    }
+}
+
+fn draw_event_dots(
+    area: &DrawingArea,
+    calendar: &Calendar,
+    cr: &cairo::Context,
+    state: &CalendarEventDotState,
+) {
+    let Some(visible_month) = state.visible_month else {
+        return;
+    };
+    if state.dots_by_date.is_empty() {
+        return;
+    }
+
+    for (label, date) in visible_day_labels(calendar, visible_month) {
+        let Some(colors) = state.dots_by_date.get(&date) else {
+            continue;
+        };
+        let Some(bounds) = label.compute_bounds(area.upcast_ref::<Widget>()) else {
+            continue;
+        };
+        let fallback_color = if colors.is_empty() {
+            // The day label resolves its own foreground, including today-cell contrast.
+            let mut foreground = label.color();
+            foreground.set_alpha(0.78);
+            Some(foreground)
+        } else {
+            None
+        };
+
+        let dot_radius = 2.0;
+        let gap = 3.0;
+        let dot_count = colors.len().max(1) as f32;
+        let total_width = dot_count * dot_radius * 2.0 + (dot_count - 1.0) * gap;
+        let mut x = bounds.x() + bounds.width() / 2.0 - total_width / 2.0 + dot_radius;
+        let y = bounds.y() + bounds.height() - 4.5;
+
+        for color in colors.iter().chain(fallback_color.iter()) {
+            cr.set_source_rgba(
+                f64::from(color.red()),
+                f64::from(color.green()),
+                f64::from(color.blue()),
+                f64::from(color.alpha()),
+            );
+            cr.arc(
+                f64::from(x),
+                f64::from(y),
+                f64::from(dot_radius),
+                0.0,
+                std::f64::consts::TAU,
+            );
+            let _ = cr.fill();
+            x += dot_radius * 2.0 + gap;
+        }
+    }
+}
+
+fn visible_day_labels(calendar: &Calendar, visible_month: NaiveDate) -> Vec<(Label, NaiveDate)> {
+    let mut labels = Vec::new();
+    collect_day_labels(calendar.upcast_ref::<Widget>(), &mut labels);
+    // GTK localizes label text, so derive dates from fixed grid positions instead.
+    let leading_days = labels
+        .iter()
+        .take_while(|label| label.has_css_class("other-month"))
+        .count();
+    let trailing_days = labels
+        .iter()
+        .rev()
+        .take_while(|label| label.has_css_class("other-month"))
+        .count();
+    let Some(dates) = visible_grid_dates(visible_month, leading_days, trailing_days, labels.len())
+    else {
+        INVALID_CALENDAR_GRID_WARNING.call_once(|| {
+            tracing::warn!(
+                "GtkCalendar grid structure is incompatible; colored event dots are disabled"
+            );
+        });
+        return Vec::new();
+    };
+
+    labels.into_iter().zip(dates).collect()
+}
+
+fn visible_grid_dates(
+    visible_month: NaiveDate,
+    leading_days: usize,
+    trailing_days: usize,
+    day_count: usize,
+) -> Option<Vec<NaiveDate>> {
+    if day_count != GTK_CALENDAR_DAY_COUNT || leading_days > 7 {
+        return None;
+    }
+    let month_start = NaiveDate::from_ymd_opt(visible_month.year(), visible_month.month(), 1)?;
+    let next_month = add_months(month_start, 1);
+    let days_in_month = next_month.pred_opt()?.day() as usize;
+    // GTK internals are not public API. Reject traversal changes rather than
+    // attaching dots to incorrect dates.
+    if leading_days + days_in_month + trailing_days != day_count {
+        return None;
+    }
+    let first_date = month_start.checked_sub_signed(chrono::Duration::days(leading_days as i64))?;
+    (0..day_count)
+        .map(|offset| first_date.checked_add_signed(chrono::Duration::days(offset as i64)))
+        .collect()
+}
+
+fn calendar_selected_date(calendar: &Calendar) -> Option<NaiveDate> {
+    NaiveDate::from_ymd_opt(
+        calendar.year(),
+        (calendar.month() + 1) as u32,
+        calendar.day() as u32,
+    )
+}
+
+fn collect_day_labels(widget: &Widget, labels: &mut Vec<Label>) {
+    // GtkCalendar exposes day labels only through its CSS node tree.
+    if let Some(label) = widget.downcast_ref::<Label>()
+        && label.has_css_class("day-number")
+    {
+        labels.push(label.clone());
+    }
+
+    let mut child = widget.first_child();
+    while let Some(current) = child {
+        collect_day_labels(&current, labels);
+        child = current.next_sibling();
+    }
+}
+
+fn add_months(date: NaiveDate, delta: i32) -> NaiveDate {
+    let total_months = date.year() * 12 + date.month0() as i32 + delta;
+    let year = total_months.div_euclid(12);
+    let month0 = total_months.rem_euclid(12) as u32;
+    for day in (1..=date.day()).rev() {
+        if let Some(result) = NaiveDate::from_ymd_opt(year, month0 + 1, day) {
+            return result;
+        }
+    }
+    date
+}
+
+fn parse_event_dot_color(color: &str) -> Option<RGBA> {
+    parse_event_color(color).map(|mut rgba| {
+        rgba.set_alpha(0.78);
+        rgba
+    })
+}
+
+fn parse_event_color(color: &str) -> Option<RGBA> {
+    RGBA::parse(color.trim()).ok()
+}
+
+fn event_marker_color(color: &str) -> Option<String> {
+    let rgba = parse_event_color(color)?;
+    let channel = |value: f32| (value * 255.0).round() as u8;
+    Some(format!(
+        "#{:02x}{:02x}{:02x}",
+        channel(rgba.red()),
+        channel(rgba.green()),
+        channel(rgba.blue())
+    ))
+}
+
+fn append_state_label(content: &GtkBox, text: &str) {
+    let label = Label::new(Some(text));
+    label.add_css_class(cal::EVENTS_STATE);
+    label.add_css_class(color::MUTED);
+    label.set_xalign(0.0);
+    label.set_width_chars(EVENT_LABEL_WIDTH_CHARS);
+    label.set_max_width_chars(EVENT_LABEL_WIDTH_CHARS);
+    label.set_wrap(true);
+    label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
+    content.append(&label);
+}
+
+fn append_event_row(content: &GtkBox, event: &CalendarEvent, date: NaiveDate) {
+    let row = GtkBox::new(Orientation::Horizontal, 8);
+    row.add_css_class(cal::EVENT_ROW);
+
+    let marker = Label::new(Some("•"));
+    marker.add_css_class(cal::EVENT_MARKER);
+    marker.set_valign(Align::Start);
+    if let Some(color) = event.color.as_deref().and_then(event_marker_color) {
+        marker.set_markup(&format!("<span foreground=\"{color}\">•</span>"));
+    }
+    row.append(&marker);
+
+    let text = GtkBox::new(Orientation::Vertical, 2);
+    text.set_hexpand(true);
+
+    let title = Label::new(None);
+    title.add_css_class(cal::EVENT_TITLE);
+    title.set_xalign(0.0);
+    title.set_ellipsize(EllipsizeMode::End);
+    title.set_width_chars(EVENT_LABEL_WIDTH_CHARS);
+    title.set_max_width_chars(EVENT_LABEL_WIDTH_CHARS);
+    title.set_markup(&format!("<b>{}</b>", markup_escape_text(&event.title)));
+    text.append(&title);
+
+    let detail_text = event_detail_text(event, date);
+    if !detail_text.is_empty() {
+        let detail = Label::new(Some(&detail_text));
+        detail.add_css_class(cal::EVENT_DETAIL);
+        detail.add_css_class(color::MUTED);
+        detail.set_xalign(0.0);
+        detail.set_ellipsize(EllipsizeMode::End);
+        detail.set_width_chars(EVENT_LABEL_WIDTH_CHARS);
+        detail.set_max_width_chars(EVENT_LABEL_WIDTH_CHARS);
+        text.append(&detail);
+    }
+
+    row.append(&text);
+    content.append(&row);
+}
+
+fn event_detail_text(event: &CalendarEvent, date: NaiveDate) -> String {
+    let time = if event.all_day {
+        "All day".to_string()
+    } else if date == event.start.date_naive() {
+        format!("{:02}:{:02}", event.start.hour(), event.start.minute())
+    } else if date != event.final_day() {
+        "Ongoing".to_string()
+    } else if event.end.time() == chrono::NaiveTime::MIN {
+        "Until midnight".to_string()
+    } else {
+        format!("Until {:02}:{:02}", event.end.hour(), event.end.minute())
+    };
+    match (&event.calendar_name, &event.location) {
+        (calendar, location) if !calendar.is_empty() && !location.is_empty() => {
+            format!("{time} · {calendar} · {location}")
+        }
+        (calendar, _) if !calendar.is_empty() => format!("{time} · {calendar}"),
+        (_, location) if !location.is_empty() => format!("{time} · {location}"),
+        _ => time,
+    }
 }
 
 #[cfg(test)]
@@ -309,27 +769,275 @@ mod tests {
             return;
         }
 
-        let (with_week_numbers, _refresh, _weather_refresh) =
-            build_clock_calendar_popover(true, false);
+        let (with_week_numbers, _refresh, _weather_refresh, _events_refresh) =
+            build_clock_calendar_popover(true, false, false);
         assert!(
             find_descendant_with_class(&with_week_numbers, "week-number-header").is_some(),
             "calendar popover should render the week-number header when week numbers are enabled"
         );
 
-        let (without_week_numbers, _refresh, _weather_refresh) =
-            build_clock_calendar_popover(false, false);
+        let (without_week_numbers, _refresh, _weather_refresh, _events_refresh) =
+            build_clock_calendar_popover(false, false, false);
         assert!(
             find_descendant_with_class(&without_week_numbers, "week-number-header").is_none(),
             "calendar popover should omit the week-number header when week numbers are disabled"
         );
 
-        let (without_weather, _refresh, weather_refresh) =
-            build_clock_calendar_popover(false, false);
+        let (without_weather, _refresh, weather_refresh, events_refresh) =
+            build_clock_calendar_popover(false, false, false);
         assert!(weather_refresh.is_none());
+        assert!(events_refresh.is_none());
         assert!(find_descendant_with_class(&without_weather, wp::EMPTY).is_none());
+        assert!(find_descendant_with_class(&without_weather, cal::EVENTS_ENABLED).is_none());
 
-        let (with_weather, _refresh, weather_refresh) = build_clock_calendar_popover(false, true);
+        let (with_weather, _refresh, weather_refresh, _events_refresh) =
+            build_clock_calendar_popover(false, true, false);
         assert!(weather_refresh.is_some());
         assert!(find_descendant_with_class(&with_weather, wp::EMPTY).is_some());
+
+        let (with_events, _refresh, _weather_refresh, events_refresh) =
+            build_clock_calendar_popover(false, false, true);
+        assert!(find_descendant_with_class(&with_events, cal::EVENTS_ENABLED).is_some());
+        assert!(find_descendant_with_class(&with_events, cal::EVENTS_CARD).is_some());
+        assert!(events_refresh.is_some());
+
+        assert_today_button_resets_month(false);
+        assert_today_button_resets_month(true);
+        assert_month_navigation_preserves_selected_day();
+        assert_month_property_change_updates_header();
+
+        let state_content = GtkBox::new(Orientation::Vertical, 0);
+        append_state_label(
+            &state_content,
+            "a long error without guaranteed word boundaries",
+        );
+        let state_label = state_content.first_child().and_downcast::<Label>().unwrap();
+        assert!(state_label.wraps());
+        assert_eq!(state_label.wrap_mode(), gtk4::pango::WrapMode::WordChar);
+    }
+
+    fn assert_today_button_resets_month(events_enabled: bool) {
+        let (popover, _refresh, _weather_refresh, _events_refresh) =
+            build_clock_calendar_popover(false, false, events_enabled);
+        let mut buttons = Vec::new();
+        collect_buttons(&popover, &mut buttons);
+        assert!(
+            buttons.len() >= 3,
+            "calendar header should have navigation buttons"
+        );
+
+        let calendar = find_descendant_with_class(&popover, cal::WIDGET)
+            .and_downcast::<Calendar>()
+            .expect("calendar popover should contain GtkCalendar");
+        let today = Local::now().date_naive();
+
+        buttons[0].emit_clicked();
+        assert_ne!(calendar.month(), today.month0() as i32);
+        buttons[1].emit_clicked();
+        assert_eq!(calendar.year(), today.year());
+        assert_eq!(calendar.month(), today.month0() as i32);
+    }
+
+    fn collect_buttons(widget: &Widget, buttons: &mut Vec<gtk4::Button>) {
+        if let Some(button) = widget.downcast_ref::<gtk4::Button>() {
+            buttons.push(button.clone());
+        }
+
+        let mut child = widget.first_child();
+        while let Some(current) = child {
+            collect_buttons(&current, buttons);
+            child = current.next_sibling();
+        }
+    }
+
+    fn assert_month_navigation_preserves_selected_day() {
+        let (popover, _refresh, _weather_refresh, _events_refresh) =
+            build_clock_calendar_popover(false, false, true);
+        let calendar = find_descendant_with_class(&popover, cal::WIDGET)
+            .and_downcast::<Calendar>()
+            .expect("calendar popover should contain GtkCalendar");
+        let title = find_descendant_with_class(&popover, cal::EVENTS_CARD)
+            .and_then(|card| card.first_child())
+            .and_downcast::<Label>()
+            .expect("event card should contain a title");
+        let mut buttons = Vec::new();
+        collect_buttons(&popover, &mut buttons);
+
+        calendar.set_day(15);
+        buttons[2].emit_clicked();
+        assert_eq!(calendar.day(), 15);
+        let selected = calendar_selected_date(&calendar).unwrap();
+        assert_eq!(title.label(), selected.format("%A, %B %-d").to_string());
+    }
+
+    fn assert_month_property_change_updates_header() {
+        let (popover, _refresh, _weather_refresh, events_refresh) =
+            build_clock_calendar_popover(false, false, false);
+        let calendar = find_descendant_with_class(&popover, cal::WIDGET)
+            .and_downcast::<Calendar>()
+            .expect("calendar popover should contain GtkCalendar");
+        let header = find_descendant_with_class(&popover, surface::POPOVER_TITLE)
+            .and_downcast::<Label>()
+            .expect("calendar popover should contain month header");
+        let today = Local::now().date_naive();
+        let target = add_months(today, if today.month() == 1 { 1 } else { -1 });
+
+        calendar.set_day(1);
+        calendar.set_month(target.month0() as i32);
+
+        assert_eq!(header.label(), target.format("%B %Y").to_string());
+        assert!(events_refresh.is_none());
+    }
+
+    #[test]
+    fn event_marker_color_parses_and_serializes_trusted_rgb() {
+        assert_eq!(event_marker_color("red").as_deref(), Some("#ff0000"));
+        assert_eq!(event_marker_color("turquoise").as_deref(), Some("#40e0d0"));
+        assert_eq!(event_marker_color(" #AABBCC ").as_deref(), Some("#aabbcc"));
+        assert_eq!(event_marker_color("#123456\" size=\"999"), None);
+        assert_eq!(event_marker_color("notacolor"), None);
+    }
+
+    #[test]
+    fn event_dot_color_uses_fixed_alpha_after_parsing() {
+        let color = parse_event_dot_color("red").expect("CSS color name should parse");
+        assert_eq!(color.red(), 1.0);
+        assert_eq!(color.green(), 0.0);
+        assert_eq!(color.blue(), 0.0);
+        assert!((color.alpha() - 0.78).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn colorless_events_use_day_label_foreground_fallback() {
+        let date = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let event = test_event("2026-06-01 10:15:00", "2026-06-01 11:15:00", false);
+        let snapshot = CalendarSnapshot {
+            focus_month: Some(date),
+            loading: false,
+            error: None,
+            backend_available: true,
+            events_by_date: std::collections::BTreeMap::from([(
+                date,
+                vec![std::sync::Arc::new(event)],
+            )]),
+        };
+
+        let state = CalendarEventDotState::from_snapshot(date, &snapshot);
+
+        assert!(state.dots_by_date.get(&date).is_some_and(Vec::is_empty));
+    }
+
+    #[test]
+    fn visible_grid_dates_are_contiguous_from_leading_grid_origin() {
+        let visible_month = NaiveDate::from_ymd_opt(2026, 2, 15).unwrap();
+
+        for leading_days in 0..=7 {
+            let trailing_days = GTK_CALENDAR_DAY_COUNT - leading_days - 28;
+            let dates = visible_grid_dates(
+                visible_month,
+                leading_days,
+                trailing_days,
+                GTK_CALENDAR_DAY_COUNT,
+            )
+            .unwrap();
+
+            assert_eq!(dates.len(), GTK_CALENDAR_DAY_COUNT);
+            assert_eq!(
+                dates[leading_days],
+                NaiveDate::from_ymd_opt(2026, 2, 1).unwrap()
+            );
+            assert!(
+                dates
+                    .windows(2)
+                    .all(|days| days[0].succ_opt() == Some(days[1]))
+            );
+        }
+    }
+
+    #[test]
+    fn month_shift_preserves_and_clamps_selected_day() {
+        let january_31 = NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+        let march_31 = NaiveDate::from_ymd_opt(2026, 3, 31).unwrap();
+        let june_15 = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+
+        assert_eq!(
+            add_months(january_31, 1),
+            NaiveDate::from_ymd_opt(2026, 2, 28).unwrap()
+        );
+        assert_eq!(
+            add_months(march_31, -1),
+            NaiveDate::from_ymd_opt(2026, 2, 28).unwrap()
+        );
+        assert_eq!(
+            add_months(june_15, 1),
+            NaiveDate::from_ymd_opt(2026, 7, 15).unwrap()
+        );
+    }
+
+    #[test]
+    fn visible_grid_dates_reject_unexpected_calendar_structure() {
+        let visible_month = NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+
+        assert!(visible_grid_dates(visible_month, 8, 6, GTK_CALENDAR_DAY_COUNT).is_none());
+        assert!(visible_grid_dates(visible_month, 0, 14, 41).is_none());
+        assert!(visible_grid_dates(visible_month, 0, 13, GTK_CALENDAR_DAY_COUNT).is_none());
+    }
+
+    #[test]
+    fn timed_event_details_follow_selected_continuation_day() {
+        let event = test_event("2026-06-01 10:15:00", "2026-06-04 12:30:00", false);
+
+        assert_eq!(
+            event_detail_text(&event, NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()),
+            "10:15"
+        );
+        assert_eq!(
+            event_detail_text(&event, NaiveDate::from_ymd_opt(2026, 6, 2).unwrap()),
+            "Ongoing"
+        );
+        assert_eq!(
+            event_detail_text(&event, NaiveDate::from_ymd_opt(2026, 6, 4).unwrap()),
+            "Until 12:30"
+        );
+    }
+
+    #[test]
+    fn timed_event_details_treat_midnight_end_as_previous_final_day() {
+        let event = test_event("2026-06-01 10:15:00", "2026-06-03 00:00:00", false);
+
+        assert_eq!(
+            event_detail_text(&event, NaiveDate::from_ymd_opt(2026, 6, 2).unwrap()),
+            "Until midnight"
+        );
+    }
+
+    #[test]
+    fn all_day_event_details_ignore_selected_day() {
+        let event = test_event("2026-06-01 00:00:00", "2026-06-04 00:00:00", true);
+
+        assert_eq!(
+            event_detail_text(&event, NaiveDate::from_ymd_opt(2026, 6, 3).unwrap()),
+            "All day"
+        );
+    }
+
+    fn test_event(start: &str, end: &str, all_day: bool) -> CalendarEvent {
+        CalendarEvent {
+            calendar_name: String::new(),
+            color: None,
+            title: "Event".to_string(),
+            location: String::new(),
+            start: chrono::NaiveDateTime::parse_from_str(start, "%Y-%m-%d %H:%M:%S")
+                .unwrap()
+                .and_local_timezone(Local)
+                .single()
+                .unwrap(),
+            end: chrono::NaiveDateTime::parse_from_str(end, "%Y-%m-%d %H:%M:%S")
+                .unwrap()
+                .and_local_timezone(Local)
+                .single()
+                .unwrap(),
+            all_day,
+        }
     }
 }

--- a/crates/vibepanel/src/widgets/clock.rs
+++ b/crates/vibepanel/src/widgets/clock.rs
@@ -3,7 +3,7 @@
 //! Uses second-resolution ticks only for formats that display seconds, and
 //! otherwise updates on minute boundaries to minimize wakeups.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -15,6 +15,7 @@ use gtk4::prelude::*;
 use tracing::{debug, trace, warn};
 use vibepanel_core::config::WidgetEntry;
 
+use crate::services::calendar as calendar_service;
 use crate::services::callbacks::CallbackId;
 use crate::services::config_manager::ConfigManager;
 use crate::services::sleep_watcher::SleepWatcher;
@@ -22,7 +23,7 @@ use crate::services::weather::WeatherService;
 use crate::styles::widget as wgt;
 use crate::widgets::WidgetConfig;
 use crate::widgets::base::{BaseWidget, MenuHandle};
-use crate::widgets::calendar_popover::build_clock_calendar_popover;
+use crate::widgets::calendar_popover::{CalendarSnapshotRefresh, build_clock_calendar_popover};
 use crate::widgets::warn_unknown_options;
 
 /// Default format string for the clock display.
@@ -51,6 +52,8 @@ pub struct ClockConfig {
     pub show_week_numbers: bool,
     /// Whether to embed weather content in the calendar popover.
     pub show_weather: bool,
+    /// Whether to auto-discover and show DankCalendar events.
+    pub calendar_events: bool,
 }
 
 impl WidgetConfig for ClockConfig {
@@ -63,6 +66,7 @@ impl WidgetConfig for ClockConfig {
                 "format_vertical",
                 "show_week_numbers",
                 "show_weather",
+                "calendar_events",
             ],
         );
 
@@ -91,11 +95,18 @@ impl WidgetConfig for ClockConfig {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        let calendar_events = entry
+            .options
+            .get("calendar_events")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true);
+
         Self {
             format,
             format_vertical,
             show_week_numbers,
             show_weather,
+            calendar_events,
         }
     }
 }
@@ -107,13 +118,31 @@ impl Default for ClockConfig {
             format_vertical: None,
             show_week_numbers: true,
             show_weather: false,
+            calendar_events: true,
+        }
+    }
+}
+
+struct ClockPopoverCallbacks {
+    weather: Option<CallbackId>,
+    calendar: Option<CallbackId>,
+}
+
+impl Drop for ClockPopoverCallbacks {
+    fn drop(&mut self) {
+        if let Some(id) = self.weather.take() {
+            WeatherService::global().disconnect(id);
+        }
+        if let Some(id) = self.calendar.take() {
+            calendar_service::CalendarService::global().disconnect(id);
         }
     }
 }
 
 /// Shared calendar/weather popover binding used by clock+weather merge groups.
 pub(crate) struct CalendarWeatherPopoverBinding {
-    weather_callback_id: Option<CallbackId>,
+    // Retained solely so its Drop disconnects popover service subscriptions.
+    _callbacks: ClockPopoverCallbacks,
 }
 
 impl CalendarWeatherPopoverBinding {
@@ -121,18 +150,15 @@ impl CalendarWeatherPopoverBinding {
         menu_handle: &Rc<MenuHandle>,
         show_week_numbers: bool,
         show_weather: bool,
+        calendar_events: bool,
     ) -> Self {
-        let weather_callback_id = wire_clock_popover(menu_handle, show_week_numbers, show_weather);
         Self {
-            weather_callback_id,
-        }
-    }
-}
-
-impl Drop for CalendarWeatherPopoverBinding {
-    fn drop(&mut self) {
-        if let Some(id) = self.weather_callback_id.take() {
-            WeatherService::global().disconnect(id);
+            _callbacks: wire_clock_popover_with_config(
+                menu_handle,
+                show_week_numbers,
+                show_weather,
+                calendar_events,
+            ),
         }
     }
 }
@@ -154,7 +180,8 @@ pub struct ClockWidget {
     /// The Rc<RefCell<>> lets self-rescheduling callbacks replace the ID.
     timer_source: Rc<RefCell<Option<SourceId>>>,
     resume_callback_id: Option<CallbackId>,
-    weather_callback_id: Option<CallbackId>,
+    // Retained solely so its Drop disconnects popover service subscriptions.
+    _popover_callbacks: ClockPopoverCallbacks,
 }
 
 impl ClockWidget {
@@ -182,11 +209,19 @@ impl ClockWidget {
         }
 
         let show_week_numbers = config.show_week_numbers;
-        let weather_callback_id = if create_popover {
+        let popover_callbacks = if create_popover {
             let menu_handle = base.create_menu(|| gtk4::Label::new(None).upcast());
-            wire_clock_popover(&menu_handle, show_week_numbers, config.show_weather)
+            wire_clock_popover_with_config(
+                &menu_handle,
+                show_week_numbers,
+                config.show_weather,
+                config.calendar_events,
+            )
         } else {
-            None
+            ClockPopoverCallbacks {
+                weather: None,
+                calendar: None,
+            }
         };
 
         let format = validated_clock_format(config.format, DEFAULT_FORMAT, "format");
@@ -223,7 +258,7 @@ impl ClockWidget {
             scheduling_mode,
             timer_source,
             resume_callback_id,
-            weather_callback_id,
+            _popover_callbacks: popover_callbacks,
         };
 
         widget.update_time();
@@ -273,21 +308,29 @@ impl ClockWidget {
 }
 
 type RefreshSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+type CalendarSnapshotRefreshSlot = Rc<RefCell<Option<CalendarSnapshotRefresh>>>;
 
-fn wire_clock_popover(
+fn wire_clock_popover_with_config(
     menu_handle: &Rc<MenuHandle>,
     show_week_numbers: bool,
     show_weather: bool,
-) -> Option<CallbackId> {
+    calendar_events: bool,
+) -> ClockPopoverCallbacks {
     let calendar_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
+    let calendar_snapshot_refresh_slot: CalendarSnapshotRefreshSlot = Rc::new(RefCell::new(None));
     let weather_refresh_slot: RefreshSlot = Rc::new(RefCell::new(None));
-
     let calendar_refresh_for_builder = calendar_refresh_slot.clone();
+    let calendar_snapshot_refresh_for_builder = calendar_snapshot_refresh_slot.clone();
     let weather_refresh_for_builder = weather_refresh_slot.clone();
     menu_handle.set_builder(move || {
-        let (widget, calendar_refresh, weather_refresh) =
-            build_clock_calendar_popover(show_week_numbers, show_weather);
+        let events_enabled = calendar_events
+            && calendar_service::CalendarService::global()
+                .snapshot()
+                .backend_available;
+        let (widget, calendar_refresh, weather_refresh, calendar_snapshot_refresh) =
+            build_clock_calendar_popover(show_week_numbers, show_weather, events_enabled);
         *calendar_refresh_for_builder.borrow_mut() = Some(calendar_refresh);
+        *calendar_snapshot_refresh_for_builder.borrow_mut() = calendar_snapshot_refresh;
         *weather_refresh_for_builder.borrow_mut() = weather_refresh;
         widget
     });
@@ -297,12 +340,16 @@ fn wire_clock_popover(
     menu_handle.set_reuse_content(true);
     let calendar_refresh_for_show = calendar_refresh_slot.clone();
     menu_handle.set_on_show(move || {
+        if calendar_events {
+            calendar_service::CalendarService::global()
+                .ensure_discovery(chrono::Local::now().date_naive());
+        }
         if let Some(ref cb) = *calendar_refresh_for_show.borrow() {
             cb();
         }
     });
 
-    if show_weather {
+    let weather = if show_weather {
         let menu_handle = Rc::clone(menu_handle);
         let weather_refresh_slot = weather_refresh_slot.clone();
         Some(WeatherService::global().connect(move |_| {
@@ -314,7 +361,35 @@ fn wire_clock_popover(
         }))
     } else {
         None
-    }
+    };
+
+    let calendar = if calendar_events {
+        let menu_handle = Rc::clone(menu_handle);
+        let calendar_snapshot_refresh_slot = calendar_snapshot_refresh_slot.clone();
+        let backend_available = Cell::new(
+            calendar_service::CalendarService::global()
+                .snapshot()
+                .backend_available,
+        );
+        let id = calendar_service::CalendarService::global().connect(move |snapshot| {
+            if backend_available.replace(snapshot.backend_available) != snapshot.backend_available {
+                menu_handle.refresh_if_visible();
+            }
+            if menu_handle.is_visible() {
+                let refresh = calendar_snapshot_refresh_slot.borrow().clone();
+                if let Some(refresh) = refresh {
+                    refresh(snapshot);
+                }
+            }
+        });
+        calendar_service::CalendarService::global()
+            .ensure_discovery(chrono::Local::now().date_naive());
+        Some(id)
+    } else {
+        None
+    };
+
+    ClockPopoverCallbacks { weather, calendar }
 }
 
 fn clock_scheduling_mode(
@@ -487,9 +562,6 @@ impl Drop for ClockWidget {
         if let Some(id) = self.resume_callback_id.take() {
             SleepWatcher::global().disconnect(id);
         }
-        if let Some(id) = self.weather_callback_id.take() {
-            WeatherService::global().disconnect(id);
-        }
         debug!("Clock timer cancelled on drop");
     }
 }
@@ -573,11 +645,32 @@ mod tests {
     }
 
     #[test]
+    fn test_clock_config_calendar_events() {
+        let enabled = HashMap::from([("calendar_events".to_string(), Value::Boolean(true))]);
+        let disabled = HashMap::from([("calendar_events".to_string(), Value::Boolean(false))]);
+
+        assert!(ClockConfig::from_entry(&make_widget_entry("clock", enabled)).calendar_events);
+        assert!(!ClockConfig::from_entry(&make_widget_entry("clock", disabled)).calendar_events);
+    }
+
+    #[test]
+    fn test_clock_config_rejects_non_boolean_calendar_events() {
+        let options = HashMap::from([(
+            "calendar_events".to_string(),
+            Value::String("dankcalendar".to_string()),
+        )]);
+        let config = ClockConfig::from_entry(&make_widget_entry("clock", options));
+
+        assert!(config.calendar_events);
+    }
+
+    #[test]
     fn test_clock_config_default_impl() {
         let config = ClockConfig::default();
         assert_eq!(config.format, "%a %d %H:%M");
         assert_eq!(config.format_vertical, None);
         assert!(!config.show_weather);
+        assert!(config.calendar_events);
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/css/calendar.rs
+++ b/crates/vibepanel/src/widgets/css/calendar.rs
@@ -21,6 +21,10 @@ pub fn css() -> &'static str {
     margin-right: -8px;
 }
 
+.calendar-events-layout {
+    min-width: 532px;
+}
+
 calendar.view {
     background: transparent;
     border: none;
@@ -53,9 +57,28 @@ calendar.view grid label.day-number {
     font-weight: 325;
 }
 
-calendar.view grid *:selected:not(.today) {
+calendar.view:not(.calendar-events-enabled) grid *:selected:not(.today) {
     background: transparent;
     color: inherit;
+    box-shadow: none;
+}
+
+calendar.view.calendar-events-enabled grid label.day-number:checked:not(.today):not(:selected) {
+    background: transparent;
+    color: var(--color-accent-primary);
+    font-weight: 600;
+    box-shadow: none;
+}
+
+calendar.view.calendar-events-enabled grid label.day-number:hover:not(.today):not(:selected) {
+    background: var(--color-card-overlay-hover);
+    border-radius: var(--radius-widget);
+}
+
+calendar.view.calendar-events-enabled grid label.day-number:selected:not(.today) {
+    background: var(--color-card-overlay-hover);
+    color: var(--color-foreground-primary);
+    border-radius: var(--radius-widget);
     box-shadow: none;
 }
 
@@ -64,6 +87,41 @@ calendar.view grid *:selected:not(.today) {
     color: var(--color-foreground-muted);
     margin-left: 12px; /* Align with week numbers column */
     margin-top: 16px; /* Align vertically with day headers (M T W...) */
+}
+
+.calendar-events-card {
+    padding: 12px;
+    border-radius: var(--radius-card);
+    background: var(--color-card-overlay);
+    min-width: 260px;
+}
+
+.calendar-events-list {
+    min-width: 236px;
+}
+
+.calendar-events-state {
+    font-size: var(--font-size-sm);
+}
+
+.calendar-event-row {
+    padding: 4px 0;
+}
+
+.calendar-event-marker {
+    color: var(--color-accent-primary);
+    opacity: 0.72;
+    font-size: var(--font-size-lg);
+    line-height: 1;
+}
+
+.calendar-event-title {
+    font-size: var(--font-size-sm);
+    color: var(--color-foreground-primary);
+}
+
+.calendar-event-detail {
+    font-size: var(--font-size-xs);
 }
 "#
 }

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -589,7 +589,9 @@ impl LayerShellPopover {
     /// Set a callback to be invoked every time the popover is shown.
     ///
     /// In reuse mode this is called after the cached content is re-parented,
-    /// allowing consumers to refresh data (e.g. update calendar to today).
+    /// allowing consumers to refresh data (e.g. update calendar to today). It
+    /// also fires when a close animation reverses before `on_close`; callbacks
+    /// that acquire resources must therefore be idempotent until `on_close` runs.
     pub fn set_on_show<F: Fn() + 'static>(&self, callback: F) {
         *self.on_show.borrow_mut() = Some(Rc::new(callback));
     }
@@ -864,6 +866,7 @@ impl LayerShellPopover {
             if self.content_dirty.take() {
                 self.rebuild_content();
             }
+            self.fire_on_show();
 
             // Use the CURRENT generation (set by hide()) so the existing tick
             // callback stays valid — no new closure allocation needed.
@@ -953,9 +956,7 @@ impl LayerShellPopover {
         anim_shell.set_child(&content);
 
         // Fire on_show callback (e.g. to refresh calendar to today's date).
-        if let Some(ref cb) = *self.on_show.borrow() {
-            cb();
-        }
+        self.fire_on_show();
 
         SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
 
@@ -1051,6 +1052,12 @@ impl LayerShellPopover {
                     popover.update_position();
                 }
             });
+        }
+    }
+
+    fn fire_on_show(&self) {
+        if let Some(ref callback) = *self.on_show.borrow() {
+            callback();
         }
     }
 

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -646,7 +646,6 @@ impl SystemPopoverBinding {
         let gpu_cb_for_show = gpu_callback_id.clone();
         menu_handle.set_on_show(move || {
             let gpu_service = GpuService::global();
-            GpuService::request_polling(&gpu_service);
 
             if let Some(ctrl) = controller_for_show.borrow().as_ref() {
                 let sys_snapshot = SystemService::global().snapshot();
@@ -655,13 +654,18 @@ impl SystemPopoverBinding {
                 ctrl.update_from_gpu_snapshot(&gpu_snapshot);
             }
 
-            let controller_for_gpu = controller_for_show.clone();
-            let cb_id = gpu_service.connect(move |snapshot: &GpuSnapshot| {
-                if let Some(ctrl) = controller_for_gpu.borrow().as_ref() {
-                    ctrl.update_from_gpu_snapshot(snapshot);
-                }
-            });
-            gpu_cb_for_show.set(Some(cb_id));
+            // A close-animation reversal fires on_show before on_close, so retain
+            // existing polling ownership and subscription across the reversal.
+            if gpu_cb_for_show.get().is_none() {
+                GpuService::request_polling(&gpu_service);
+                let controller_for_gpu = controller_for_show.clone();
+                let cb_id = gpu_service.connect(move |snapshot: &GpuSnapshot| {
+                    if let Some(ctrl) = controller_for_gpu.borrow().as_ref() {
+                        ctrl.update_from_gpu_snapshot(snapshot);
+                    }
+                });
+                gpu_cb_for_show.set(Some(cb_id));
+            }
         });
 
         // Stop GPU polling when the popover closes.
@@ -669,8 +673,8 @@ impl SystemPopoverBinding {
         menu_handle.set_on_close(move || {
             if let Some(cb_id) = gpu_cb_for_close.take() {
                 GpuService::global().disconnect(cb_id);
+                GpuService::global().release_polling();
             }
-            GpuService::global().release_polling();
         });
 
         Self {

--- a/crates/vibepanel/src/widgets/weather.rs
+++ b/crates/vibepanel/src/widgets/weather.rs
@@ -87,7 +87,7 @@ impl WeatherWidget {
 
         let menu_handle = if create_popover {
             let menu_handle = base.create_menu(move || {
-                crate::widgets::weather_popover::build_weather_content_reactive().0
+                crate::widgets::weather_popover::build_weather_content_reactive(None).0
             });
             menu_handle.set_reuse_content(true);
             Some(menu_handle)

--- a/crates/vibepanel/src/widgets/weather_popover.rs
+++ b/crates/vibepanel/src/widgets/weather_popover.rs
@@ -6,7 +6,7 @@
 
 use chrono::NaiveDate;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Label, Orientation, Widget};
+use gtk4::{Align, Box as GtkBox, Label, Orientation, SizeGroup, Widget};
 use std::rc::Rc;
 
 use crate::services::icons::IconsService;
@@ -18,45 +18,64 @@ use vibepanel_core::config::WeatherUnits;
 const HERO_DETAIL_MAX_WIDTH_CHARS: i32 = 16;
 
 /// Build reusable weather content plus a refresh callback for reused popovers.
-pub fn build_weather_content_reactive() -> (Widget, Rc<dyn Fn()>) {
+///
+/// Pass size groups for the compact calendar/weather layout; omit them for the
+/// standalone vertical weather popover.
+pub fn build_weather_content_reactive(
+    compact_size_groups: Option<(SizeGroup, SizeGroup)>,
+) -> (Widget, Rc<dyn Fn()>) {
     let snapshot = WeatherService::global().snapshot();
-    let container = build_weather_content_box(&snapshot);
+    let container = GtkBox::new(
+        Orientation::Vertical,
+        if compact_size_groups.is_some() { 8 } else { 12 },
+    );
+    populate_weather_content(&container, &snapshot, compact_size_groups.as_ref());
 
     let refresh_container = container.clone();
+    let refresh_size_groups = compact_size_groups.clone();
     let refresh = Rc::new(move || {
         while let Some(child) = refresh_container.first_child() {
             refresh_container.remove(&child);
         }
 
         let snapshot = WeatherService::global().snapshot();
-        populate_weather_content(&refresh_container, &snapshot);
+        populate_weather_content(&refresh_container, &snapshot, refresh_size_groups.as_ref());
     });
 
     (container.upcast::<Widget>(), refresh)
 }
 
-fn build_weather_content_box(snapshot: &WeatherSnapshot) -> GtkBox {
-    let container = GtkBox::new(Orientation::Vertical, 12);
-    populate_weather_content(&container, snapshot);
-    container
-}
-
-fn populate_weather_content(container: &GtkBox, snapshot: &WeatherSnapshot) {
+fn populate_weather_content(
+    container: &GtkBox,
+    snapshot: &WeatherSnapshot,
+    compact_size_groups: Option<&(SizeGroup, SizeGroup)>,
+) {
     if !snapshot.available || (snapshot.current.is_none() && snapshot.error.is_some()) {
         container.append(&build_empty_state(snapshot));
         return;
     }
 
     let Some(current) = snapshot.current.as_ref() else {
-        // Available but no data yet (first fetch in flight, no cache).
         container.append(&build_empty_state(snapshot));
         return;
     };
 
-    container.append(&build_hero(snapshot, current));
-
-    if !snapshot.daily.is_empty() {
-        container.append(&build_forecast_strip(snapshot));
+    let hero = build_hero(snapshot, current);
+    if let Some((left_size_group, right_size_group)) = compact_size_groups {
+        let row = GtkBox::new(Orientation::Horizontal, 12);
+        left_size_group.add_widget(&hero);
+        row.append(&hero);
+        if !snapshot.daily.is_empty() {
+            let forecast = build_forecast_strip(snapshot);
+            right_size_group.add_widget(&forecast);
+            row.append(&forecast);
+        }
+        container.append(&row);
+    } else {
+        container.append(&hero);
+        if !snapshot.daily.is_empty() {
+            container.append(&build_forecast_strip(snapshot));
+        }
     }
 
     if let Some(banner) = build_status_banner(snapshot) {


### PR DESCRIPTION
Add DankCalendar integration for calendar events in the clock popover. Dates with events have colored dots on the calendar and there is a new event box to show events. 

The integration is enabled by default and it auto-discovers the DankCalendar socket, disable events with:
```toml
[widgets.clock]
calendar_events = false
```

Currently it's read-only, i.e we only show events. There is no way to create events from VibePanel as of now.

<img width="647" height="301" alt="image" src="https://github.com/user-attachments/assets/e96d9c1e-5743-4bb1-844a-0c2fe03fe598" />
