### PR TITLE
feat(quick_settings): add per-stream audio controls

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -9,7 +9,7 @@ if command -v xvfb-run >/dev/null 2>&1; then
 else
     printf '%s\n' 'skipping scripts/run-ui-regression-tests.sh: xvfb-run is not installed'
 fi
-echo '+cargo clippy --all -- -D warnings'
-cargo clippy --all -- -D warnings
+echo '+cargo clippy --all-targets -- -D warnings'
+cargo clippy --all-targets -- -D warnings
 echo '+cargo fmt --all -- --check'
 cargo fmt --all -- --check

--- a/crates/vibepanel/src/services/audio.rs
+++ b/crates/vibepanel/src/services/audio.rs
@@ -17,6 +17,7 @@
 //! - Volume/mute commands are sent to the background thread via `std::sync::mpsc`
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -37,7 +38,7 @@ use super::callbacks::{CallbackId, Callbacks};
 /// devices are discovered and defaults are resolved.
 const INITIAL_SETTLE_MS: u64 = 200;
 use pulse::callbacks::ListResult;
-use pulse::context::introspect::SinkInfo;
+use pulse::context::introspect::{SinkInfo, SinkInputInfo};
 use pulse::context::subscribe::{Facility, InterestMaskSet, Operation as SubscribeOp};
 use pulse::context::{Context, FlagSet as ContextFlagSet, State as ContextState};
 use pulse::def::PortAvailable;
@@ -52,6 +53,12 @@ pub struct SinkInfoSnapshot {
     pub name: String,
     /// Human-readable description.
     pub description: String,
+    /// Human-readable active port description, useful as UI subtitle.
+    pub port_description: Option<String>,
+    /// PulseAudio device form factor hint (e.g. speaker, headphone, headset).
+    pub form_factor: Option<String>,
+    /// PulseAudio/PipeWire icon hint (e.g. audio-speakers, audio-headphones).
+    pub device_icon_name: Option<String>,
     /// Whether this is the current default sink.
     pub is_default: bool,
     /// Whether the sink's active port is available (e.g., headphones plugged in).
@@ -68,6 +75,10 @@ pub struct SourceInfoSnapshot {
     pub name: String,
     /// Human-readable description.
     pub description: String,
+    /// Human-readable active port description, useful as UI subtitle.
+    pub port_description: Option<String>,
+    /// PulseAudio device form factor hint (e.g. microphone, headset, webcam).
+    pub form_factor: Option<String>,
     /// Whether this is the current default source.
     pub is_default: bool,
     /// Whether the source's active port is available (e.g., mic plugged in).
@@ -75,6 +86,27 @@ pub struct SourceInfoSnapshot {
     /// `Some(false)` means the port is not available.
     /// `Some(true)` means the port is available.
     pub port_available: Option<bool>,
+}
+
+/// Information about an application playback stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppVolumeSnapshot {
+    /// PulseAudio sink-input index used for per-stream volume changes.
+    pub index: u32,
+    /// Human-readable application name.
+    pub app_name: String,
+    /// Application identifier used for desktop-entry icon resolution.
+    pub app_id: String,
+    /// Optional icon name advertised by the application stream.
+    pub app_icon_name: String,
+    /// Human-readable stream/media description.
+    pub media_description: String,
+    /// Current stream volume as a percentage.
+    pub volume: u32,
+    /// Whether the stream is muted.
+    pub muted: bool,
+    /// Number of channels in the stream volume structure.
+    pub channel_count: u8,
 }
 
 /// Snapshot of audio service state for callbacks.
@@ -104,6 +136,8 @@ pub struct AudioSnapshot {
     pub control_available: bool,
     /// Whether mic volume/mute controls are currently functional.
     pub mic_control_available: bool,
+    /// Application playback streams with per-stream volume controls.
+    pub app_volumes: Vec<AppVolumeSnapshot>,
 }
 
 impl Default for AudioSnapshot {
@@ -120,6 +154,7 @@ impl Default for AudioSnapshot {
             available: false,
             control_available: true, // Optimistic default; updated when sink info arrives
             mic_control_available: true,
+            app_volumes: Vec::new(),
         }
     }
 }
@@ -181,6 +216,12 @@ enum AudioCommand {
     /// Values are clamped to the configured user-facing range before sending. Silently ignored if
     /// no default source is available or if mic control is unavailable.
     SetMicVolume(u32),
+
+    /// Set an application playback stream volume to an absolute percentage.
+    SetAppVolume { index: u32, percent: u32 },
+
+    /// Toggle the mute state for an application playback stream.
+    ToggleAppMute { index: u32 },
 
     /// Set the mute state for the default audio input source (microphone).
     ///
@@ -297,6 +338,7 @@ struct AudioStateUpdate {
     available: bool,
     control_available: bool,
     mic_control_available: bool,
+    app_volumes: Vec<AppVolumeSnapshot>,
 }
 
 /// Shared, process-wide audio service.
@@ -477,6 +519,19 @@ impl AudioService {
         let _ = self.command_tx.send(AudioCommand::SetMicVolume(percent));
     }
 
+    /// Set an application playback stream volume as a percentage.
+    pub fn set_app_volume(&self, index: u32, percent: u32) {
+        let percent = user_volume_percent(percent, self.user_max_percent());
+        let _ = self
+            .command_tx
+            .send(AudioCommand::SetAppVolume { index, percent });
+    }
+
+    /// Toggle an application playback stream mute state.
+    pub fn toggle_app_mute(&self, index: u32) {
+        let _ = self.command_tx.send(AudioCommand::ToggleAppMute { index });
+    }
+
     /// Set the default source (microphone) by name.
     pub fn set_default_source(&self, name: &str) {
         let _ = self
@@ -524,6 +579,7 @@ impl AudioService {
             available: update.available,
             control_available: update.control_available,
             mic_control_available: update.mic_control_available,
+            app_volumes: update.app_volumes,
         };
 
         if *self.current.borrow() == new_snapshot {
@@ -657,6 +713,18 @@ struct PulseWorkerState {
     /// Similar to `control_available` but for the default source.
     mic_control_available: bool,
 
+    /// Application playback streams eligible for per-app volume controls.
+    app_volumes: Vec<AppVolumeSnapshot>,
+
+    /// Monotonic revision assigned to optimistic application volume and mute changes.
+    app_change_revision: u64,
+
+    /// Desired mute states awaiting confirmation from a fresh enumeration.
+    pending_app_mutes: HashMap<u32, PendingAppMute>,
+
+    /// Desired volume states awaiting confirmation from a fresh enumeration.
+    pending_app_volumes: HashMap<u32, PendingAppVolume>,
+
     // ===== Connection State =====
     /// Whether we have an active connection to the PulseAudio server.
     ///
@@ -682,6 +750,18 @@ struct PulseWorkerState {
     /// externally). When this reaches 2, `control_available` is set to `false`
     /// indicating the backend is unresponsive to volume commands.
     stuck_attempts: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PendingAppMute {
+    muted: bool,
+    revision: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PendingAppVolume {
+    volume: u32,
+    revision: u64,
 }
 
 /// Main function for the PulseAudio worker thread.
@@ -836,11 +916,11 @@ fn setup_subscriptions(
     let state_for_cb = Arc::clone(&state);
     let context_for_cb = Arc::clone(&context);
 
-    ctx.set_subscribe_callback(Some(Box::new(move |facility, op, index| {
+    ctx.set_subscribe_callback(Some(Box::new(move |facility, op, _index| {
         let Some(facility) = facility else { return };
         let Some(op) = op else { return };
 
-        // We care about sink, source, and server changes.
+        // We care about sink, source, sink-input, and server changes.
         // Note: We're inside a callback, so the mainloop is already locked.
         // We must NOT call mainloop.lock() or ml.lock() here.
         match facility {
@@ -849,12 +929,7 @@ fn setup_subscriptions(
                     op,
                     SubscribeOp::Changed | SubscribeOp::New | SubscribeOp::Removed
                 ) {
-                    // Fetch updated sink info.
-                    fetch_sink_by_index_from_callback(
-                        Arc::clone(&context_for_cb),
-                        Arc::clone(&state_for_cb),
-                        index,
-                    );
+                    fetch_sinks_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
                 }
             }
             Facility::Source => {
@@ -862,27 +937,30 @@ fn setup_subscriptions(
                     op,
                     SubscribeOp::Changed | SubscribeOp::New | SubscribeOp::Removed
                 ) {
-                    // Fetch updated source info for mic volume/mute.
-                    fetch_source_by_index_from_callback(
-                        Arc::clone(&context_for_cb),
-                        Arc::clone(&state_for_cb),
-                        index,
-                    );
+                    fetch_sources_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
+                }
+            }
+            Facility::SinkInput => {
+                if matches!(
+                    op,
+                    SubscribeOp::Changed | SubscribeOp::New | SubscribeOp::Removed
+                ) {
+                    fetch_sink_inputs_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
                 }
             }
             Facility::Server => {
                 // Server info changed (e.g., default sink changed).
-                fetch_full_state_from_callback(
-                    Arc::clone(&context_for_cb),
-                    Arc::clone(&state_for_cb),
-                );
+                fetch_full_state_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
             }
             _ => {}
         }
     })));
 
-    // Subscribe to sink, source, and server events.
-    let mask = InterestMaskSet::SINK | InterestMaskSet::SOURCE | InterestMaskSet::SERVER;
+    // Subscribe to sink, source, sink-input, and server events.
+    let mask = InterestMaskSet::SINK
+        | InterestMaskSet::SOURCE
+        | InterestMaskSet::SINK_INPUT
+        | InterestMaskSet::SERVER;
     ctx.subscribe(mask, |_success| {});
 
     ml.unlock();
@@ -956,6 +1034,12 @@ fn handle_command(
                 percent,
             );
         }
+        AudioCommand::SetAppVolume { index, percent } => {
+            set_sink_input_volume(mainloop, context, state, index, percent);
+        }
+        AudioCommand::ToggleAppMute { index } => {
+            toggle_sink_input_mute(mainloop, context, state, index);
+        }
         AudioCommand::SetDefaultSink(name) => {
             set_default_sink(Arc::clone(&mainloop), Arc::clone(&context), &name);
             // The server event will trigger a full state refresh.
@@ -997,10 +1081,16 @@ fn fetch_full_state(
     context: Arc<Mutex<Context>>,
     state: Arc<Mutex<PulseWorkerState>>,
 ) {
-    // First, get server info to find the default sink/source names.
     let mut ml = mainloop.lock();
     ml.lock();
 
+    fetch_full_state_inner(context, state);
+
+    ml.unlock();
+}
+
+/// Fetch all audio state while the PulseAudio mainloop is already locked.
+fn fetch_full_state_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerState>>) {
     let ctx = context.lock();
     let introspect = ctx.introspect();
 
@@ -1026,67 +1116,18 @@ fn fetch_full_state(
 
         {
             let mut st = state_for_cb.lock();
-            st.default_sink_name = default_sink_name.clone();
-            st.available = true;
-        }
-
-        // We're inside a callback, so the mainloop is already locked.
-        // Use the context directly without locking the mainloop.
-
-        // Fetch sinks
-        fetch_sinks_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
-
-        // Fetch default sink details
-        if let Some(sink_name) = default_sink_name {
-            fetch_sink_by_name_inner(
-                Arc::clone(&context_for_cb),
-                Arc::clone(&state_for_cb),
-                &sink_name,
-            );
-        }
-
-        // Fetch default source for mic mute status
-        if default_source_name.is_some() {
-            fetch_default_source_from_callback(
-                Arc::clone(&context_for_cb),
-                Arc::clone(&state_for_cb),
-            );
-        }
-    });
-
-    ml.unlock();
-}
-
-/// Version called from within a callback (mainloop already locked).
-fn fetch_full_state_from_callback(
-    context: Arc<Mutex<Context>>,
-    state: Arc<Mutex<PulseWorkerState>>,
-) {
-    let ctx = context.lock();
-    let introspect = ctx.introspect();
-
-    let state_for_cb = Arc::clone(&state);
-    let context_for_cb = Arc::clone(&context);
-
-    // Use a Mutex to track whether we've already processed the callback.
-    let called = Arc::new(Mutex::new(false));
-
-    introspect.get_server_info(move |info| {
-        // Ensure we only process once.
-        {
-            let mut c = called.lock();
-            if *c {
-                return;
+            if st.default_sink_name.as_deref() != default_sink_name.as_deref()
+                || default_sink_name.is_none()
+            {
+                clear_default_sink_state(&mut st);
             }
-            *c = true;
-        }
-
-        let default_sink_name = info.default_sink_name.as_ref().map(|s| s.to_string());
-        let default_source_name = info.default_source_name.as_ref().map(|s| s.to_string());
-
-        {
-            let mut st = state_for_cb.lock();
             st.default_sink_name = default_sink_name.clone();
+            if st.default_source_name.as_deref() != default_source_name.as_deref()
+                || default_source_name.is_none()
+            {
+                clear_default_source_state(&mut st);
+            }
+            st.default_source_name = default_source_name.clone();
             st.available = true;
         }
 
@@ -1096,22 +1137,11 @@ fn fetch_full_state_from_callback(
         // Fetch sinks
         fetch_sinks_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
 
-        // Fetch default sink details
-        if let Some(sink_name) = default_sink_name {
-            fetch_sink_by_name_inner(
-                Arc::clone(&context_for_cb),
-                Arc::clone(&state_for_cb),
-                &sink_name,
-            );
-        }
+        // Fetch sources
+        fetch_sources_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
 
-        // Fetch default source for mic mute status
-        if default_source_name.is_some() {
-            fetch_default_source_from_callback(
-                Arc::clone(&context_for_cb),
-                Arc::clone(&state_for_cb),
-            );
-        }
+        // Fetch application playback streams
+        fetch_sink_inputs_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
     });
 }
 
@@ -1141,6 +1171,15 @@ fn fetch_sinks_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerS
 
                 let default_name = state_for_cb.lock().default_sink_name.clone();
                 let is_default = default_name.as_ref().map(|n| n == &name).unwrap_or(false);
+                if is_default {
+                    update_sink_state(&state_for_cb, info);
+                }
+                let port_description = info
+                    .active_port
+                    .as_ref()
+                    .and_then(|port| port.description.as_ref().map(|value| value.to_string()));
+                let form_factor = audio_prop(&info.proplist, "device.form_factor");
+                let device_icon_name = audio_prop(&info.proplist, "device.icon_name");
 
                 // Check active port availability (for jack detection, e.g., headphones)
                 // PortAvailable::Unknown means no jack detection support - treat as available
@@ -1154,6 +1193,9 @@ fn fetch_sinks_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerS
                 collected_for_cb.lock().push(SinkInfoSnapshot {
                     name,
                     description,
+                    port_description,
+                    form_factor,
+                    device_icon_name,
                     is_default,
                     port_available,
                 });
@@ -1163,6 +1205,7 @@ fn fetch_sinks_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerS
                 let sinks = std::mem::take(&mut *collected_for_cb.lock());
                 {
                     let mut st = state_for_cb.lock();
+                    clear_missing_default_sink_state(&mut st, &sinks);
                     st.sinks = sinks;
                 }
                 send_state_update(&state_for_cb.lock());
@@ -1175,22 +1218,154 @@ fn fetch_sinks_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerS
 }
 
 /// Inner version called from within a callback (mainloop already locked).
-fn fetch_sink_by_name_inner(
-    context: Arc<Mutex<Context>>,
-    state: Arc<Mutex<PulseWorkerState>>,
-    name: &str,
-) {
+fn fetch_sink_inputs_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerState>>) {
     let ctx = context.lock();
     let introspect = ctx.introspect();
 
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    let collected_for_cb = Arc::clone(&collected);
     let state_for_cb = Arc::clone(&state);
+    // Mainloop serialization dispatches this request after all app operations
+    // through this revision.
+    let enumeration_revision = state.lock().app_change_revision;
 
-    introspect.get_sink_info_by_name(name, move |result| {
-        if let ListResult::Item(info) = result {
-            update_sink_state(&state_for_cb, info);
+    introspect.get_sink_input_info_list(move |result| match result {
+        ListResult::Item(info) => {
+            if let Some(snapshot) = app_volume_from_sink_input(info) {
+                collected_for_cb.lock().push(snapshot);
+            }
+        }
+        ListResult::End => {
+            let mut app_volumes = std::mem::take(&mut *collected_for_cb.lock());
+            app_volumes.sort_by(|a, b| a.app_name.cmp(&b.app_name).then(a.index.cmp(&b.index)));
+            {
+                let mut st = state_for_cb.lock();
+                reconcile_pending_app_mutes(
+                    &mut app_volumes,
+                    &mut st.pending_app_mutes,
+                    enumeration_revision,
+                );
+                reconcile_pending_app_volumes(
+                    &mut app_volumes,
+                    &mut st.pending_app_volumes,
+                    enumeration_revision,
+                );
+                st.app_volumes = app_volumes;
+            }
             send_state_update(&state_for_cb.lock());
         }
+        ListResult::Error => {
+            warn!("AudioService: error fetching sink input list");
+        }
     });
+}
+
+fn app_volume_from_sink_input(info: &SinkInputInfo<'_>) -> Option<AppVolumeSnapshot> {
+    if !info.has_volume
+        || !info.volume.is_valid()
+        || info.volume.len() == 0
+        || !is_application_sink_input(info)
+    {
+        return None;
+    }
+
+    let app_name = sink_input_prop(info, "application.name")
+        .or_else(|| sink_input_prop(info, "application.process.binary"))
+        .unwrap_or_else(|| "Application".to_string());
+    let app_id = sink_input_prop(info, "application.id")
+        .or_else(|| sink_input_prop(info, "application.process.binary"))
+        .unwrap_or_else(|| app_name.clone());
+    let app_icon_name = sink_input_prop(info, "application.icon_name").unwrap_or_default();
+    let media_description = sink_input_prop(info, "media.name")
+        .or_else(|| info.name.as_ref().map(|name| name.to_string()))
+        .unwrap_or_else(|| "Audio stream".to_string());
+    let volume = volume_to_percent(info.volume.avg());
+
+    Some(AppVolumeSnapshot {
+        index: info.index,
+        app_name,
+        app_id,
+        app_icon_name,
+        media_description,
+        volume,
+        muted: info.mute,
+        channel_count: info.volume.len(),
+    })
+}
+
+fn sink_input_prop(info: &SinkInputInfo<'_>, key: &str) -> Option<String> {
+    info.proplist
+        .get_str(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn audio_prop(proplist: &Proplist, key: &str) -> Option<String> {
+    proplist
+        .get_str(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn clear_default_sink_state(st: &mut PulseWorkerState) {
+    st.default_sink_name = None;
+    st.default_sink_index = None;
+    st.channel_count = 0;
+    st.control_available = false;
+    st.last_volume_request = None;
+    st.stuck_attempts = 0;
+}
+
+fn clear_default_source_state(st: &mut PulseWorkerState) {
+    st.default_source_name = None;
+    st.default_source_index = None;
+    st.mic_muted = None;
+    st.mic_volume = None;
+    st.mic_channel_count = 0;
+    st.mic_control_available = false;
+}
+
+fn clear_missing_default_sink_state(st: &mut PulseWorkerState, sinks: &[SinkInfoSnapshot]) {
+    if st
+        .default_sink_name
+        .as_ref()
+        .is_some_and(|default| !sinks.iter().any(|sink| &sink.name == default))
+    {
+        clear_default_sink_state(st);
+    }
+}
+
+fn clear_missing_default_source_state(st: &mut PulseWorkerState, source_names: &[String]) {
+    if st
+        .default_source_name
+        .as_ref()
+        .is_some_and(|default| !source_names.iter().any(|name| name == default))
+    {
+        clear_default_source_state(st);
+    }
+}
+
+fn is_application_sink_input(info: &SinkInputInfo<'_>) -> bool {
+    let app_name = sink_input_prop(info, "application.name");
+    let process_binary = sink_input_prop(info, "application.process.binary");
+
+    if app_name.is_none() && process_binary.is_none() {
+        return false;
+    }
+
+    if info.client.is_none() || !info.volume_writable {
+        return false;
+    }
+
+    let media_role = sink_input_prop(info, "media.role").unwrap_or_default();
+    if matches!(
+        media_role.as_str(),
+        "filter" | "abstract" | "test" | "event"
+    ) {
+        return false;
+    }
+
+    true
 }
 
 /// Fetch the default sink state (called from command handler, locks mainloop).
@@ -1225,87 +1400,6 @@ fn fetch_default_sink(
 }
 
 /// Inner version called from within a callback (mainloop already locked).
-fn fetch_sink_by_index_from_callback(
-    context: Arc<Mutex<Context>>,
-    state: Arc<Mutex<PulseWorkerState>>,
-    index: u32,
-) {
-    let ctx = context.lock();
-    let introspect = ctx.introspect();
-
-    let state_for_cb = Arc::clone(&state);
-
-    introspect.get_sink_info_by_index(index, move |result| {
-        if let ListResult::Item(info) = result {
-            // Only update if this is the default sink.
-            let is_default = {
-                let st = state_for_cb.lock();
-                st.default_sink_index == Some(info.index)
-                    || st.default_sink_name.as_deref() == info.name.as_ref().map(|s| s.as_ref())
-            };
-
-            if is_default {
-                update_sink_state(&state_for_cb, info);
-                send_state_update(&state_for_cb.lock());
-            }
-        }
-    });
-}
-
-/// Version called from within a callback (mainloop already locked, no need for lock/unlock).
-fn fetch_default_source_from_callback(
-    context: Arc<Mutex<Context>>,
-    state: Arc<Mutex<PulseWorkerState>>,
-) {
-    let ctx = context.lock();
-    let introspect = ctx.introspect();
-
-    // First get server info to find the default source name.
-    let state_for_cb = Arc::clone(&state);
-    let context_for_source = Arc::clone(&context);
-
-    // Use a Mutex to track whether we've already processed the callback.
-    let called = Arc::new(Mutex::new(false));
-
-    introspect.get_server_info(move |info| {
-        // Ensure we only process once.
-        {
-            let mut c = called.lock();
-            if *c {
-                return;
-            }
-            *c = true;
-        }
-
-        let default_source_name = info.default_source_name.as_ref().map(|s| s.to_string());
-
-        {
-            let mut st = state_for_cb.lock();
-            st.default_source_name = default_source_name.clone();
-        }
-
-        if let Some(source_name) = default_source_name {
-            // We're inside a callback, so the mainloop is already locked.
-            // Just get the context and call introspect directly.
-            let ctx2 = context_for_source.lock();
-            let introspect2 = ctx2.introspect();
-
-            let state_for_source = Arc::clone(&state_for_cb);
-
-            introspect2.get_source_info_by_name(&source_name, move |result| {
-                if let ListResult::Item(info) = result {
-                    update_source_state(&state_for_source, info);
-                    send_state_update(&state_for_source.lock());
-                }
-            });
-        }
-
-        // Fetch all sources for the source list
-        fetch_sources_inner(Arc::clone(&context_for_source), Arc::clone(&state_for_cb));
-    });
-}
-
-/// Inner version called from within a callback (mainloop already locked).
 fn fetch_sources_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorkerState>>) {
     let ctx = context.lock();
     let introspect = ctx.introspect();
@@ -1313,16 +1407,13 @@ fn fetch_sources_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorke
     // Collect sources in a temporary Vec.
     let collected_sources = Arc::new(Mutex::new(Vec::new()));
     let collected_for_cb = Arc::clone(&collected_sources);
+    let collected_source_names = Arc::new(Mutex::new(Vec::new()));
+    let names_for_cb = Arc::clone(&collected_source_names);
     let state_for_cb = Arc::clone(&state);
 
     introspect.get_source_info_list(move |result| {
         match result {
             ListResult::Item(info) => {
-                // Skip monitor sources (they mirror sinks, not useful as mic inputs)
-                if info.monitor_of_sink.is_some() {
-                    return;
-                }
-
                 let name = info
                     .name
                     .as_ref()
@@ -1334,8 +1425,25 @@ fn fetch_sources_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorke
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| name.clone());
 
+                names_for_cb.lock().push(name.clone());
+
                 let default_name = state_for_cb.lock().default_source_name.clone();
                 let is_default = default_name.as_ref().map(|n| n == &name).unwrap_or(false);
+                // Update controls before filtering: a monitor can be the configured default source.
+                if is_default {
+                    update_source_state(&state_for_cb, info);
+                }
+
+                // Skip monitor sources (they mirror sinks, not useful as mic inputs)
+                if info.monitor_of_sink.is_some() {
+                    return;
+                }
+
+                let port_description = info
+                    .active_port
+                    .as_ref()
+                    .and_then(|port| port.description.as_ref().map(|value| value.to_string()));
+                let form_factor = audio_prop(&info.proplist, "device.form_factor");
 
                 // Check active port availability (for jack detection)
                 let port_available = info.active_port.as_ref().map(|port| match port.available {
@@ -1346,6 +1454,8 @@ fn fetch_sources_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorke
                 collected_for_cb.lock().push(SourceInfoSnapshot {
                     name,
                     description,
+                    port_description,
+                    form_factor,
                     is_default,
                     port_available,
                 });
@@ -1353,8 +1463,10 @@ fn fetch_sources_inner(context: Arc<Mutex<Context>>, state: Arc<Mutex<PulseWorke
             ListResult::End => {
                 // All sources collected; update state.
                 let sources = std::mem::take(&mut *collected_for_cb.lock());
+                let source_names = std::mem::take(&mut *names_for_cb.lock());
                 {
                     let mut st = state_for_cb.lock();
+                    clear_missing_default_source_state(&mut st, &source_names);
                     st.sources = sources;
                 }
                 send_state_update(&state_for_cb.lock());
@@ -1402,34 +1514,6 @@ fn update_source_state(
     }
 }
 
-/// Inner version called from within a callback (mainloop already locked).
-fn fetch_source_by_index_from_callback(
-    context: Arc<Mutex<Context>>,
-    state: Arc<Mutex<PulseWorkerState>>,
-    index: u32,
-) {
-    let ctx = context.lock();
-    let introspect = ctx.introspect();
-
-    let state_for_cb = Arc::clone(&state);
-
-    introspect.get_source_info_by_index(index, move |result| {
-        if let ListResult::Item(info) = result {
-            // Only update if this is the default source.
-            let is_default = {
-                let st = state_for_cb.lock();
-                st.default_source_index == Some(info.index)
-                    || st.default_source_name.as_deref() == info.name.as_ref().map(|s| s.as_ref())
-            };
-
-            if is_default {
-                update_source_state(&state_for_cb, info);
-                send_state_update(&state_for_cb.lock());
-            }
-        }
-    });
-}
-
 fn update_sink_state(state: &Arc<Mutex<PulseWorkerState>>, info: &SinkInfo) {
     let mut st = state.lock();
 
@@ -1457,13 +1541,6 @@ fn update_sink_state(state: &Arc<Mutex<PulseWorkerState>>, info: &SinkInfo) {
         sink_state,
         info.flags
     );
-
-    // Reset behavioral detection state if sink changed
-    let sink_changed = st.default_sink_name.as_deref() != info.name.as_ref().map(|s| s.as_ref());
-    if sink_changed {
-        st.last_volume_request = None;
-        st.stuck_attempts = 0;
-    }
 
     // Calculate volume as percentage (only if volume structure is valid)
     let volume_percent = if volume_valid && channel_count > 0 {
@@ -1739,6 +1816,205 @@ fn set_source_volume(
     ml.unlock();
 }
 
+fn set_cached_app_volume(
+    state: &mut PulseWorkerState,
+    index: u32,
+    volume: u32,
+) -> Option<(u8, PendingAppVolume)> {
+    let position = state
+        .app_volumes
+        .iter()
+        .position(|stream| stream.index == index)?;
+    let channel_count = state.app_volumes[position].channel_count;
+    if channel_count == 0 {
+        return None;
+    }
+
+    state.app_change_revision = state.app_change_revision.saturating_add(1);
+    let pending = PendingAppVolume {
+        volume,
+        revision: state.app_change_revision,
+    };
+    state.pending_app_volumes.insert(index, pending);
+    state.app_volumes[position].volume = volume;
+    Some((channel_count, pending))
+}
+
+fn remove_matching_pending_app_volume(
+    pending_volumes: &mut HashMap<u32, PendingAppVolume>,
+    index: u32,
+    pending: PendingAppVolume,
+) -> bool {
+    if pending_volumes.get(&index) != Some(&pending) {
+        return false;
+    }
+    pending_volumes.remove(&index);
+    true
+}
+
+fn set_sink_input_volume(
+    mainloop: Arc<Mutex<Mainloop>>,
+    context: Arc<Mutex<Context>>,
+    state: Arc<Mutex<PulseWorkerState>>,
+    index: u32,
+    percent: u32,
+) {
+    let mut ml = mainloop.lock();
+    ml.lock();
+
+    let volume_value = percent_to_valid_volume(percent);
+    let percent = volume_to_percent(volume_value);
+    let (channel_count, pending) = {
+        let mut st = state.lock();
+        let Some(change) = set_cached_app_volume(&mut st, index, percent) else {
+            debug!(
+                index,
+                "AudioService: skipping app volume change - stream unavailable"
+            );
+            ml.unlock();
+            return;
+        };
+        send_state_update(&st);
+        change
+    };
+
+    let mut cv = pulse::volume::ChannelVolumes::default();
+    cv.set(channel_count, volume_value);
+
+    let ctx = context.lock();
+    let mut introspect = ctx.introspect();
+    let context_for_cb = Arc::clone(&context);
+    let state_for_cb = Arc::clone(&state);
+    introspect.set_sink_input_volume(
+        index,
+        &cv,
+        Some(Box::new(move |success| {
+            if !success {
+                warn!(index, percent, "AudioService: failed to set app volume");
+                let mut st = state_for_cb.lock();
+                remove_matching_pending_app_volume(&mut st.pending_app_volumes, index, pending);
+                // Refresh re-locks state; parking_lot::Mutex is not reentrant.
+                drop(st);
+                fetch_sink_inputs_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
+            }
+        })),
+    );
+
+    ml.unlock();
+}
+
+fn toggle_cached_app_mute(state: &mut PulseWorkerState, index: u32) -> Option<PendingAppMute> {
+    let cached_muted = state
+        .app_volumes
+        .iter()
+        .find(|stream| stream.index == index)?
+        .muted;
+    let muted = !state
+        .pending_app_mutes
+        .get(&index)
+        .map(|pending| pending.muted)
+        .unwrap_or(cached_muted);
+    state.app_change_revision = state.app_change_revision.saturating_add(1);
+    let pending = PendingAppMute {
+        muted,
+        revision: state.app_change_revision,
+    };
+    state.pending_app_mutes.insert(index, pending);
+    if let Some(stream) = state
+        .app_volumes
+        .iter_mut()
+        .find(|stream| stream.index == index)
+    {
+        stream.muted = muted;
+    }
+    Some(pending)
+}
+
+fn reconcile_pending_app_mutes(
+    streams: &mut [AppVolumeSnapshot],
+    pending_mutes: &mut HashMap<u32, PendingAppMute>,
+    enumeration_revision: u64,
+) {
+    pending_mutes.retain(|index, pending| {
+        if enumeration_revision >= pending.revision {
+            return false;
+        }
+
+        if let Some(stream) = streams.iter_mut().find(|stream| stream.index == *index) {
+            stream.muted = pending.muted;
+        }
+        true
+    });
+}
+
+fn reconcile_pending_app_volumes(
+    streams: &mut [AppVolumeSnapshot],
+    pending_volumes: &mut HashMap<u32, PendingAppVolume>,
+    enumeration_revision: u64,
+) {
+    pending_volumes.retain(|index, pending| {
+        if enumeration_revision >= pending.revision {
+            return false;
+        }
+
+        if let Some(stream) = streams.iter_mut().find(|stream| stream.index == *index) {
+            stream.volume = pending.volume;
+        }
+        true
+    });
+}
+
+fn toggle_sink_input_mute(
+    mainloop: Arc<Mutex<Mainloop>>,
+    context: Arc<Mutex<Context>>,
+    state: Arc<Mutex<PulseWorkerState>>,
+    index: u32,
+) {
+    let mut ml = mainloop.lock();
+    ml.lock();
+
+    let pending = {
+        let mut st = state.lock();
+        let Some(pending) = toggle_cached_app_mute(&mut st, index) else {
+            debug!(
+                index,
+                "AudioService: skipping app mute change - stream unavailable"
+            );
+            ml.unlock();
+            return;
+        };
+        send_state_update(&st);
+        pending
+    };
+
+    let ctx = context.lock();
+    let mut introspect = ctx.introspect();
+    let context_for_cb = Arc::clone(&context);
+    let state_for_cb = Arc::clone(&state);
+    introspect.set_sink_input_mute(
+        index,
+        pending.muted,
+        Some(Box::new(move |success| {
+            if !success {
+                warn!(
+                    index,
+                    muted = pending.muted,
+                    "AudioService: failed to set app mute"
+                );
+                let mut st = state_for_cb.lock();
+                if st.pending_app_mutes.get(&index) == Some(&pending) {
+                    st.pending_app_mutes.remove(&index);
+                }
+                // Refresh re-locks state; parking_lot::Mutex is not reentrant.
+                drop(st);
+                fetch_sink_inputs_inner(Arc::clone(&context_for_cb), Arc::clone(&state_for_cb));
+            }
+        })),
+    );
+
+    ml.unlock();
+}
+
 fn set_default_sink(mainloop: Arc<Mutex<Mainloop>>, context: Arc<Mutex<Context>>, name: &str) {
     let mut ml = mainloop.lock();
     ml.lock();
@@ -1772,6 +2048,7 @@ fn build_state_update(state: &PulseWorkerState) -> AudioStateUpdate {
         available: state.available,
         control_available: state.control_available,
         mic_control_available: state.mic_control_available,
+        app_volumes: state.app_volumes.clone(),
     }
 }
 
@@ -2159,5 +2436,267 @@ mod tests {
         assert_eq!(bounded_relative_volume_target(200, -5, 153), Some(153));
         assert_eq!(bounded_relative_volume_target(50, -5, 153), Some(45));
         assert_eq!(bounded_relative_volume_target(50, 0, 153), None);
+    }
+
+    #[test]
+    fn cached_app_mute_toggles_compose_across_stale_enumeration() {
+        let stream = AppVolumeSnapshot {
+            index: 7,
+            app_name: "App".to_string(),
+            app_id: "app".to_string(),
+            app_icon_name: String::new(),
+            media_description: "Playback".to_string(),
+            volume: 50,
+            muted: false,
+            channel_count: 2,
+        };
+        let mut state = PulseWorkerState {
+            app_volumes: vec![stream.clone()],
+            ..Default::default()
+        };
+
+        assert!(toggle_cached_app_mute(&mut state, 7).unwrap().muted);
+
+        let mut stale_enumeration = vec![stream];
+        reconcile_pending_app_mutes(&mut stale_enumeration, &mut state.pending_app_mutes, 0);
+        state.app_volumes = stale_enumeration;
+
+        assert!(!toggle_cached_app_mute(&mut state, 7).unwrap().muted);
+        assert!(!state.app_volumes[0].muted);
+        assert_eq!(state.pending_app_mutes.len(), 1);
+
+        let revision = state.app_change_revision;
+        let mut confirmed_enumeration = state.app_volumes.clone();
+        reconcile_pending_app_mutes(
+            &mut confirmed_enumeration,
+            &mut state.pending_app_mutes,
+            revision,
+        );
+        assert!(state.pending_app_mutes.is_empty());
+        assert_eq!(toggle_cached_app_mute(&mut state, 99), None);
+    }
+
+    #[test]
+    fn post_revision_mute_disagreement_preserves_backend_state() {
+        let mut streams = vec![AppVolumeSnapshot {
+            index: 7,
+            app_name: "App".to_string(),
+            app_id: "app".to_string(),
+            app_icon_name: String::new(),
+            media_description: "Playback".to_string(),
+            volume: 50,
+            muted: false,
+            channel_count: 2,
+        }];
+        let mut pending_mutes = HashMap::from([(
+            7,
+            PendingAppMute {
+                muted: true,
+                revision: 1,
+            },
+        )]);
+
+        reconcile_pending_app_mutes(&mut streams, &mut pending_mutes, 1);
+
+        assert!(pending_mutes.is_empty());
+        assert!(!streams[0].muted);
+    }
+
+    #[test]
+    fn stale_enumeration_preserves_pending_app_volume() {
+        let stream = AppVolumeSnapshot {
+            index: 7,
+            app_name: "App".to_string(),
+            app_id: "app".to_string(),
+            app_icon_name: String::new(),
+            media_description: "Playback".to_string(),
+            volume: 50,
+            muted: false,
+            channel_count: 2,
+        };
+        let mut state = PulseWorkerState {
+            app_volumes: vec![stream.clone()],
+            ..Default::default()
+        };
+
+        let (_, pending) = set_cached_app_volume(&mut state, 7, 75).unwrap();
+        let mut stale_enumeration = vec![stream];
+        reconcile_pending_app_volumes(&mut stale_enumeration, &mut state.pending_app_volumes, 0);
+
+        assert_eq!(pending.revision, 1);
+        assert_eq!(stale_enumeration[0].volume, 75);
+        assert_eq!(state.pending_app_volumes.get(&7), Some(&pending));
+    }
+
+    #[test]
+    fn post_revision_volume_disagreement_preserves_backend_state() {
+        let mut streams = vec![AppVolumeSnapshot {
+            index: 7,
+            app_name: "App".to_string(),
+            app_id: "app".to_string(),
+            app_icon_name: String::new(),
+            media_description: "Playback".to_string(),
+            volume: 60,
+            muted: false,
+            channel_count: 2,
+        }];
+        let mut pending_volumes = HashMap::from([(
+            7,
+            PendingAppVolume {
+                volume: 75,
+                revision: 1,
+            },
+        )]);
+
+        reconcile_pending_app_volumes(&mut streams, &mut pending_volumes, 1);
+
+        assert!(pending_volumes.is_empty());
+        assert_eq!(streams[0].volume, 60);
+    }
+
+    #[test]
+    fn older_volume_failure_preserves_newer_pending_change() {
+        let mut state = PulseWorkerState {
+            app_volumes: vec![AppVolumeSnapshot {
+                index: 7,
+                app_name: "App".to_string(),
+                app_id: "app".to_string(),
+                app_icon_name: String::new(),
+                media_description: "Playback".to_string(),
+                volume: 50,
+                muted: false,
+                channel_count: 2,
+            }],
+            ..Default::default()
+        };
+
+        let mute = toggle_cached_app_mute(&mut state, 7).unwrap();
+        let (_, older) = set_cached_app_volume(&mut state, 7, 60).unwrap();
+        let (_, newer) = set_cached_app_volume(&mut state, 7, 70).unwrap();
+
+        assert_eq!(mute.revision, 1);
+        assert_eq!(older.revision, 2);
+        assert_eq!(newer.revision, 3);
+        assert!(!remove_matching_pending_app_volume(
+            &mut state.pending_app_volumes,
+            7,
+            older,
+        ));
+        assert_eq!(state.pending_app_volumes.get(&7), Some(&newer));
+        assert_eq!(state.app_volumes[0].volume, 70);
+    }
+
+    #[test]
+    fn missing_default_sink_clears_control_state() {
+        let mut state = PulseWorkerState {
+            default_sink_name: Some("removed".to_string()),
+            default_sink_index: Some(7),
+            control_available: true,
+            ..Default::default()
+        };
+        let sinks = vec![SinkInfoSnapshot {
+            name: "remaining".to_string(),
+            description: "Remaining".to_string(),
+            port_description: None,
+            form_factor: None,
+            device_icon_name: None,
+            is_default: false,
+            port_available: None,
+        }];
+
+        clear_missing_default_sink_state(&mut state, &sinks);
+
+        assert_eq!(state.default_sink_name, None);
+        assert_eq!(state.default_sink_index, None);
+        assert!(!state.control_available);
+    }
+
+    #[test]
+    fn present_default_sink_preserves_control_state() {
+        let mut state = PulseWorkerState {
+            default_sink_name: Some("remaining".to_string()),
+            default_sink_index: Some(7),
+            control_available: true,
+            ..Default::default()
+        };
+        let sinks = vec![SinkInfoSnapshot {
+            name: "remaining".to_string(),
+            description: "Remaining".to_string(),
+            port_description: None,
+            form_factor: None,
+            device_icon_name: None,
+            is_default: true,
+            port_available: None,
+        }];
+
+        clear_missing_default_sink_state(&mut state, &sinks);
+
+        assert_eq!(state.default_sink_name.as_deref(), Some("remaining"));
+        assert_eq!(state.default_sink_index, Some(7));
+        assert!(state.control_available);
+    }
+
+    #[test]
+    fn source_presence_includes_filtered_monitors() {
+        let mut state = PulseWorkerState {
+            default_source_name: Some("sink.monitor".to_string()),
+            default_source_index: Some(9),
+            mic_control_available: true,
+            ..Default::default()
+        };
+
+        clear_missing_default_source_state(&mut state, &["sink.monitor".to_string()]);
+        assert_eq!(state.default_source_name.as_deref(), Some("sink.monitor"));
+
+        clear_missing_default_source_state(&mut state, &[]);
+        assert_eq!(state.default_source_name, None);
+        assert_eq!(state.default_source_index, None);
+        assert!(!state.mic_control_available);
+    }
+
+    #[test]
+    fn clear_default_sink_state_disables_stale_controls() {
+        let mut state = PulseWorkerState {
+            volume: 42,
+            muted: true,
+            default_sink_name: Some("sink".to_string()),
+            default_sink_index: Some(7),
+            channel_count: 2,
+            control_available: true,
+            last_volume_request: Some(50),
+            stuck_attempts: 1,
+            ..Default::default()
+        };
+
+        clear_default_sink_state(&mut state);
+
+        assert_eq!(state.default_sink_name, None);
+        assert_eq!(state.default_sink_index, None);
+        assert_eq!(state.channel_count, 0);
+        assert!(!state.control_available);
+        assert_eq!(state.last_volume_request, None);
+        assert_eq!(state.stuck_attempts, 0);
+    }
+
+    #[test]
+    fn clear_default_source_state_disables_stale_controls() {
+        let mut state = PulseWorkerState {
+            mic_muted: Some(true),
+            mic_volume: Some(42),
+            default_source_name: Some("source".to_string()),
+            default_source_index: Some(9),
+            mic_channel_count: 1,
+            mic_control_available: true,
+            ..Default::default()
+        };
+
+        clear_default_source_state(&mut state);
+
+        assert_eq!(state.default_source_name, None);
+        assert_eq!(state.default_source_index, None);
+        assert_eq!(state.mic_muted, None);
+        assert_eq!(state.mic_volume, None);
+        assert_eq!(state.mic_channel_count, 0);
+        assert!(!state.mic_control_available);
     }
 }

--- a/crates/vibepanel/src/services/icons.rs
+++ b/crates/vibepanel/src/services/icons.rs
@@ -1268,10 +1268,11 @@ pub fn resolve_app_icon_name(app_id: &str, fallback: &str) -> String {
         return icon_name;
     }
     // Try the app_id directly as an icon name (some apps use their name)
-    let display = gtk4::gdk::Display::default().expect("No display");
-    let icon_theme = IconTheme::for_display(&display);
-    if icon_theme.has_icon(app_id) {
-        return app_id.to_string();
+    if let Some(display) = gtk4::gdk::Display::default() {
+        let icon_theme = IconTheme::for_display(&display);
+        if icon_theme.has_icon(app_id) {
+            return app_id.to_string();
+        }
     }
     fallback.to_string()
 }
@@ -2482,6 +2483,17 @@ mod tests {
         // Unknown names pass through unchanged
         assert_eq!(material_symbol_name("unknown-icon"), "unknown-icon");
         assert_eq!(material_symbol_name("wifi"), "wifi");
+    }
+
+    #[test]
+    fn resolve_app_icon_name_falls_back_without_matching_icon() {
+        assert_eq!(
+            resolve_app_icon_name(
+                "vibepanel-test-definitely-missing-application",
+                "audio-x-generic"
+            ),
+            "audio-x-generic"
+        );
     }
 
     // GTK Icon Mapping Tests

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -401,6 +401,36 @@ pub mod qs {
     /// Audio details container (`.qs-audio-details`).
     pub const AUDIO_DETAILS: &str = "qs-audio-details";
 
+    /// Application volume list container (`.qs-app-volume-list`).
+    pub const APP_VOLUME_LIST: &str = "qs-app-volume-list";
+
+    /// Application volume row (`.qs-app-volume-row`).
+    pub const APP_VOLUME_ROW: &str = "qs-app-volume-row";
+
+    /// Application volume icon slot (`.qs-app-volume-icon-slot`).
+    pub const APP_VOLUME_ICON_SLOT: &str = "qs-app-volume-icon-slot";
+
+    /// Application volume icon (`.qs-app-volume-icon`).
+    pub const APP_VOLUME_ICON: &str = "qs-app-volume-icon";
+
+    /// Application volume fallback icon (`.qs-app-volume-icon-fallback`).
+    pub const APP_VOLUME_ICON_FALLBACK: &str = "qs-app-volume-icon-fallback";
+
+    /// Application volume title (`.qs-app-volume-title`).
+    pub const APP_VOLUME_TITLE: &str = "qs-app-volume-title";
+
+    /// Application volume description (`.qs-app-volume-description`).
+    pub const APP_VOLUME_DESCRIPTION: &str = "qs-app-volume-description";
+
+    /// Application volume value (`.qs-app-volume-value`).
+    pub const APP_VOLUME_VALUE: &str = "qs-app-volume-value";
+
+    /// Application volume slider (`.qs-app-volume-slider`).
+    pub const APP_VOLUME_SLIDER: &str = "qs-app-volume-slider";
+
+    /// Application volume mute button (`.qs-app-volume-mute`).
+    pub const APP_VOLUME_MUTE: &str = "qs-app-volume-mute";
+
     /// Section header (`.qs-section-header`).
     pub const SECTION_HEADER: &str = "qs-section-header";
 

--- a/crates/vibepanel/src/widgets/css/quick_settings.rs
+++ b/crates/vibepanel/src/widgets/css/quick_settings.rs
@@ -176,6 +176,10 @@ window.quick-settings-window {{
     background: transparent;
 }}
 
+.qs-section-header {{
+    font-size: var(--font-size-md);
+}}
+
 .qs-row {{
     background: var(--color-card-overlay);
     border-radius: var(--radius-widget);
@@ -440,6 +444,93 @@ window.quick-settings-window {{
     font-size: var(--font-size-xs);
     font-style: italic;
     padding: 4px 0;
+}}
+
+/* Application volume cards inside expanded audio details */
+.qs-app-volume-list .qs-row {{
+    padding: 0;
+}}
+
+.qs-app-volume-row {{
+    margin: 3px 0;
+}}
+
+.qs-app-volume-icon-slot {{
+    min-width: calc(var(--icon-size) * 1.5);
+    margin-right: 10px;
+}}
+
+.qs-app-volume-icon-fallback {{
+    font-size: calc(var(--icon-size) * 1.0);
+}}
+
+.qs-app-volume-title {{
+    font-size: var(--font-size-sm);
+    font-weight: bold;
+}}
+
+.qs-app-volume-description {{
+    font-size: var(--font-size-sm);
+    font-weight: normal;
+}}
+
+.qs-app-volume-value {{
+    font-size: var(--font-size-sm);
+    font-weight: bold;
+    min-width: 34px;
+}}
+
+.qs-app-volume-mute {{
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    min-width: 28px;
+    min-height: 28px;
+    margin-left: 8px;
+    margin-right: 0;
+    padding: 2px;
+    border-radius: var(--radius-widget);
+    font-size: calc(var(--icon-size) * 0.95);
+}}
+
+.qs-app-volume-mute:hover {{
+    background: var(--color-card-overlay-hover);
+}}
+
+.qs-app-volume-slider {{
+    min-height: 14px;
+    margin: 0 0 0 0;
+    padding: 0;
+}}
+
+.qs-app-volume-slider > trough {{
+    min-height: 3px;
+    border-radius: calc(var(--slider-radius) * 0.75);
+    background-color: var(--color-slider-track);
+    margin: 0;
+}}
+
+.qs-app-volume-slider > trough > highlight {{
+    background-image: image(var(--color-accent-slider, var(--color-accent-primary)));
+    background-color: var(--color-accent-slider, var(--color-accent-primary));
+    border: none;
+    min-height: 3px;
+    border-radius: calc(var(--slider-radius) * 0.75);
+}}
+
+.qs-app-volume-slider > trough > slider {{
+    min-width: 12px;
+    min-height: 12px;
+    margin: -4px;
+    padding: 0;
+    background-color: var(--color-accent-primary);
+    border-radius: calc(var(--slider-knob-radius) * 0.75);
+    border: none;
+    box-shadow: none;
+}}
+
+.qs-app-volume-slider > trough > slider:active {{
+    transform: scale(1.15);
 }}
 
 /* ===== MARQUEE LABEL ===== */

--- a/crates/vibepanel/src/widgets/quick_settings/audio_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/audio_card.rs
@@ -12,18 +12,21 @@ use std::rc::Rc;
 use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Button, EventControllerScroll, EventControllerScrollFlags, Label,
-    ListBox, ListBoxRow, Orientation, Overlay, Revealer, RevealerTransitionType, Scale,
+    Align, Box as GtkBox, Button, CenterBox, EventControllerScroll, EventControllerScrollFlags,
+    Image, Label, ListBox, ListBoxRow, Orientation, Revealer, RevealerTransitionType, Scale,
 };
 
 use super::components::SliderRow;
-use super::ui_helpers::{add_placeholder_row, clear_list_box, create_qs_list_box};
-use crate::services::audio::{AudioService, AudioSnapshot};
+use super::ui_helpers::{
+    add_placeholder_row, audio_output_icon_name, clear_list_box, create_device_row,
+    create_qs_list_box, device_subtitle,
+};
+use crate::services::audio::{AppVolumeSnapshot, AudioService, AudioSnapshot, SinkInfoSnapshot};
 use crate::services::config_manager::ConfigManager;
-use crate::services::icons::{IconHandle, IconsService};
+use crate::services::icons::{IconHandle, IconsService, resolve_app_icon_name};
 use crate::services::surfaces::SurfaceStyleManager;
 use crate::styles::{color, qs, row, state};
-use crate::widgets::base::add_ripple_to_row;
+use crate::widgets::base::vp_button;
 
 /// Get the appropriate volume icon name based on volume level and mute state.
 ///
@@ -58,12 +61,22 @@ pub struct AudioCardState {
     pub revealer: RefCell<Option<Revealer>>,
     /// Audio sink list box.
     pub list_box: RefCell<Option<ListBox>>,
+    /// Last sink-list inputs rendered into `list_box`.
+    sink_list_snapshot: RefCell<Option<(bool, Vec<SinkInfoSnapshot>)>>,
+    /// Application volume list box.
+    pub app_list_box: RefCell<Option<ListBox>>,
+    /// Last application-list inputs rendered; `None` means the list has not rendered yet.
+    app_volume_list_key: RefCell<Option<AppVolumeListKey>>,
+    /// Current application volume row widgets, aligned with the rendered stream keys.
+    app_volume_rows: RefCell<Vec<AppVolumeRowState>>,
     /// Flag to prevent slider feedback loop.
     pub updating: Cell<bool>,
     /// Audio row container (for CSS class toggling).
     pub row: RefCell<Option<GtkBox>>,
     /// Hint label shown when audio control is unavailable.
     pub hint_label: RefCell<Option<Label>>,
+    /// Volume delta used for application slider scroll.
+    pub app_scroll_step: Cell<i32>,
 }
 
 impl AudioCardState {
@@ -75,11 +88,57 @@ impl AudioCardState {
             arrow: RefCell::new(None),
             revealer: RefCell::new(None),
             list_box: RefCell::new(None),
+            sink_list_snapshot: RefCell::new(None),
+            app_list_box: RefCell::new(None),
+            app_volume_list_key: RefCell::new(None),
+            app_volume_rows: RefCell::new(Vec::new()),
             updating: Cell::new(false),
             row: RefCell::new(None),
             hint_label: RefCell::new(None),
+            app_scroll_step: Cell::new(5),
         }
     }
+
+    pub fn invalidate_list_caches(&self) {
+        *self.sink_list_snapshot.borrow_mut() = None;
+        *self.app_volume_list_key.borrow_mut() = None;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AppVolumeKey {
+    index: u32,
+    app_name: String,
+    app_id: String,
+    app_icon_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AppVolumeListKey {
+    available: bool,
+    streams: Vec<AppVolumeKey>,
+}
+
+impl From<&AppVolumeSnapshot> for AppVolumeKey {
+    fn from(stream: &AppVolumeSnapshot) -> Self {
+        Self {
+            index: stream.index,
+            app_name: stream.app_name.clone(),
+            app_id: stream.app_id.clone(),
+            app_icon_name: stream.app_icon_name.clone(),
+        }
+    }
+}
+
+struct AppVolumeRowState {
+    row: ListBoxRow,
+    index: u32,
+    description_label: Label,
+    value_label: Label,
+    slider: Scale,
+    mute_button: Button,
+    mute_icon: IconHandle,
+    updating: Rc<Cell<bool>>,
 }
 
 impl Default for AudioCardState {
@@ -148,6 +207,8 @@ pub struct AudioDetailsWidgets {
     pub revealer: Revealer,
     /// The list box for sinks.
     pub list_box: ListBox,
+    /// The list box for application streams.
+    pub app_list_box: ListBox,
 }
 
 /// Build the audio details section with sink list.
@@ -162,7 +223,7 @@ pub fn build_audio_details() -> AudioDetailsWidgets {
     container.add_css_class(qs::AUDIO_DETAILS);
 
     // Section header
-    let header = Label::new(Some("Sound"));
+    let header = Label::new(Some("Output Devices"));
     header.set_xalign(0.0);
     header.add_css_class(qs::SECTION_HEADER);
     container.append(&header);
@@ -171,6 +232,15 @@ pub fn build_audio_details() -> AudioDetailsWidgets {
     let list_box = create_qs_list_box();
     container.append(&list_box);
 
+    let app_header = Label::new(Some("Applications"));
+    app_header.set_xalign(0.0);
+    app_header.add_css_class(qs::SECTION_HEADER);
+    container.append(&app_header);
+
+    let app_list_box = create_qs_list_box();
+    app_list_box.add_css_class(qs::APP_VOLUME_LIST);
+    container.append(&app_list_box);
+
     // Wrap in revealer
     let revealer = Revealer::new();
     revealer.set_transition_type(RevealerTransitionType::SlideDown);
@@ -178,7 +248,11 @@ pub fn build_audio_details() -> AudioDetailsWidgets {
     revealer.set_reveal_child(false);
     revealer.set_child(Some(&container));
 
-    AudioDetailsWidgets { revealer, list_box }
+    AudioDetailsWidgets {
+        revealer,
+        list_box,
+        app_list_box,
+    }
 }
 
 /// Create a hint label for when audio control is unavailable.
@@ -195,101 +269,10 @@ pub fn build_audio_hint_label() -> Label {
     label
 }
 
-/// Create a sink row for the audio sink list.
-///
-/// # Arguments
-///
-/// - `description`: The human-readable sink description.
-/// - `is_default`: Whether this sink is the current default.
-/// - `port_available`: Whether the sink's port is available (e.g., headphones plugged in).
-///   `None` means no jack detection, `Some(false)` means unavailable.
-pub fn create_sink_row(
-    description: &str,
-    is_default: bool,
-    port_available: Option<bool>,
-) -> ListBoxRow {
-    let list_row = ListBoxRow::new();
-    list_row.add_css_class(row::QS);
-    list_row.add_css_class(row::BASE);
-
-    // Check if port is unavailable (explicitly false, not unknown/None)
-    let is_unavailable = port_available == Some(false);
-
-    let hbox = GtkBox::new(Orientation::Horizontal, 6);
-    hbox.add_css_class(row::QS_CONTENT);
-
-    // Description label
-    let label = Label::new(Some(description));
-    label.set_xalign(0.0);
-    label.set_hexpand(true);
-    label.set_ellipsize(EllipsizeMode::End);
-    label.set_single_line_mode(true);
-    label.set_width_chars(22);
-    label.set_max_width_chars(22);
-    label.add_css_class(row::QS_TITLE);
-    label.add_css_class(color::PRIMARY);
-    hbox.append(&label);
-
-    // Selection indicator
-    if is_default {
-        // Overlay: background box + checkmark icon floating on top
-        let overlay = Overlay::new();
-        overlay.set_valign(Align::Center);
-
-        // Background box (same size as unselected indicator)
-        let bg = GtkBox::new(Orientation::Horizontal, 0);
-        bg.add_css_class(row::QS_INDICATOR_BG);
-        overlay.set_child(Some(&bg));
-
-        // Checkmark icon (larger, overflows the background)
-        let icons = IconsService::global();
-        let indicator = icons.create_icon("object-select-symbolic", &[row::QS_INDICATOR]);
-        indicator.widget().set_halign(Align::Center);
-        indicator.widget().set_valign(Align::Center);
-        overlay.add_overlay(&indicator.widget());
-
-        hbox.append(&overlay);
-    } else {
-        // CSS-styled box for unselected (respects --radius-pill)
-        let indicator = GtkBox::new(Orientation::Horizontal, 0);
-        indicator.add_css_class(row::QS_RADIO_INDICATOR);
-        hbox.append(&indicator);
-    }
-
-    // Add ripple overlay for press feedback on activatable rows.
-    // Move padding from the row CSS to content margins so the ripple
-    // DrawingArea fills the full row background.
-    if is_unavailable {
-        list_row.set_child(Some(&hbox));
-    } else {
-        // Transfer .qs-row padding to content margins; the CSS rule
-        // `.qs-row.vp-has-ripple { padding: 0 }` zeros the row padding.
-        hbox.set_margin_top(6);
-        hbox.set_margin_bottom(6);
-        hbox.set_margin_start(10);
-        hbox.set_margin_end(10);
-
-        add_ripple_to_row(&list_row, &hbox);
-    }
-
-    // If port is unavailable, gray out the row and make it non-activatable
-    if is_unavailable {
-        list_row.set_activatable(false);
-        list_row.set_focusable(false);
-        list_row.set_sensitive(false);
-    } else {
-        list_row.set_activatable(true);
-        list_row.set_focusable(true);
-    }
-
-    list_row
-}
-
 /// Populate the audio sink list with available sinks.
 ///
-/// Sinks with unavailable ports (e.g., headphones not plugged in) are shown
-/// but grayed out and non-selectable.
-pub fn populate_audio_sink_list(list_box: &ListBox, snapshot: &AudioSnapshot) {
+/// Sinks with unavailable ports (e.g., headphones not plugged in) are omitted.
+fn populate_audio_sink_list(list_box: &ListBox, snapshot: &AudioSnapshot) {
     clear_list_box(list_box);
 
     if !snapshot.available {
@@ -322,9 +305,296 @@ pub fn populate_audio_sink_list(list_box: &ListBox, snapshot: &AudioSnapshot) {
             continue;
         }
 
-        let row = create_sink_row(&sink.description, sink.is_default, sink.port_available);
+        let subtitle = device_subtitle(
+            &sink.description,
+            sink.port_description.as_deref(),
+            sink.form_factor.as_deref(),
+        );
+        let icon_name = audio_output_icon_name(
+            sink.device_icon_name.as_deref(),
+            sink.form_factor.as_deref(),
+        );
+        let row = create_device_row(
+            &sink.description,
+            subtitle.as_deref(),
+            Some(icon_name),
+            sink.is_default,
+        );
         list_box.append(&row);
     }
+}
+
+pub fn sync_audio_sink_list(
+    state: &AudioCardState,
+    list_box: &ListBox,
+    snapshot: &AudioSnapshot,
+) -> bool {
+    let unchanged = state
+        .sink_list_snapshot
+        .borrow()
+        .as_ref()
+        .is_some_and(|(available, sinks)| {
+            *available == snapshot.available && sinks == &snapshot.sinks
+        });
+    if unchanged {
+        return false;
+    }
+
+    populate_audio_sink_list(list_box, snapshot);
+    *state.sink_list_snapshot.borrow_mut() = Some((snapshot.available, snapshot.sinks.clone()));
+    true
+}
+
+/// Populate application stream volume controls.
+fn populate_app_volume_list(state: &AudioCardState, list_box: &ListBox, snapshot: &AudioSnapshot) {
+    clear_list_box(list_box);
+    state.app_volume_rows.borrow_mut().clear();
+    *state.app_volume_list_key.borrow_mut() = Some(app_volume_list_key(snapshot));
+
+    if !snapshot.available {
+        add_placeholder_row(list_box, "Audio unavailable");
+        return;
+    }
+
+    if snapshot.app_volumes.is_empty() {
+        add_placeholder_row(list_box, "No application audio");
+        return;
+    }
+
+    let mut rows = Vec::with_capacity(snapshot.app_volumes.len());
+    for stream in &snapshot.app_volumes {
+        let row = create_app_volume_row(stream, state.app_scroll_step.get());
+        list_box.append(&row.row);
+        rows.push(row);
+    }
+    *state.app_volume_rows.borrow_mut() = rows;
+}
+
+pub fn sync_app_volume_list(
+    state: &AudioCardState,
+    list_box: &ListBox,
+    snapshot: &AudioSnapshot,
+) -> bool {
+    let key = app_volume_list_key(snapshot);
+    if state.app_volume_list_key.borrow().as_ref() != Some(&key) {
+        populate_app_volume_list(state, list_box, snapshot);
+        return true;
+    }
+
+    let rows = state.app_volume_rows.borrow();
+    for (row, stream) in rows.iter().zip(&snapshot.app_volumes) {
+        row.update(stream);
+    }
+    false
+}
+
+fn app_volume_list_key(snapshot: &AudioSnapshot) -> AppVolumeListKey {
+    AppVolumeListKey {
+        available: snapshot.available,
+        streams: if snapshot.available {
+            snapshot
+                .app_volumes
+                .iter()
+                .map(AppVolumeKey::from)
+                .collect()
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+fn create_app_volume_row(stream: &AppVolumeSnapshot, scroll_step: i32) -> AppVolumeRowState {
+    let list_row = ListBoxRow::new();
+    list_row.add_css_class(row::QS);
+    list_row.add_css_class(row::BASE);
+    list_row.add_css_class(qs::APP_VOLUME_ROW);
+    list_row.set_activatable(false);
+    list_row.set_focusable(false);
+
+    let outer = GtkBox::new(Orientation::Horizontal, 0);
+    outer.add_css_class(row::QS_CONTENT);
+    outer.set_margin_top(6);
+    outer.set_margin_bottom(6);
+    outer.set_margin_start(10);
+    outer.set_margin_end(10);
+
+    append_app_volume_icon(&outer, stream);
+
+    let content = GtkBox::new(Orientation::Vertical, 2);
+    content.set_hexpand(true);
+
+    let top_row = GtkBox::new(Orientation::Horizontal, 6);
+
+    let title_label = Label::new(Some(&stream.app_name));
+    title_label.add_css_class(qs::APP_VOLUME_TITLE);
+    title_label.add_css_class(color::PRIMARY);
+    title_label.set_xalign(0.0);
+    title_label.set_ellipsize(EllipsizeMode::End);
+    title_label.set_single_line_mode(true);
+    title_label.set_tooltip_text(Some(&stream.app_name));
+    top_row.append(&title_label);
+
+    let description_label = Label::new(None);
+    description_label.add_css_class(qs::APP_VOLUME_DESCRIPTION);
+    description_label.add_css_class(color::MUTED);
+    description_label.set_xalign(0.0);
+    description_label.set_hexpand(true);
+    description_label.set_ellipsize(EllipsizeMode::End);
+    description_label.set_single_line_mode(true);
+    top_row.append(&description_label);
+
+    let value_label = Label::new(None);
+    value_label.add_css_class(qs::APP_VOLUME_VALUE);
+    value_label.set_halign(Align::End);
+    value_label.add_css_class(color::PRIMARY);
+    top_row.append(&value_label);
+
+    content.append(&top_row);
+
+    let slider = Scale::with_range(
+        Orientation::Horizontal,
+        0.0,
+        AudioService::global().user_max_percent() as f64,
+        1.0,
+    );
+    slider.add_css_class(qs::APP_VOLUME_SLIDER);
+    slider.set_draw_value(false);
+    slider.set_hexpand(true);
+    slider.set_round_digits(0);
+    attach_app_volume_scroll_controller(&slider, scroll_step);
+
+    let index = stream.index;
+    let updating = Rc::new(Cell::new(false));
+    let updating_for_slider = Rc::clone(&updating);
+    slider.connect_value_changed(move |slider| {
+        if updating_for_slider.get() {
+            return;
+        }
+        AudioService::global().set_app_volume(index, slider.value().round() as u32);
+    });
+
+    content.append(&slider);
+    outer.append(&content);
+    let (mute_button, mute_icon) = build_app_volume_mute_button(stream.index);
+    outer.append(&mute_button);
+    list_row.set_child(Some(&outer));
+
+    let row = AppVolumeRowState {
+        row: list_row,
+        index: stream.index,
+        description_label,
+        value_label,
+        slider,
+        mute_button,
+        mute_icon,
+        updating,
+    };
+    row.update(stream);
+    row
+}
+
+impl AppVolumeRowState {
+    fn update(&self, stream: &AppVolumeSnapshot) {
+        debug_assert_eq!(self.index, stream.index);
+        let description = format!("- {}", stream.media_description);
+        if self.description_label.text() != description {
+            self.description_label.set_text(&description);
+            self.description_label
+                .set_tooltip_text(Some(&stream.media_description));
+        }
+        let tooltip = format!("{}%", stream.volume);
+        self.value_label.set_text(&tooltip);
+        self.value_label.set_tooltip_text(Some(&tooltip));
+        self.updating.set(true);
+        self.slider
+            .set_range(0.0, AudioService::global().user_max_percent().max(1) as f64);
+        self.slider.set_value(stream.volume as f64);
+        self.slider.set_tooltip_text(Some(&tooltip));
+        self.updating.set(false);
+
+        let icon_name = volume_icon_name(stream.volume, stream.muted);
+        self.mute_icon.set_icon(icon_name);
+        let icon = self.mute_icon.widget();
+        if stream.muted {
+            icon.add_css_class(state::MUTED);
+        } else {
+            icon.remove_css_class(state::MUTED);
+        }
+        let mute_tooltip = if stream.muted { "Unmute" } else { "Mute" };
+        if self.mute_button.tooltip_text().as_deref() != Some(mute_tooltip) {
+            self.mute_button.set_tooltip_text(Some(mute_tooltip));
+        }
+    }
+}
+
+fn build_app_volume_mute_button(index: u32) -> (Button, IconHandle) {
+    let button = vp_button();
+    button.set_has_frame(false);
+    button.add_css_class(qs::APP_VOLUME_MUTE);
+    button.set_valign(Align::Center);
+
+    let icon_handle =
+        IconsService::global().create_icon("audio-volume-muted-symbolic", &[color::PRIMARY]);
+    icon_handle.widget().set_halign(Align::Center);
+    icon_handle.widget().set_valign(Align::Center);
+    button.set_child(Some(&icon_handle.widget()));
+
+    button.connect_clicked(move |_| {
+        AudioService::global().toggle_app_mute(index);
+    });
+
+    (button, icon_handle)
+}
+
+fn append_app_volume_icon(container: &GtkBox, stream: &AppVolumeSnapshot) {
+    let icon_slot = CenterBox::new();
+    icon_slot.add_css_class(qs::APP_VOLUME_ICON_SLOT);
+    icon_slot.set_halign(Align::Start);
+    icon_slot.set_valign(Align::Center);
+    icon_slot.set_hexpand(false);
+
+    if let Some(icon_name) = resolve_stream_icon_name(stream) {
+        let app_icon = Image::from_icon_name(&icon_name);
+        app_icon.add_css_class(qs::APP_VOLUME_ICON);
+        let icon_size = ConfigManager::global().theme_sizes().pixmap_icon_size as i32;
+        app_icon.set_pixel_size((icon_size as f32 * 1.25).round() as i32);
+        app_icon.set_halign(Align::Center);
+        app_icon.set_valign(Align::Center);
+        icon_slot.set_center_widget(Some(&app_icon));
+        container.append(&icon_slot);
+        return;
+    }
+
+    let fallback = IconsService::global().create_icon(
+        "audio-speakers-symbolic",
+        &[qs::APP_VOLUME_ICON, color::PRIMARY],
+    );
+    fallback.add_css_class(qs::APP_VOLUME_ICON_FALLBACK);
+    fallback.widget().set_valign(Align::Center);
+    fallback.widget().set_halign(Align::Center);
+    fallback.widget().set_hexpand(false);
+    icon_slot.set_center_widget(Some(&fallback.widget()));
+    container.append(&icon_slot);
+}
+
+fn resolve_stream_icon_name(stream: &AppVolumeSnapshot) -> Option<String> {
+    for candidate in [
+        stream.app_icon_name.as_str(),
+        stream.app_id.as_str(),
+        stream.app_name.as_str(),
+    ] {
+        let candidate = candidate.trim();
+        if candidate.is_empty() || candidate.eq_ignore_ascii_case("application") {
+            continue;
+        }
+
+        let icon_name = resolve_app_icon_name(candidate, "");
+        if !icon_name.is_empty() {
+            return Some(icon_name);
+        }
+    }
+
+    None
 }
 
 /// Handle Audio state changes from AudioService.
@@ -373,11 +643,17 @@ pub fn on_audio_changed(state: &AudioCardState, snapshot: &AudioSnapshot) {
         }
     }
 
-    // Update sink list
-    if let Some(list_box) = state.list_box.borrow().as_ref() {
-        populate_audio_sink_list(list_box, snapshot);
-        // Apply Pango font attrs to dynamically created list rows
+    // Update sink list only when device inputs change.
+    if let Some(list_box) = state.list_box.borrow().as_ref()
+        && sync_audio_sink_list(state, list_box, snapshot)
+    {
         SurfaceStyleManager::global().apply_pango_attrs_all(list_box);
+    }
+
+    if let Some(app_list_box) = state.app_list_box.borrow().as_ref()
+        && sync_app_volume_list(state, app_list_box, snapshot)
+    {
+        SurfaceStyleManager::global().apply_pango_attrs_all(app_list_box);
     }
 }
 
@@ -412,14 +688,55 @@ pub fn on_audio_sink_row_activated(row: &ListBoxRow) {
 /// volume only changes once a full tick is reached. The accumulator resets
 /// on direction change so that reversing scroll direction feels responsive.
 pub fn attach_volume_scroll_controller(widget: &impl IsA<gtk4::Widget>, step: i32) {
+    attach_volume_scroll_controller_inner(
+        widget,
+        step,
+        move || {
+            let snapshot = AudioService::global().current();
+            if !snapshot.available || !snapshot.control_available {
+                return false;
+            }
+
+            true
+        },
+        |direction, step| {
+            AudioService::global().set_volume_relative(direction * step);
+        },
+    );
+}
+
+fn attach_app_volume_scroll_controller(slider: &Scale, step: i32) {
+    let slider_for_apply = slider.downgrade();
+
+    attach_volume_scroll_controller_inner(
+        slider,
+        step,
+        || true,
+        move |direction, step| {
+            let Some(slider) = slider_for_apply.upgrade() else {
+                return;
+            };
+            let adjustment = slider.adjustment();
+            let value = (slider.value() + f64::from(direction * step))
+                .clamp(adjustment.lower(), adjustment.upper());
+            slider.set_value(value);
+        },
+    );
+}
+
+fn attach_volume_scroll_controller_inner(
+    widget: &impl IsA<gtk4::Widget>,
+    step: i32,
+    can_scroll: impl Fn() -> bool + 'static,
+    apply_step: impl Fn(i32, i32) + 'static,
+) {
     let scroll = EventControllerScroll::new(EventControllerScrollFlags::VERTICAL);
     scroll.set_propagation_phase(gtk4::PropagationPhase::Capture);
 
     let accumulated = Rc::new(Cell::new(0.0f64));
 
     scroll.connect_scroll(move |_controller, _dx, dy| {
-        let snapshot = AudioService::global().current();
-        if !snapshot.available || !snapshot.control_available {
+        if !can_scroll() {
             accumulated.set(0.0);
             return gtk4::glib::Propagation::Proceed;
         }
@@ -433,13 +750,11 @@ pub fn attach_volume_scroll_controller(widget: &impl IsA<gtk4::Widget>, step: i3
         }
 
         acc += dy;
-
-        let audio = AudioService::global();
         let step = step.abs();
 
         while acc.abs() >= 1.0 {
             let direction = if acc < 0.0 { 1 } else { -1 };
-            audio.set_volume_relative(direction * step);
+            apply_step(direction, step);
             acc -= acc.signum();
         }
 
@@ -448,4 +763,94 @@ pub fn attach_volume_scroll_controller(widget: &impl IsA<gtk4::Widget>, step: i3
     });
 
     widget.add_controller(scroll);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(
+        volume: u32,
+        muted: bool,
+        media_description: &str,
+        channel_count: u8,
+    ) -> AppVolumeSnapshot {
+        AppVolumeSnapshot {
+            index: 7,
+            app_name: "App".to_string(),
+            app_id: "app".to_string(),
+            app_icon_name: "app-icon".to_string(),
+            media_description: media_description.to_string(),
+            volume,
+            muted,
+            channel_count,
+        }
+    }
+
+    fn snapshot(app_volumes: Vec<AppVolumeSnapshot>) -> AudioSnapshot {
+        AudioSnapshot {
+            available: true,
+            app_volumes,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn app_volume_list_key_ignores_dynamic_stream_fields() {
+        let first = snapshot(vec![stream(25, false, "Playback", 2)]);
+        let second = snapshot(vec![stream(80, true, "Next track", 6)]);
+
+        assert_eq!(app_volume_list_key(&first), app_volume_list_key(&second));
+    }
+
+    #[test]
+    fn app_volume_list_key_distinguishes_unavailable_from_available_empty() {
+        let unavailable = AudioSnapshot::default();
+        let available = snapshot(Vec::new());
+
+        assert_ne!(
+            app_volume_list_key(&unavailable),
+            app_volume_list_key(&available)
+        );
+    }
+
+    #[test]
+    fn app_volume_list_key_changes_when_streams_appear() {
+        let empty = snapshot(Vec::new());
+        let populated = snapshot(vec![stream(25, false, "Playback", 2)]);
+
+        assert_ne!(app_volume_list_key(&empty), app_volume_list_key(&populated));
+    }
+
+    #[test]
+    fn uninitialized_app_volume_list_differs_from_rendered_unavailable() {
+        let state = AudioCardState::new();
+        let unavailable_key = app_volume_list_key(&AudioSnapshot::default());
+
+        assert_ne!(
+            state.app_volume_list_key.borrow().as_ref(),
+            Some(&unavailable_key)
+        );
+
+        *state.app_volume_list_key.borrow_mut() = Some(unavailable_key.clone());
+        assert_eq!(
+            state.app_volume_list_key.borrow().as_ref(),
+            Some(&unavailable_key)
+        );
+    }
+
+    #[test]
+    fn invalidating_audio_list_caches_clears_rendered_inputs() {
+        let state = AudioCardState::new();
+        *state.sink_list_snapshot.borrow_mut() = Some((true, Vec::new()));
+        *state.app_volume_list_key.borrow_mut() = Some(AppVolumeListKey {
+            available: true,
+            streams: Vec::new(),
+        });
+
+        state.invalidate_list_caches();
+
+        assert!(state.sink_list_snapshot.borrow().is_none());
+        assert!(state.app_volume_list_key.borrow().is_none());
+    }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bluetooth_card.rs
@@ -19,15 +19,16 @@ use tracing::debug;
 use super::components::ListRow;
 use super::ui_helpers::{
     ExpandableCard, ExpandableCardBase, ScanButton, add_disabled_placeholder, add_placeholder_row,
-    build_accent_subtitle, clear_list_box, create_qs_list_box, create_row_action_label,
-    create_row_menu_action, create_row_menu_button, set_icon_active, set_subtitle_active,
+    build_accent_subtitle, clear_list_box, close_row_menu_popover, create_qs_list_box,
+    create_row_action_label, create_row_menu_action, create_row_menu_button,
+    present_row_menu_popover, set_icon_active, set_subtitle_active,
 };
 use crate::services::bluetooth::{
     BluetoothAuthRequest, BluetoothDevice, BluetoothService, BluetoothSnapshot,
 };
 use crate::services::icons::IconsService;
 use crate::services::surfaces::SurfaceStyleManager;
-use crate::styles::{button, color, icon, qs, row, state, surface};
+use crate::styles::{button, color, icon, qs, row, surface};
 use crate::widgets::base::configure_popover;
 
 /// Identity of an auth request for cache invalidation.
@@ -364,7 +365,11 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
 
         if connected {
             let path = path_for_menu.clone();
+            let popover_weak = popover.downgrade();
             let action = create_row_menu_action("Disconnect", move || {
+                if let Some(popover) = popover_weak.upgrade() {
+                    close_row_menu_popover(&popover);
+                }
                 let bt = BluetoothService::global();
                 debug!("bt_disconnect_from_menu path={}", path);
                 bt.disconnect_device(&path);
@@ -372,7 +377,11 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
             content_box.append(&action);
         } else {
             let path = path_for_menu.clone();
+            let popover_weak = popover.downgrade();
             let action = create_row_menu_action("Connect", move || {
+                if let Some(popover) = popover_weak.upgrade() {
+                    close_row_menu_popover(&popover);
+                }
                 let bt = BluetoothService::global();
                 debug!("bt_connect_from_menu path={}", path);
                 bt.connect_device(&path);
@@ -381,7 +390,11 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
         }
 
         let path = path_for_menu.clone();
+        let popover_weak = popover.downgrade();
         let action = create_row_menu_action("Forget", move || {
+            if let Some(popover) = popover_weak.upgrade() {
+                close_row_menu_popover(&popover);
+            }
             let bt = BluetoothService::global();
             debug!("bt_forget_from_menu path={}", path);
             bt.forget_device(&path);
@@ -390,16 +403,7 @@ fn create_bluetooth_action_widget(dev: &BluetoothDevice, is_pairing: bool) -> gt
 
         panel.append(&content_box);
         popover.set_child(Some(&panel));
-        popover.set_parent(btn);
-
-        menu_icon_widget.add_css_class(state::EXPANDED);
-        let icon_for_close = menu_icon_widget.clone();
-        popover.connect_closed(move |p| {
-            icon_for_close.remove_css_class(state::EXPANDED);
-            p.unparent();
-        });
-
-        popover.popup();
+        present_row_menu_popover(&popover, btn, &menu_icon_widget);
     });
 
     menu_btn.upcast()

--- a/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
@@ -16,7 +16,8 @@ use gtk4::{
 
 use super::components::SliderRow;
 use super::ui_helpers::{
-    add_placeholder_row, clear_list_box, create_device_row, create_qs_list_box, device_subtitle,
+    add_placeholder_row, audio_input_icon_name, clear_list_box, create_device_row,
+    create_qs_list_box, device_subtitle,
 };
 use crate::services::audio::{AudioService, AudioSnapshot, SourceInfoSnapshot};
 use crate::services::config_manager::ConfigManager;
@@ -231,10 +232,11 @@ fn populate_mic_source_list(list_box: &ListBox, sources: &[SourceInfoSnapshot]) 
             source.port_description.as_deref(),
             source.form_factor.as_deref(),
         );
+        let icon_name = audio_input_icon_name(source.form_factor.as_deref());
         let row = create_device_row(
             &source.description,
             subtitle.as_deref(),
-            None,
+            Some(icon_name),
             source.is_default,
         );
         list_box.append(&row);

--- a/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/mic_card.rs
@@ -8,21 +8,21 @@
 
 use std::cell::{Cell, RefCell};
 
-use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, Overlay, Revealer,
+    Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, Revealer,
     RevealerTransitionType, Scale,
 };
 
 use super::components::SliderRow;
-use super::ui_helpers::{add_placeholder_row, clear_list_box, create_qs_list_box};
+use super::ui_helpers::{
+    add_placeholder_row, clear_list_box, create_device_row, create_qs_list_box, device_subtitle,
+};
 use crate::services::audio::{AudioService, AudioSnapshot, SourceInfoSnapshot};
 use crate::services::config_manager::ConfigManager;
-use crate::services::icons::{IconHandle, IconsService};
+use crate::services::icons::IconHandle;
 use crate::services::surfaces::SurfaceStyleManager;
-use crate::styles::{color, qs, row, state};
-use crate::widgets::base::add_ripple_to_row;
+use crate::styles::{color, qs, state};
 
 /// Get the appropriate mic icon name based on volume level and mute state.
 pub fn mic_icon_name(volume: u32, muted: bool) -> &'static str {
@@ -55,6 +55,8 @@ pub struct MicCardState {
     pub revealer: RefCell<Option<Revealer>>,
     /// Mic source list box.
     pub list_box: RefCell<Option<ListBox>>,
+    /// Last source list rendered into `list_box`.
+    source_list_snapshot: RefCell<Option<Vec<SourceInfoSnapshot>>>,
     /// Flag to prevent slider feedback loop.
     pub updating: Cell<bool>,
     /// Mic row container (for CSS class toggling).
@@ -72,10 +74,15 @@ impl MicCardState {
             arrow: RefCell::new(None),
             revealer: RefCell::new(None),
             list_box: RefCell::new(None),
+            source_list_snapshot: RefCell::new(None),
             updating: Cell::new(false),
             row: RefCell::new(None),
             hint_label: RefCell::new(None),
         }
+    }
+
+    pub fn invalidate_list_cache(&self) {
+        *self.source_list_snapshot.borrow_mut() = None;
     }
 }
 
@@ -159,7 +166,7 @@ pub fn build_mic_details() -> MicDetailsWidgets {
     container.add_css_class(qs::AUDIO_DETAILS);
 
     // Section header
-    let header = Label::new(Some("Input"));
+    let header = Label::new(Some("Input Devices"));
     header.set_xalign(0.0);
     header.add_css_class(qs::SECTION_HEADER);
     container.append(&header);
@@ -190,100 +197,10 @@ pub fn build_mic_hint_label() -> Label {
     label
 }
 
-/// Create a source row for the mic source list.
-///
-/// # Arguments
-///
-/// - `description`: The human-readable source description.
-/// - `is_default`: Whether this source is the current default.
-/// - `port_available`: Whether the source's port is available.
-///   `None` means no jack detection, `Some(false)` means unavailable.
-pub fn create_source_row(
-    description: &str,
-    is_default: bool,
-    port_available: Option<bool>,
-) -> ListBoxRow {
-    let list_row = ListBoxRow::new();
-    list_row.add_css_class(row::QS);
-    list_row.add_css_class(row::BASE);
-
-    // Check if port is unavailable (explicitly false, not unknown/None)
-    let is_unavailable = port_available == Some(false);
-
-    let hbox = GtkBox::new(Orientation::Horizontal, 6);
-    hbox.add_css_class(row::QS_CONTENT);
-
-    // Description label
-    let label = Label::new(Some(description));
-    label.set_xalign(0.0);
-    label.set_hexpand(true);
-    label.set_ellipsize(EllipsizeMode::End);
-    label.set_single_line_mode(true);
-    label.set_width_chars(22);
-    label.set_max_width_chars(22);
-    label.add_css_class(row::QS_TITLE);
-    label.add_css_class(color::PRIMARY);
-    hbox.append(&label);
-
-    // Selection indicator
-    if is_default {
-        // Overlay: background box + checkmark icon floating on top
-        let overlay = Overlay::new();
-        overlay.set_valign(Align::Center);
-
-        // Background box (same size as unselected indicator)
-        let bg = GtkBox::new(Orientation::Horizontal, 0);
-        bg.add_css_class(row::QS_INDICATOR_BG);
-        overlay.set_child(Some(&bg));
-
-        // Checkmark icon (larger, overflows the background)
-        let icons = IconsService::global();
-        let indicator = icons.create_icon("object-select-symbolic", &[row::QS_INDICATOR]);
-        indicator.widget().set_halign(Align::Center);
-        indicator.widget().set_valign(Align::Center);
-        overlay.add_overlay(&indicator.widget());
-
-        hbox.append(&overlay);
-    } else {
-        // CSS-styled box for unselected (respects --radius-pill)
-        let indicator = GtkBox::new(Orientation::Horizontal, 0);
-        indicator.add_css_class(row::QS_RADIO_INDICATOR);
-        hbox.append(&indicator);
-    }
-
-    // Add ripple overlay for press feedback on activatable rows.
-    // Move padding from the row CSS to content margins so the ripple
-    // DrawingArea fills the full row background.
-    if is_unavailable {
-        list_row.set_child(Some(&hbox));
-    } else {
-        // Transfer .qs-row padding to content margins; the CSS rule
-        // `.qs-row.vp-has-ripple { padding: 0 }` zeros the row padding.
-        hbox.set_margin_top(6);
-        hbox.set_margin_bottom(6);
-        hbox.set_margin_start(10);
-        hbox.set_margin_end(10);
-
-        add_ripple_to_row(&list_row, &hbox);
-    }
-
-    // If port is unavailable, gray out the row and make it non-activatable
-    if is_unavailable {
-        list_row.set_activatable(false);
-        list_row.set_focusable(false);
-        list_row.set_sensitive(false);
-    } else {
-        list_row.set_activatable(true);
-        list_row.set_focusable(true);
-    }
-
-    list_row
-}
-
 /// Populate the mic source list with available sources.
 ///
-/// Sources with unavailable ports are shown but grayed out and non-selectable.
-pub fn populate_mic_source_list(list_box: &ListBox, sources: &[SourceInfoSnapshot]) {
+/// Sources with unavailable ports are omitted.
+fn populate_mic_source_list(list_box: &ListBox, sources: &[SourceInfoSnapshot]) {
     clear_list_box(list_box);
 
     if sources.is_empty() {
@@ -309,13 +226,33 @@ pub fn populate_mic_source_list(list_box: &ListBox, sources: &[SourceInfoSnapsho
             continue;
         }
 
-        let row = create_source_row(
+        let subtitle = device_subtitle(
             &source.description,
+            source.port_description.as_deref(),
+            source.form_factor.as_deref(),
+        );
+        let row = create_device_row(
+            &source.description,
+            subtitle.as_deref(),
+            None,
             source.is_default,
-            source.port_available,
         );
         list_box.append(&row);
     }
+}
+
+pub fn sync_mic_source_list(
+    state: &MicCardState,
+    list_box: &ListBox,
+    sources: &[SourceInfoSnapshot],
+) -> bool {
+    if state.source_list_snapshot.borrow().as_deref() == Some(sources) {
+        return false;
+    }
+
+    populate_mic_source_list(list_box, sources);
+    *state.source_list_snapshot.borrow_mut() = Some(sources.to_vec());
+    true
 }
 
 /// Handle Audio state changes from AudioService (mic-related fields).
@@ -366,10 +303,10 @@ pub fn on_mic_changed(state: &MicCardState, snapshot: &AudioSnapshot) {
         }
     }
 
-    // Update source list
-    if let Some(list_box) = state.list_box.borrow().as_ref() {
-        populate_mic_source_list(list_box, &snapshot.sources);
-        // Apply Pango font attrs to dynamically created list rows
+    // Update source list only when device inputs change.
+    if let Some(list_box) = state.list_box.borrow().as_ref()
+        && sync_mic_source_list(state, list_box, &snapshot.sources)
+    {
         SurfaceStyleManager::global().apply_pango_attrs_all(list_box);
     }
 }
@@ -391,5 +328,20 @@ pub fn on_mic_source_row_activated(row: &ListBoxRow, sources: &[SourceInfoSnapsh
 
     if let Some(source) = available_sources.get(index as usize) {
         AudioService::global().set_default_source(&source.name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalidating_mic_list_cache_clears_rendered_inputs() {
+        let state = MicCardState::new();
+        *state.source_list_snapshot.borrow_mut() = Some(Vec::new());
+
+        state.invalidate_list_cache();
+
+        assert!(state.source_list_snapshot.borrow().is_none());
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/network_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/network_card.rs
@@ -21,8 +21,9 @@ use tracing::debug;
 use super::components::ListRow;
 use super::ui_helpers::{
     ExpandableCard, ExpandableCardBase, ScanButton, add_disabled_placeholder, add_placeholder_row,
-    build_accent_subtitle, build_error_subtitle, clear_list_box, create_qs_list_box,
-    create_row_action_label, create_row_menu_action, create_row_menu_button, set_icon_active,
+    build_accent_subtitle, build_error_subtitle, clear_list_box, close_row_menu_popover,
+    create_qs_list_box, create_row_action_label, create_row_menu_action, create_row_menu_button,
+    present_row_menu_popover, set_icon_active,
 };
 use super::window::current_quick_settings_window;
 use crate::services::icons::{IconHandle, IconsService};
@@ -1313,7 +1314,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
             let action = create_row_menu_action("Disconnect", move || {
                 // Close popover first to avoid "still has children" warning
                 if let Some(p) = popover_weak.upgrade() {
-                    p.popdown();
+                    close_row_menu_popover(&p);
                 }
                 let network = NetworkService::global();
                 debug!("wifi_disconnect_from_menu ssid={}", ssid_clone);
@@ -1327,7 +1328,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
             let action = create_row_menu_action("Connect", move || {
                 // Close popover first to avoid "still has children" warning
                 if let Some(p) = popover_weak.upgrade() {
-                    p.popdown();
+                    close_row_menu_popover(&p);
                 }
                 let network = NetworkService::global();
                 debug!("wifi_connect_from_menu ssid={}", ssid_clone);
@@ -1345,7 +1346,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
             let action = create_row_menu_action("Forget", move || {
                 // Close popover first to avoid "still has children" warning
                 if let Some(p) = popover_weak.upgrade() {
-                    p.popdown();
+                    close_row_menu_popover(&p);
                 }
                 let network = NetworkService::global();
                 debug!("wifi_forget_from_menu ssid={}", ssid_clone);
@@ -1358,16 +1359,7 @@ fn create_network_action_widget(net: &WifiNetwork) -> gtk4::Widget {
         SurfaceStyleManager::global().apply_pango_attrs_all(&content_box);
 
         popover.set_child(Some(&panel));
-        popover.set_parent(btn);
-
-        menu_icon_widget.add_css_class(state::EXPANDED);
-        let icon_for_close = menu_icon_widget.clone();
-        popover.connect_closed(move |p| {
-            icon_for_close.remove_css_class(state::EXPANDED);
-            p.unparent();
-        });
-
-        popover.popup();
+        present_row_menu_popover(&popover, btn, &menu_icon_widget);
     });
 
     menu_btn.upcast()

--- a/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
@@ -6,11 +6,13 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use crate::services::icons::{CairoSpinner, IconHandle, IconsService};
-use crate::styles::{button, color, qs, row, state};
+use crate::styles::{button, color, icon, qs, row, state};
+use crate::widgets::base::add_ripple_to_row;
+use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, Revealer, SelectionMode,
-    ToggleButton,
+    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, Overlay, Popover,
+    Revealer, SelectionMode, ToggleButton,
 };
 
 /// Base state for expandable cards (Wi-Fi, Bluetooth, VPN).
@@ -76,6 +78,161 @@ pub fn set_subtitle_active(label: &Label, active: bool) {
     } else {
         label.remove_css_class(state::SUBTITLE_ACTIVE);
     }
+}
+
+pub fn device_subtitle(
+    description: &str,
+    port_description: Option<&str>,
+    form_factor: Option<&str>,
+) -> Option<String> {
+    port_description
+        .and_then(|subtitle| meaningful_device_subtitle(description, subtitle))
+        .map(str::to_owned)
+        .or_else(|| {
+            form_factor
+                .and_then(|factor| meaningful_device_subtitle(description, factor))
+                .map(title_case_device_hint)
+        })
+}
+
+pub fn audio_output_icon_name(
+    device_icon_name: Option<&str>,
+    form_factor: Option<&str>,
+) -> &'static str {
+    form_factor
+        .and_then(audio_form_factor_icon)
+        .or_else(|| device_icon_name.and_then(audio_icon_family))
+        .unwrap_or("audio-card-symbolic")
+}
+
+fn audio_icon_family(icon_name: &str) -> Option<&'static str> {
+    let icon_name = icon_name.trim();
+
+    [
+        ("audio-headphones", "audio-headphones"),
+        ("audio-headset", "audio-headset"),
+        ("audio-speakers", "audio-speakers"),
+        ("audio-card", "audio-card-symbolic"),
+    ]
+    .into_iter()
+    .find_map(|(family, canonical)| {
+        icon_name
+            .strip_prefix(family)
+            .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('-'))
+            .then_some(canonical)
+    })
+}
+
+fn audio_form_factor_icon(form_factor: &str) -> Option<&'static str> {
+    match form_factor.trim().to_ascii_lowercase().as_str() {
+        "headphone" | "headphones" => Some("audio-headphones"),
+        "headset" | "hands-free" | "handsfree" => Some("audio-headset"),
+        "speaker" | "speakers" => Some("audio-speakers"),
+        _ => None,
+    }
+}
+
+pub(super) fn create_device_row(
+    description: &str,
+    subtitle: Option<&str>,
+    icon_name: Option<&str>,
+    is_default: bool,
+) -> ListBoxRow {
+    let list_row = ListBoxRow::new();
+    list_row.add_css_class(row::QS);
+    list_row.add_css_class(row::BASE);
+
+    let content = GtkBox::new(Orientation::Horizontal, 6);
+    content.add_css_class(row::QS_CONTENT);
+
+    if let Some(icon_name) = icon_name {
+        let icon_handle = IconsService::global()
+            .create_icon(icon_name, &[icon::TEXT, row::QS_ICON, color::PRIMARY]);
+        icon_handle.widget().set_valign(Align::Center);
+        content.append(&icon_handle.widget());
+    }
+
+    let labels = GtkBox::new(Orientation::Vertical, 2);
+    labels.set_hexpand(true);
+
+    let title = Label::new(Some(description));
+    title.set_xalign(0.0);
+    title.set_ellipsize(EllipsizeMode::End);
+    title.set_single_line_mode(true);
+    title.set_width_chars(22);
+    title.set_max_width_chars(22);
+    title.add_css_class(row::QS_TITLE);
+    title.add_css_class(color::PRIMARY);
+    labels.append(&title);
+
+    if let Some(subtitle) = subtitle {
+        let label = Label::new(Some(subtitle));
+        label.set_xalign(0.0);
+        label.set_ellipsize(EllipsizeMode::End);
+        label.set_single_line_mode(true);
+        label.add_css_class(row::QS_SUBTITLE);
+        label.add_css_class(color::MUTED);
+        labels.append(&label);
+    }
+
+    content.append(&labels);
+
+    if is_default {
+        let overlay = Overlay::new();
+        overlay.set_valign(Align::Center);
+        overlay.set_margin_end(8);
+
+        let background = GtkBox::new(Orientation::Horizontal, 0);
+        background.add_css_class(row::QS_INDICATOR_BG);
+        overlay.set_child(Some(&background));
+
+        let indicator =
+            IconsService::global().create_icon("object-select-symbolic", &[row::QS_INDICATOR]);
+        indicator.widget().set_halign(Align::Center);
+        indicator.widget().set_valign(Align::Center);
+        overlay.add_overlay(&indicator.widget());
+        content.append(&overlay);
+    } else {
+        let indicator = GtkBox::new(Orientation::Horizontal, 0);
+        indicator.set_valign(Align::Center);
+        indicator.set_margin_end(8);
+        indicator.add_css_class(row::QS_RADIO_INDICATOR);
+        content.append(&indicator);
+    }
+
+    content.set_margin_top(6);
+    content.set_margin_bottom(6);
+    content.set_margin_start(10);
+    content.set_margin_end(10);
+    add_ripple_to_row(&list_row, &content);
+    list_row.set_activatable(true);
+    list_row.set_focusable(true);
+
+    list_row
+}
+
+fn meaningful_device_subtitle<'a>(description: &str, subtitle: &'a str) -> Option<&'a str> {
+    let subtitle = subtitle.trim();
+    if subtitle.is_empty() || subtitle.eq_ignore_ascii_case(description.trim()) {
+        return None;
+    }
+
+    Some(subtitle)
+}
+
+fn title_case_device_hint(value: &str) -> String {
+    value
+        .split(['-', '_', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Build a subtitle with an error-colored primary word followed by muted dot-separated parts.
@@ -297,6 +454,55 @@ pub fn create_row_menu_button() -> (Button, IconHandle) {
     menu_btn.set_child(Some(&icon_widget));
 
     (menu_btn, icon_handle)
+}
+
+/// Close and detach a row menu before its parent button can be removed.
+pub fn close_row_menu_popover(popover: &Popover) {
+    if popover.parent().is_none() {
+        return;
+    }
+
+    popover.popdown();
+    if popover.parent().is_some() {
+        popover.unparent();
+    }
+}
+
+/// Attach and present a row menu with cleanup for dynamic list rebuilds.
+pub fn present_row_menu_popover(
+    popover: &Popover,
+    button: &Button,
+    menu_icon: &impl IsA<gtk4::Widget>,
+) {
+    popover.set_parent(button);
+
+    let menu_icon = menu_icon.as_ref();
+    menu_icon.add_css_class(state::EXPANDED);
+    let unmap_handler = Rc::new(RefCell::new(None));
+    let popover_weak = popover.downgrade();
+    let id = button.connect_unmap(move |_| {
+        if let Some(popover) = popover_weak.upgrade() {
+            close_row_menu_popover(&popover);
+        }
+    });
+    *unmap_handler.borrow_mut() = Some(id);
+
+    let icon_for_close = menu_icon.clone();
+    let button_weak = button.downgrade();
+    let unmap_handler_for_close = Rc::clone(&unmap_handler);
+    popover.connect_closed(move |popover| {
+        if let Some(button) = button_weak.upgrade()
+            && let Some(id) = unmap_handler_for_close.borrow_mut().take()
+        {
+            button.disconnect(id);
+        }
+        icon_for_close.remove_css_class(state::EXPANDED);
+        if popover.parent().is_some() {
+            popover.unparent();
+        }
+    });
+
+    popover.popup();
 }
 
 /// Create a single inline action as accent-colored text (no background).
@@ -555,5 +761,58 @@ impl ScanButton {
                 self.button.grab_focus();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{audio_output_icon_name, device_subtitle};
+
+    #[test]
+    fn device_subtitle_preserves_port_description_casing() {
+        assert_eq!(
+            device_subtitle("USB Audio", Some("HDMI / DisplayPort 2"), Some("speaker")),
+            Some("HDMI / DisplayPort 2".to_string())
+        );
+    }
+
+    #[test]
+    fn device_subtitle_title_cases_form_factor_fallback() {
+        assert_eq!(
+            device_subtitle("USB Audio", None, Some("headset-microphone")),
+            Some("Headset Microphone".to_string())
+        );
+    }
+
+    #[test]
+    fn audio_output_icon_normalizes_supported_device_hints() {
+        assert_eq!(
+            audio_output_icon_name(Some("audio-speakers-bluetooth"), None),
+            "audio-speakers"
+        );
+        assert_eq!(
+            audio_output_icon_name(Some("audio-card-analog-usb"), None),
+            "audio-card-symbolic"
+        );
+        assert_eq!(
+            audio_output_icon_name(Some("audio-headphones-symbolic"), None),
+            "audio-headphones"
+        );
+    }
+
+    #[test]
+    fn audio_output_icon_uses_safe_fallbacks() {
+        assert_eq!(
+            audio_output_icon_name(Some("vendor-specific-device"), Some("headset")),
+            "audio-headset"
+        );
+        assert_eq!(
+            audio_output_icon_name(Some("audio-card-analog"), Some("headset")),
+            "audio-headset"
+        );
+        assert_eq!(
+            audio_output_icon_name(Some("vendor-specific-device"), Some("internal")),
+            "audio-card-symbolic"
+        );
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
@@ -105,6 +105,17 @@ pub fn audio_output_icon_name(
         .unwrap_or("audio-card-symbolic")
 }
 
+pub fn audio_input_icon_name(form_factor: Option<&str>) -> &'static str {
+    match form_factor.map(str::trim).map(str::to_ascii_lowercase) {
+        Some(form_factor)
+            if matches!(form_factor.as_str(), "headset" | "hands-free" | "handsfree") =>
+        {
+            "audio-headset"
+        }
+        _ => "audio-input-microphone-symbolic",
+    }
+}
+
 fn audio_icon_family(icon_name: &str) -> Option<&'static str> {
     let icon_name = icon_name.trim();
 
@@ -766,7 +777,7 @@ impl ScanButton {
 
 #[cfg(test)]
 mod tests {
-    use super::{audio_output_icon_name, device_subtitle};
+    use super::{audio_input_icon_name, audio_output_icon_name, device_subtitle};
 
     #[test]
     fn device_subtitle_preserves_port_description_casing() {
@@ -813,6 +824,19 @@ mod tests {
         assert_eq!(
             audio_output_icon_name(Some("vendor-specific-device"), Some("internal")),
             "audio-card-symbolic"
+        );
+    }
+
+    #[test]
+    fn audio_input_icon_distinguishes_headsets() {
+        assert_eq!(audio_input_icon_name(Some("headset")), "audio-headset");
+        assert_eq!(
+            audio_input_icon_name(Some("microphone")),
+            "audio-input-microphone-symbolic"
+        );
+        assert_eq!(
+            audio_input_icon_name(None),
+            "audio-input-microphone-symbolic"
         );
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -343,12 +343,23 @@ impl QuickSettingsWindow {
         // Subscribe to services
         Self::subscribe_to_services(&qs);
 
-        // Update revealer durations when animations config is toggled at runtime.
+        // Refresh theme-dependent widgets and animation durations at runtime.
         {
             let qs_weak = Rc::downgrade(&qs);
             let id = ConfigManager::global().on_theme_change(move || {
                 if let Some(qs) = qs_weak.upgrade() {
                     Self::update_revealer_durations(&qs);
+                    if qs.cards_config.audio || qs.cards_config.mic {
+                        let audio_snapshot = AudioService::global().current();
+                        if qs.cards_config.audio {
+                            qs.audio.invalidate_list_caches();
+                            audio_card::on_audio_changed(&qs.audio, &audio_snapshot);
+                        }
+                        if qs.cards_config.mic {
+                            qs.mic.invalidate_list_cache();
+                            mic_card::on_mic_changed(&qs.mic, &audio_snapshot);
+                        }
+                    }
                 }
             });
             qs.theme_callback_id.set(Some(id));
@@ -984,6 +995,7 @@ impl QuickSettingsWindow {
         let audio_widgets = build_audio_row();
         let audio_details = build_audio_details();
         let audio_hint_label = build_audio_hint_label();
+        qs.audio.app_scroll_step.set(qs.audio_scroll_percentage);
 
         // Add row identifier for CSS targeting
         audio_widgets.row.add_css_class(qs::AUDIO_OUTPUT);
@@ -1037,7 +1049,8 @@ impl QuickSettingsWindow {
         }
 
         // Populate initial sink list
-        audio_card::populate_audio_sink_list(&audio_details.list_box, &audio_snapshot);
+        audio_card::sync_audio_sink_list(&qs.audio, &audio_details.list_box, &audio_snapshot);
+        audio_card::sync_app_volume_list(&qs.audio, &audio_details.app_list_box, &audio_snapshot);
 
         // Check initial control availability
         let control_ok = audio_snapshot.available && audio_snapshot.control_available;
@@ -1054,6 +1067,7 @@ impl QuickSettingsWindow {
         *qs.audio.arrow.borrow_mut() = Some(audio_widgets.arrow_handle.clone());
         *qs.audio.revealer.borrow_mut() = Some(audio_details.revealer.clone());
         *qs.audio.list_box.borrow_mut() = Some(audio_details.list_box.clone());
+        *qs.audio.app_list_box.borrow_mut() = Some(audio_details.app_list_box.clone());
         *qs.audio.row.borrow_mut() = Some(audio_widgets.row.clone());
         *qs.audio.hint_label.borrow_mut() = Some(audio_hint_label.clone());
 
@@ -1132,7 +1146,7 @@ impl QuickSettingsWindow {
         }
 
         // Populate initial source list
-        mic_card::populate_mic_source_list(&mic_details.list_box, &audio_snapshot.sources);
+        mic_card::sync_mic_source_list(&qs.mic, &mic_details.list_box, &audio_snapshot.sources);
 
         // Check initial control availability
         let control_ok = audio_snapshot.available && audio_snapshot.mic_control_available;


### PR DESCRIPTION
Add per-stream volume control in quick settings and improves the look of drop-down for audio a bit with form factor icons and port description. Fixes #180. Also fixes a bug where new audio devices didn't show up immediately.

<img width="304" height="358" alt="image" src="https://github.com/user-attachments/assets/25f875dd-68e0-4055-9aaa-77a09fa9d9c7" />
