### PR TITLE
perf(memory): limit glibc retention for large allocations

### DIFF
--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -192,6 +192,15 @@ enum PopoverAction {
 }
 
 fn main() -> ExitCode {
+    // Return memory used by large, short-lived image decodes to the OS instead
+    // of keeping it for reuse. Keep glibc's matching trim setting so smaller
+    // allocations remain efficient.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    unsafe {
+        libc::mallopt(libc::M_MMAP_THRESHOLD, 4 * 1024 * 1024);
+        libc::mallopt(libc::M_TRIM_THRESHOLD, 8 * 1024 * 1024);
+    }
+
     let mut args = Args::parse();
 
     // Initialize logging


### PR DESCRIPTION
Adjusts glibc's allocator settings so memory used when for example decoding large wallpapers is returned to the system instead of being kept around for reuse.
