### PR TITLE
feat(quick_settings): remember expanded menu state

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,6 +56,7 @@ background_opacity = 1.0
 #   # suspend_command = "loginctl suspend"
 #   # lock_command = "loginctl lock-session"
 #   # logout_command = "niri msg action quit"  # unset/empty = compositor IPC logout
+#   # remember_expanded_state = true  # Keep cards expanded across panel close/open
 #
 #   [widgets.media]
 #   visualizer = true  # Enable/disable cava audio visualizer (default: true)

--- a/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/bar_widget.rs
@@ -103,6 +103,7 @@ impl Default for QuickSettingsCardsConfig {
 /// vpn = false                          # hide the VPN card
 /// idle_inhibitor = false               # hide the idle inhibitor card
 /// vpn_close_on_connect = true          # close panel when VPN connects successfully
+/// remember_expanded_state = false      # keep cards expanded across close/open
 /// audio_scroll_percentage = 5          # volume change per scroll tick (% points, 1..=25)
 /// ```
 #[derive(Debug, Clone)]
@@ -111,6 +112,8 @@ pub struct QuickSettingsConfig {
     pub cards: QuickSettingsCardsConfig,
     /// Volume delta (percentage points) for scroll on QS widget/window.
     pub audio_scroll_percentage: i32,
+    /// Whether expanded card state is preserved when the panel closes.
+    pub remember_expanded_state: bool,
     /// Shell commands used by the power card.
     pub power_commands: PowerCommandsConfig,
 }
@@ -128,6 +131,7 @@ impl WidgetConfig for QuickSettingsConfig {
             "brightness",
             "power",
             "vpn_close_on_connect",
+            "remember_expanded_state",
             "audio_scroll_percentage",
             "shutdown_command",
             "reboot_command",
@@ -187,6 +191,11 @@ impl WidgetConfig for QuickSettingsConfig {
                 vpn_close_on_connect: get_bool("vpn_close_on_connect"),
             },
             audio_scroll_percentage,
+            remember_expanded_state: entry
+                .options
+                .get("remember_expanded_state")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
             power_commands: PowerCommandsConfig {
                 shutdown: get_command("shutdown_command", &default_commands.shutdown),
                 reboot: get_command("reboot_command", &default_commands.reboot),
@@ -203,6 +212,7 @@ impl Default for QuickSettingsConfig {
         Self {
             cards: QuickSettingsCardsConfig::default(),
             audio_scroll_percentage: Self::DEFAULT_AUDIO_SCROLL_PERCENTAGE,
+            remember_expanded_state: false,
             power_commands: PowerCommandsConfig::default(),
         }
     }
@@ -734,5 +744,21 @@ mod tests {
         assert_eq!(config.power_commands.suspend, "loginctl suspend");
         assert_eq!(config.power_commands.lock, "swaylock");
         assert_eq!(config.power_commands.logout, "niri msg action quit");
+    }
+
+    #[test]
+    fn quick_settings_remember_expanded_state_is_opt_in() {
+        let default_config = QuickSettingsConfig::from_entry(&WidgetEntry::new("quick_settings"));
+        assert!(!default_config.remember_expanded_state);
+
+        let mut options = HashMap::new();
+        options.insert("remember_expanded_state".to_string(), Value::Boolean(true));
+        let entry = WidgetEntry {
+            name: "quick_settings".to_string(),
+            options,
+        };
+
+        let config = QuickSettingsConfig::from_entry(&entry);
+        assert!(config.remember_expanded_state);
     }
 }

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -4,7 +4,7 @@
 //! QuickSettingsWindowHandle. The window is lazily created on first open
 //! and kept alive across close/re-open cycles using `set_visible(false)`
 //! / `set_visible(true)` toggling. Service subscriptions stay alive
-//! while hidden. UI state is reset on close so it opens fresh.
+//! while hidden. Expanded card state can optionally be preserved across closes.
 
 use gtk4::gdk::{self, Monitor};
 use gtk4::glib::{self, ControlFlow};
@@ -165,6 +165,7 @@ pub struct QuickSettingsWindow {
     cards_config: QuickSettingsCardsConfig,
     power_commands: PowerCommandsConfig,
     audio_scroll_percentage: i32,
+    remember_expanded_state: bool,
     scroll_container: ScrolledWindow,
     /// Service callback IDs, used to disconnect/unsubscribe on close.
     network_callback_id: Cell<Option<CallbackId>>,
@@ -259,6 +260,7 @@ impl QuickSettingsWindow {
             cards_config: config.cards,
             power_commands: config.power_commands,
             audio_scroll_percentage: config.audio_scroll_percentage,
+            remember_expanded_state: config.remember_expanded_state,
             scroll_container,
             network_callback_id: Cell::new(None),
             bluetooth_callback_id: Cell::new(None),
@@ -1264,15 +1266,31 @@ impl QuickSettingsWindow {
         }
     }
 
-    /// Reset all UI state to its initial (collapsed) appearance.
+    /// Reset transient UI state when the panel closes.
     ///
-    /// Called when hiding the panel so it opens fresh next time. This
-    /// collapses all revealers, removes expanded arrow indicators, hides
-    /// auth dialogs, and scrolls back to the top.
+    /// Unless configured otherwise, expanded cards are collapsed. Auth dialog
+    /// state, scrolling, and focus are always reset because they should not
+    /// survive a close/open cycle.
     fn reset_ui_state(&self) {
-        // --- Collapse all toggle card revealers (network, bluetooth, vpn, updates, power) ---
+        if !self.remember_expanded_state {
+            self.collapse_all_cards();
+        }
 
-        // Helper: collapse a revealer and remove the EXPANDED class from its arrow
+        // --- Hide auth dialogs ---
+        network_card::hide_password_dialog(&self.network);
+        vpn_card::hide_vpn_auth_dialog(&self.vpn);
+        self.bluetooth.clear_auth_input();
+
+        // --- Scroll to top ---
+        self.scroll_container.vadjustment().set_value(0.0);
+
+        // --- Clear focus from any focused widget ---
+        gtk4::prelude::RootExt::set_focus(&self.window, None::<&gtk4::Widget>);
+    }
+
+    /// Collapse every expandable card and reset its expanded indicators.
+    fn collapse_all_cards(&self) {
+        // Helper: collapse a revealer and remove the EXPANDED class from its arrow.
         let collapse = |base: &super::ui_helpers::ExpandableCardBase| {
             if let Some(revealer) = base.revealer.borrow().as_ref() {
                 collapse_revealer_instant(revealer);
@@ -1287,16 +1305,13 @@ impl QuickSettingsWindow {
         collapse(&self.vpn.base);
         collapse(&self.updates.base);
 
-        // Power card (expander variant)
         if let Some(ref power_state) = *self.power.borrow() {
             collapse(&power_state.base);
-            // Reset subtitle back to default
             if let Some(ref subtitle) = *power_state.base.subtitle.borrow() {
                 subtitle.set_label("Hold to shut down");
             }
         }
 
-        // --- Collapse audio and mic revealers ---
         if let Some(revealer) = self.audio.revealer.borrow().as_ref() {
             collapse_revealer_instant(revealer);
         }
@@ -1310,17 +1325,6 @@ impl QuickSettingsWindow {
         if let Some(arrow) = self.mic.arrow.borrow().as_ref() {
             arrow.widget().remove_css_class(state::EXPANDED);
         }
-
-        // --- Hide auth dialogs ---
-        network_card::hide_password_dialog(&self.network);
-        vpn_card::hide_vpn_auth_dialog(&self.vpn);
-        self.bluetooth.clear_auth_input();
-
-        // --- Scroll to top ---
-        self.scroll_container.vadjustment().set_value(0.0);
-
-        // --- Clear focus from any focused widget ---
-        gtk4::prelude::RootExt::set_focus(&self.window, None::<&gtk4::Widget>);
     }
 
     // Position and visibility management


### PR DESCRIPTION
As discussed in #180  - adds a setting to make quick settings keep state of expanded menus between open/close.

```
[widgets.quick_settings]
remember_expanded_state = true
```