### PR TITLE
refactor(widgets): use quantized true-scale animation

### DIFF
--- a/crates/vibepanel/src/sectioned_bar_tests.rs
+++ b/crates/vibepanel/src/sectioned_bar_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::theme_vars::{THEME_VAR_EXPECTATIONS, ThemeVarRole, ThemeVarScope};
 use crate::ui_regression_test_support::{
-    CssProviderGuard, Rgba8, assert_pixel_close, center_pixel_of_surface, edge_pixel_of_surface,
+    CssProviderGuard, Rgba8, assert_pixel_close, center_pixel_of_surface,
     find_descendant_with_class, flush_gtk, init_gtk_or_skip, label_with_text,
     maybe_hold_probe_window, painted_surface_fixture_with_classes, run_ignored_contract_subprocess,
     sample_widget_pixel,
@@ -2182,34 +2182,6 @@ fn run_test_widget_outline_color_css_override_pixel() {
     flush_gtk();
 }
 
-fn run_test_surface_outline_css_gsk_parity() {
-    let mut config = test_config();
-    config.theme.outline = true;
-    config.theme.outline_width = 4;
-    config.theme.outline_color = "accent".to_string();
-    config.theme.outline_opacity = 0.8;
-    config.theme.accent = Some("#446688".to_string());
-    config.widgets.background_color = Some("#101820".to_string());
-    config.widgets.popover_background_opacity = Some(1.0);
-
-    set_ui_regression_config(&config);
-    let surface_fixture = painted_surface_fixture(&config, crate::styles::surface::POPOVER);
-    let css_edge = edge_pixel_of_surface(&surface_fixture);
-    let gsk_rgba = crate::services::config_manager::ConfigManager::global()
-        .surface_outline_rgba_for_widget("custom-a", &surface_fixture.surface);
-    let gsk_edge = Rgba8::from_gdk(gsk_rgba).premultiply_alpha();
-
-    assert_pixel_close(
-        css_edge,
-        gsk_edge,
-        "CSS-rendered surface outline and GSK animated outline resolver should agree",
-    );
-
-    maybe_hold_probe_window();
-    surface_fixture.window.close();
-    flush_gtk();
-}
-
 fn run_test_theme_mode_dark_light_pixels() {
     let mut dark = test_config();
     dark.theme.mode = "dark".to_string();
@@ -2608,11 +2580,6 @@ ui_regression_config_tests!(
         test_ui_regression_widget_outline_color_css_override_pixel,
         "widgets.outline_color_css_override_pixel",
         run_test_widget_outline_color_css_override_pixel
-    ),
-    (
-        test_ui_regression_surface_outline_css_gsk_parity,
-        "theme.surface_outline_css_gsk_parity",
-        run_test_surface_outline_css_gsk_parity
     ),
     (
         test_ui_regression_theme_mode_dark_light_pixel,

--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -1013,9 +1013,9 @@ impl BackgroundEffectManager {
 
     /// Apply a blur region that tracks the ScaleBox grow-in animation.
     ///
-    /// During the open animation the ScaleBox clips its child to a centered rect
-    /// whose size is `content_size * scale`.  This method sets the blur region to
-    /// match that clip so the compositor blur grows in sync with the visual.
+    /// During the open animation the ScaleBox scales its child around the center.
+    /// This method sets the blur region to the transformed bounds so the compositor
+    /// blur grows in sync with the visual.
     ///
     /// `scale` should be the current ScaleBox scale (ANIM_SCALE_FROM → 1.0).
     /// At `scale == 1.0` this produces the same region as `apply_blur_region`.
@@ -1047,9 +1047,10 @@ impl BackgroundEffectManager {
         let content_w = (width - margin_start - margin_end) as f64;
         let content_h = (height - margin_top - margin_bottom) as f64;
 
-        // ScaleBox clips to a centered rect of size content * scale.
+        // ScaleBox transforms to centered bounds of size content * scale.
         let scaled_w = content_w * scale;
         let scaled_h = content_h * scale;
+        let scaled_radius = (radius as f64 * scale).round() as i32;
         let dx = (content_w - scaled_w) / 2.0;
         let dy = (content_h - scaled_h) / 2.0;
 
@@ -1064,7 +1065,7 @@ impl BackgroundEffectManager {
             y.round() as i32,
             scaled_w.round() as i32,
             scaled_h.round() as i32,
-            radius,
+            scaled_radius,
             crate::services::config_manager::ConfigManager::global().surface_outline_visible(),
         );
 

--- a/crates/vibepanel/src/services/config_manager.rs
+++ b/crates/vibepanel/src/services/config_manager.rs
@@ -30,7 +30,6 @@ use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::Recursiv
 use std::collections::HashSet;
 use tracing::{debug, error, info, warn};
 
-use vibepanel_core::theme::{BORDER_OPACITY_DARK, BORDER_OPACITY_GTK, BORDER_OPACITY_LIGHT};
 use vibepanel_core::{
     Config, ThemePalette, ThemeSizes,
     config::{BarPosition, SchemePolarity},
@@ -382,94 +381,6 @@ impl ConfigManager {
     /// Whether floating surface outlines are effectively visible.
     pub fn surface_outline_visible(&self) -> bool {
         self.surface_outline_width() > 0.0
-    }
-
-    /// Resolve the current floating-surface outline as a concrete RGBA color.
-    ///
-    /// Custom GSK drawing cannot consume CSS variables or `color-mix()` tokens,
-    /// so this mirrors the supported `outline_color` symbolic values with the
-    /// already-computed palette colors. Per-widget overrides from
-    /// `[widgets.<name>]` take precedence over the global `theme.outline_color`.
-    /// This mirrors config/palette-driven outlines, not arbitrary user CSS overrides.
-    pub fn surface_outline_rgba_for_widget(
-        &self,
-        widget_name: &str,
-        widget: &impl IsA<gtk4::Widget>,
-    ) -> gtk4::gdk::RGBA {
-        let config = self.config.borrow();
-        let color = config
-            .widgets
-            .get_options(widget_name)
-            .and_then(|opts| opts.outline_color.as_deref())
-            .unwrap_or(&config.theme.outline_color)
-            .to_owned();
-        let alpha = (config.theme.outline_opacity as f32).clamp(0.0, 1.0);
-        drop(config);
-
-        self.resolve_outline_rgba(&color, alpha, widget)
-    }
-
-    fn resolve_outline_rgba(
-        &self,
-        color: &str,
-        alpha: f32,
-        widget: &impl IsA<gtk4::Widget>,
-    ) -> gtk4::gdk::RGBA {
-        let palette = self
-            .popover_palette
-            .borrow()
-            .clone()
-            .unwrap_or_else(|| self.palette.borrow().clone());
-        let is_subtle = color == "subtle";
-        let color = match color {
-            "subtle" => palette.border_subtle.as_str(),
-            "accent" => palette.accent_primary.as_str(),
-            "foreground" => palette.foreground_primary.as_str(),
-            value => value,
-        };
-
-        gtk4::gdk::RGBA::parse(color)
-            .map(|rgba| rgba.with_alpha(rgba.alpha() * alpha))
-            .unwrap_or_else(|_| {
-                // GTK mode stores some palette colors as CSS tokens. Resolve
-                // simple named colors through the widget style context so the
-                // animated outline matches the resting CSS outline.
-                if let Some(name) = color.strip_prefix('@') {
-                    // GTK4 has no non-deprecated replacement for resolving
-                    // runtime @token colors from the active theme.
-                    #[allow(deprecated)]
-                    if let Some(rgba) = widget.style_context().lookup_color(name) {
-                        return rgba.with_alpha(rgba.alpha() * alpha);
-                    }
-                }
-
-                if is_subtle && palette.is_gtk_mode {
-                    // Same GTK4 limitation as above, but `subtle` stores this
-                    // inside a color-mix() expression instead of a bare token.
-                    #[allow(deprecated)]
-                    if let Some(rgba) = widget.style_context().lookup_color("window_fg_color") {
-                        return rgba.with_alpha(rgba.alpha() * alpha * BORDER_OPACITY_GTK as f32);
-                    }
-                }
-
-                let fallback = if palette.is_dark_mode {
-                    gtk4::gdk::RGBA::WHITE
-                } else {
-                    gtk4::gdk::RGBA::BLACK
-                };
-                // GTK color-mix() values such as the subtle outline are not
-                // parseable here; approximate the baked-in non-GTK subtle alpha.
-                let subtle_factor = if is_subtle {
-                    if palette.is_dark_mode {
-                        BORDER_OPACITY_DARK as f32
-                    } else {
-                        BORDER_OPACITY_LIGHT as f32
-                    }
-                } else {
-                    1.0
-                };
-                fallback.with_alpha(alpha * subtle_factor)
-            })
     }
 
     /// Effective floating-surface outline width in logical pixels.

--- a/crates/vibepanel/src/services/surfaces.rs
+++ b/crates/vibepanel/src/services/surfaces.rs
@@ -1,7 +1,7 @@
 //! Surface styling helpers for vibepanel.
 //!
 //! This module owns runtime surface helpers that cannot live in static CSS,
-//! such as shadow margins, animated outlines, and optional Pango font styling.
+//! such as shadow margins and optional Pango font styling.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -13,9 +13,7 @@ use tracing::debug;
 use vibepanel_core::SurfaceStyles;
 use vibepanel_core::config::BarPosition;
 
-use crate::services::config_manager::ConfigManager;
-use crate::styles::{icon, surface};
-use crate::widgets::scale_box::ScaleBox;
+use crate::styles::icon;
 
 // Thread-local singleton storage for SurfaceStyleManager
 thread_local! {
@@ -36,8 +34,8 @@ fn default_surface_styles() -> SurfaceStyles {
 
 /// Process-wide surface styling manager.
 ///
-/// Provides runtime styling helpers for shadow margins, GSK outline coordination,
-/// Pango font workarounds, and tray contrast adjustments.
+/// Provides runtime styling helpers for shadow margins, Pango font workarounds,
+/// and tray contrast adjustments.
 pub struct SurfaceStyleManager {
     styles: RefCell<SurfaceStyles>,
     /// Whether to use Pango attributes for font rendering instead of CSS.
@@ -126,37 +124,6 @@ impl SurfaceStyleManager {
         } else {
             0
         }
-    }
-
-    /// Apply the temporary ScaleBox outline used while floating surfaces animate.
-    ///
-    /// The real CSS border is suppressed only when there is a GSK outline to
-    /// draw, so disabled outlines keep their normal resting CSS appearance.
-    pub fn apply_animated_surface_outline(
-        &self,
-        shell: &ScaleBox,
-        widget_name: &str,
-        active: bool,
-    ) {
-        let config = ConfigManager::global();
-        let width = config.surface_outline_width();
-        let color = if active && width > 0.0 {
-            debug_assert!(
-                shell.child_has_css_class(surface::POPOVER),
-                "animated surface outline suppression expects a popover surface child"
-            );
-            config.surface_outline_rgba_for_widget(widget_name, shell)
-        } else {
-            gtk4::gdk::RGBA::TRANSPARENT
-        };
-
-        shell.set_animated_outline(
-            active,
-            config.surface_border_radius() as f32,
-            width,
-            color,
-            surface::SUPPRESS_CSS_OUTLINE,
-        );
     }
 
     /// Apply shadow-aware margins to a popover/overlay container.

--- a/crates/vibepanel/src/styles.rs
+++ b/crates/vibepanel/src/styles.rs
@@ -783,10 +783,6 @@ pub mod surface {
     /// Kept as a user-CSS compatibility alias; scheduled for removal in a future breaking release.
     pub const SURFACE_POPOVER: &str = "vp-surface-popover";
 
-    /// Temporarily hide the CSS-painted outline while `ScaleBox` draws it on
-    /// the moving clip boundary during grow animation.
-    pub const SUPPRESS_CSS_OUTLINE: &str = "vp-suppress-css-outline";
-
     /// Deprecated: use [`POPOVER`]. Popover styling (`.widget-menu`).
     ///
     /// Still applied to native `gtk4::Popover` shells for CSS reset rules

--- a/crates/vibepanel/src/ui_regression_test_support.rs
+++ b/crates/vibepanel/src/ui_regression_test_support.rs
@@ -373,15 +373,6 @@ pub(crate) fn center_pixel_of_surface(fixture: &PaintedSurfaceFixture) -> Rgba8 
     )
 }
 
-pub(crate) fn edge_pixel_of_surface(fixture: &PaintedSurfaceFixture) -> Rgba8 {
-    sample_widget_pixel(
-        &fixture.window,
-        &fixture.surface,
-        1,
-        fixture.surface.height() / 2,
-    )
-}
-
 pub(crate) fn assert_pixel_close(observed: Rgba8, expected: Rgba8, message: &str) {
     assert!(
         observed.close_to(expected, 2),

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -277,11 +277,6 @@ window.media-window > .media-content {{
     border-radius: var(--radius-widget-lg);
 }}
 
-/* Mirrors the generated surface rule for static popover styles. */
-.popover.vp-suppress-css-outline {{
-    border-color: transparent;
-}}
-
 popover.widget-menu,
 box.popover-wrapper,
 box.widget-menu-wrapper {{

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -69,7 +69,7 @@ pub struct PopoverAnchor {
 pub(crate) const ANIM_DURATION_MS: f64 = super::css::POPOVER_ANIMATION_MS as f64;
 
 /// Starting scale for popover open/close animation.
-/// ScaleBox simulates this via symmetric center-clip (no actual scale transform).
+/// ScaleBox renders this as a true (quantized) center scale transform.
 pub(crate) const ANIM_SCALE_FROM: f64 = 0.94;
 
 /// Direction of the popover animation.
@@ -182,10 +182,80 @@ impl AnimState {
     }
 }
 
-pub(crate) fn snap_anim_shell(shell: &ScaleBox, widget_name: &str, opacity: f64, scale: f64) {
+pub(crate) fn snap_anim_shell(shell: &ScaleBox, opacity: f64, scale: f64) {
     shell.set_opacity(opacity);
     shell.set_scale(scale);
-    SurfaceStyleManager::global().apply_animated_surface_outline(shell, widget_name, false);
+}
+
+/// Drive a popover animation, preserving progress during mid-flight reversals.
+///
+/// `blur_target` pairs the target window with its shadow margin. `on_complete`
+/// runs once with the direction of the completed segment.
+pub(crate) fn run_popover_animation(
+    shell: &ScaleBox,
+    anim_state: &Rc<RefCell<AnimState>>,
+    anim_generation: &Rc<Cell<u32>>,
+    generation: u32,
+    direction: AnimDirection,
+    blur_target: Option<(glib::WeakRef<ApplicationWindow>, i32)>,
+    on_complete: impl Fn(AnimDirection, &ScaleBox) + 'static,
+) {
+    let start_time_us = shell.frame_clock().map(|fc| fc.frame_time()).unwrap_or(0);
+
+    let need_tick =
+        anim_state
+            .borrow_mut()
+            .prepare(direction, generation, start_time_us, shell.opacity());
+
+    if !need_tick {
+        return;
+    }
+
+    let anim_state = Rc::clone(anim_state);
+    let anim_gen = Rc::clone(anim_generation);
+    shell.add_tick_callback(move |shell, frame_clock| {
+        // Generation check — bail if a newer cycle started.
+        // Do NOT touch `active` — a newer tick callback owns that now.
+        if anim_gen.get() != generation {
+            return ControlFlow::Break;
+        }
+
+        let now_us = frame_clock.frame_time();
+        let (progress, complete, direction) = {
+            let state = anim_state.borrow();
+            if !state.active {
+                return ControlFlow::Break;
+            }
+            (
+                state.current_progress(now_us),
+                state.is_complete(now_us),
+                state.direction,
+            )
+        };
+
+        shell.set_opacity(progress);
+        let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
+        shell.set_scale(scale);
+
+        if direction == AnimDirection::Opening
+            && ConfigManager::global().blur_enabled()
+            && let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            && let Some((ref window_weak, blur_margin)) = blur_target
+            && let Some(window) = window_weak.upgrade()
+        {
+            // Match the blur to the quantized scale that ScaleBox renders.
+            blur.apply_open_animation_blur(&window, blur_margin, shell.scale(), complete);
+        }
+
+        if complete {
+            anim_state.borrow_mut().active = false;
+            on_complete(direction, shell);
+            return ControlFlow::Break;
+        }
+
+        ControlFlow::Continue
+    });
 }
 
 fn measured_popover_size(widget: &gtk4::Widget) -> Option<(i32, i32)> {
@@ -466,15 +536,17 @@ where
 ///
 /// ## Animation architecture
 ///
-/// Open/close animations (opacity fade) are driven by a **tick callback**
-/// on the persistent animation shell, not by CSS `transition:` properties.
-/// CSS `transform: scale()` transitions are observed to cause unbounded
-/// memory growth in GTK4.
+/// Open/close animations (opacity fade + scale) are driven by a **tick
+/// callback** on the persistent animation shell ([`run_popover_animation`]),
+/// not by CSS `transition:` properties. The shell is a [`ScaleBox`] that
+/// renders a true center scale transform with a *quantized* scale value —
+/// continuous per-frame scales leak renderer glyph caches (see the
+/// `scale_box` module docs), which is why CSS transitions cannot be used.
 ///
 /// The tick callback reads the frame clock each frame, computes eased progress
-/// from an `AnimState`, and applies opacity via `Widget::set_opacity()`. This gives:
+/// from an `AnimState`, and applies opacity + scale. This gives:
 ///
-/// - **No CSS transitions** (no `transition:` on any widget)
+/// - **Bounded memory** (quantized text scales reuse glyph cache entries)
 /// - **Smooth mid-flight reversal** (clicking close during open reverses from
 ///   the current position, proportional timing)
 /// - **No jank** (no snapping between states on rapid clicks)
@@ -761,7 +833,7 @@ impl LayerShellPopover {
         // If animations are disabled, snap closed immediately.
         if !ConfigManager::global().animations_enabled() {
             if let Some(ref shell) = anim_shell {
-                snap_anim_shell(shell, &self.widget_name, 0.0, ANIM_SCALE_FROM);
+                snap_anim_shell(shell, 0.0, ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             // No explicit blur removal needed — unmapping suspends
@@ -821,14 +893,6 @@ impl LayerShellPopover {
         }
 
         anim_shell.set_child(&content);
-        if self.anim_state.borrow().active {
-            SurfaceStyleManager::global().apply_animated_surface_outline(
-                &anim_shell,
-                &self.widget_name,
-                true,
-            );
-        }
-
         SurfaceStyleManager::global().apply_pango_attrs_all(&anim_shell);
 
         // Reposition after content updates while visible (e.g. notifications
@@ -913,7 +977,7 @@ impl LayerShellPopover {
         {
             // Snap-close without animation to avoid recursion.
             if let Some(ref shell) = *self.anim_shell.borrow() {
-                snap_anim_shell(shell, &self.widget_name, 0.0, ANIM_SCALE_FROM);
+                snap_anim_shell(shell, 0.0, ANIM_SCALE_FROM);
                 shell.remove_child();
             }
             if let Some(ref window) = *self.window.borrow() {
@@ -1022,7 +1086,7 @@ impl LayerShellPopover {
             // Animations disabled: snap everything visible before mapping so a
             // close/open cycle cannot leave the reused layer-shell surface
             // transparent if GTK skips or delays the idle positioning pass.
-            snap_anim_shell(&anim_shell, &self.widget_name, 1.0, 1.0);
+            snap_anim_shell(&anim_shell, 1.0, 1.0);
             window.set_opacity(1.0);
 
             // Position before map using GTK's natural size so the first visible
@@ -1187,81 +1251,25 @@ impl LayerShellPopover {
             return;
         };
 
-        let start_time_us = anim_shell
-            .frame_clock()
-            .map(|fc| fc.frame_time())
-            .unwrap_or(0);
-
-        let need_tick = self.anim_state.borrow_mut().prepare(
-            direction,
-            generation,
-            start_time_us,
-            anim_shell.opacity(),
-        );
-
-        // Prepare first so reversal paths can reuse the existing tick callback;
-        // then ensure the current child has animation-outline styling even if no
-        // new callback is needed.
-        SurfaceStyleManager::global().apply_animated_surface_outline(
-            &anim_shell,
-            &self.widget_name,
-            true,
-        );
-
-        if !need_tick {
-            return;
-        }
-
-        let anim_state = Rc::clone(&self.anim_state);
-        let anim_gen = Rc::clone(&self.anim_generation);
         let window = self.window.borrow().as_ref().cloned();
-        let shell_for_scale = anim_shell.clone();
+        let window_for_complete = window.as_ref().map(|w| w.downgrade());
         let on_close = self.on_close.borrow().clone();
-        let widget_name = self.widget_name.clone();
 
-        anim_shell.add_tick_callback(move |shell, frame_clock| {
-            // Generation check — bail if a newer cycle started.
-            // Do NOT touch `active` — a newer tick callback owns that now.
-            if anim_gen.get() != generation {
-                return ControlFlow::Break;
-            }
-
-            let now_us = frame_clock.frame_time();
-            let (progress, complete, direction) = {
-                let state = anim_state.borrow();
-                if !state.active {
-                    return ControlFlow::Break;
-                }
-                (
-                    state.current_progress(now_us),
-                    state.is_complete(now_us),
-                    state.direction,
-                )
-            };
-
-            // Apply visual state — opacity and scale, no CSS involvement.
-            shell.set_opacity(progress);
-            // Interpolate scale: ANIM_SCALE_FROM at progress=0 → 1.0 at progress=1.
-            let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
-            shell_for_scale.set_scale(scale);
-
-            if direction == AnimDirection::Opening
-                && ConfigManager::global().blur_enabled()
-                && let Some(blur) =
-                    crate::services::background_effect::BackgroundEffectManager::global()
-                && let Some(ref w) = window
-            {
-                blur.apply_open_animation_blur(w, POPOVER_SHADOW_MARGIN, scale, complete);
-            }
-
-            if complete {
-                anim_state.borrow_mut().active = false;
-
+        run_popover_animation(
+            &anim_shell,
+            &self.anim_state,
+            &self.anim_generation,
+            generation,
+            direction,
+            window
+                .as_ref()
+                .map(|w| (w.downgrade(), POPOVER_SHADOW_MARGIN)),
+            move |direction, shell| {
                 if direction == AnimDirection::Closing {
                     // Close complete — remove content and hide window.
-                    snap_anim_shell(&shell_for_scale, &widget_name, 0.0, ANIM_SCALE_FROM);
-                    shell_for_scale.remove_child();
-                    if let Some(ref w) = window {
+                    snap_anim_shell(shell, 0.0, ANIM_SCALE_FROM);
+                    shell.remove_child();
+                    if let Some(w) = window_for_complete.as_ref().and_then(|w| w.upgrade()) {
                         w.set_visible(false);
                     }
                     // Fire on_close now that the popover is fully hidden.
@@ -1270,13 +1278,10 @@ impl LayerShellPopover {
                     }
                 } else {
                     // Open complete — ensure we're at exactly 1.0.
-                    snap_anim_shell(&shell_for_scale, &widget_name, 1.0, 1.0);
+                    snap_anim_shell(shell, 1.0, 1.0);
                 }
-                return ControlFlow::Break;
-            }
-
-            ControlFlow::Continue
-        });
+            },
+        );
     }
 
     fn update_position(&self) {

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -7,7 +7,7 @@
 //! while hidden. Expanded card state can optionally be preserved across closes.
 
 use gtk4::gdk::{self, Monitor};
-use gtk4::glib::{self, ControlFlow};
+use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{
     Application, ApplicationWindow, Box as GtkBox, Button, EventControllerKey, Label, Orientation,
@@ -35,7 +35,7 @@ use crate::widgets::layer_shell_popover::{
     calculate_bar_exclusive_zone, calculate_popover_bar_margin, calculate_popover_bottom_margin,
     calculate_popover_right_margin, configure_popover_layer_anchors, create_click_catcher,
     is_keynav_key, popover_bar_edge, popover_keyboard_mode, reset_popover_margins,
-    setup_esc_handler, snap_anim_shell,
+    run_popover_animation, setup_esc_handler, snap_anim_shell,
 };
 use crate::widgets::scale_box::ScaleBox;
 
@@ -116,26 +116,20 @@ const QUICK_SETTINGS_DEFAULT_RIGHT_MARGIN: i32 = 8;
 const CARD_ROW_SPACING: i32 = 8;
 const CARD_ROW_GAP: i32 = 8;
 const AUDIO_SECTION_TOP_MARGIN: i32 = 12;
-/// Config key for the quick-settings widget, used for per-widget
-/// outline_color overrides in the animated outline path.
-const QUICK_SETTINGS_WIDGET: &str = "quick_settings";
 
 /// Full Quick Settings window.
 ///
 /// ## Animation architecture
 ///
-/// Open/close animations are driven by a **tick callback** on the animation
-/// shell (`ScaleBox`), not by CSS `transition:` properties. CSS `transform:
-/// scale()` transitions are observed to cause unbounded memory growth in
-/// GTK4. See `LayerShellPopover` for the same pattern.
+/// Open/close animations use [`run_popover_animation`] and a [`ScaleBox`]. See
+/// the `scale_box` module docs for why the transform is quantized.
 pub struct QuickSettingsWindow {
     window: ApplicationWindow,
     click_catcher: RefCell<Option<ApplicationWindow>>,
     /// Animation shell wrapping the outer container. Opacity and scale are
     /// animated via tick callback — no CSS transitions involved.
     anim_shell: ScaleBox,
-    /// Wrapper between window and anim_shell that provides shadow margins
-    /// so the ScaleBox grow-in clip animation is visible.
+    /// Wrapper providing transparent margins for surface shadows.
     margin_wrapper: GtkBox,
     /// Content container (surface styles, focus suppression).
     outer_container: RefCell<Option<GtkBox>>,
@@ -233,8 +227,6 @@ impl QuickSettingsWindow {
         anim_shell.set_opacity(0.0);
         anim_shell.set_scale(ANIM_SCALE_FROM);
 
-        // Margin wrapper sits between window and anim_shell, providing
-        // transparent padding so the ScaleBox clip animation is visible.
         let margin_wrapper = GtkBox::new(Orientation::Vertical, 0);
         margin_wrapper.add_css_class(surface::POPOVER_WRAPPER);
         margin_wrapper.add_css_class(surface::WIDGET_MENU_WRAPPER);
@@ -285,10 +277,6 @@ impl QuickSettingsWindow {
 
         let outer = Self::build_content(&qs);
 
-        // Hierarchy: window → margin_wrapper → anim_shell (ScaleBox) → outer
-        // The margin wrapper provides transparent padding around the ScaleBox
-        // so the rounded-clip grow animation is visible (same pattern as
-        // LayerShellPopover).
         anim_shell.set_child(&outer);
         margin_wrapper.append(&anim_shell.clone().upcast::<gtk4::Widget>());
         window.set_child(Some(&margin_wrapper));
@@ -1508,7 +1496,7 @@ impl QuickSettingsWindow {
                     if ConfigManager::global().animations_enabled() {
                         qs.start_animation(AnimDirection::Opening, generation);
                     } else {
-                        snap_anim_shell(&qs.anim_shell, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
+                        snap_anim_shell(&qs.anim_shell, 1.0, 1.0);
                     }
                     let snapshot = NetworkService::global().snapshot();
                     network_card::on_network_changed(&qs.network, &snapshot, &qs.window);
@@ -1541,7 +1529,7 @@ impl QuickSettingsWindow {
                     if ConfigManager::global().animations_enabled() {
                         qs.start_animation(AnimDirection::Opening, generation);
                     } else {
-                        snap_anim_shell(&qs.anim_shell, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
+                        snap_anim_shell(&qs.anim_shell, 1.0, 1.0);
                     }
 
                     let snapshot = NetworkService::global().snapshot();
@@ -1664,12 +1652,7 @@ impl QuickSettingsWindow {
 
         if !ConfigManager::global().animations_enabled() {
             // Animations disabled — snap closed immediately.
-            snap_anim_shell(
-                &self.anim_shell,
-                QUICK_SETTINGS_WIDGET,
-                0.0,
-                ANIM_SCALE_FROM,
-            );
+            snap_anim_shell(&self.anim_shell, 0.0, ANIM_SCALE_FROM);
             self.is_animating_out.set(false);
             self.reset_ui_state();
             // No explicit blur removal needed — unmapping suspends
@@ -1729,95 +1712,30 @@ impl QuickSettingsWindow {
     /// close), the current progress is captured and the animation reverses from
     /// that point with proportional timing — no snapping.
     fn start_animation(&self, direction: AnimDirection, generation: u32) {
-        let start_time_us = self
-            .anim_shell
-            .frame_clock()
-            .map(|fc| fc.frame_time())
-            .unwrap_or(0);
-
-        let need_tick = self.anim_state.borrow_mut().prepare(
-            direction,
-            generation,
-            start_time_us,
-            self.anim_shell.opacity(),
-        );
-
-        // Prepare first so reversal paths can reuse the existing tick callback;
-        // then ensure the current child has animation-outline styling even if no
-        // new callback is needed.
-        SurfaceStyleManager::global().apply_animated_surface_outline(
-            &self.anim_shell,
-            QUICK_SETTINGS_WIDGET,
-            true,
-        );
-
-        if !need_tick {
-            return;
-        }
-
-        let anim_state = Rc::clone(&self.anim_state);
-        let anim_gen = Rc::clone(&self.anim_generation);
         let window_weak = self.window.downgrade();
-        let shell_clone = self.anim_shell.clone();
 
-        self.anim_shell
-            .add_tick_callback(move |shell, frame_clock| {
-                if anim_gen.get() != generation {
-                    return ControlFlow::Break;
-                }
-
-                let now_us = frame_clock.frame_time();
-                let (progress, complete, direction) = {
-                    let state = anim_state.borrow();
-                    if !state.active {
-                        return ControlFlow::Break;
+        run_popover_animation(
+            &self.anim_shell,
+            &self.anim_state,
+            &self.anim_generation,
+            generation,
+            direction,
+            Some((self.window.downgrade(), QUICK_SETTINGS_OUTER_MARGIN)),
+            move |direction, shell| {
+                if direction == AnimDirection::Closing {
+                    snap_anim_shell(shell, 0.0, ANIM_SCALE_FROM);
+                    if let Some(window) = window_weak.upgrade()
+                        && let Some(qs) = get_qs_window_data(&window)
+                    {
+                        qs.is_animating_out.set(false);
+                        qs.reset_ui_state();
+                        qs.window.set_visible(false);
                     }
-                    (
-                        state.current_progress(now_us),
-                        state.is_complete(now_us),
-                        state.direction,
-                    )
-                };
-
-                // Apply visual state — opacity and scale, no CSS involvement.
-                shell.set_opacity(progress);
-                let scale = ANIM_SCALE_FROM + (1.0 - ANIM_SCALE_FROM) * progress;
-                shell_clone.set_scale(scale);
-
-                if direction == AnimDirection::Opening
-                    && ConfigManager::global().blur_enabled()
-                    && let Some(blur) =
-                        crate::services::background_effect::BackgroundEffectManager::global()
-                    && let Some(window) = window_weak.upgrade()
-                {
-                    blur.apply_open_animation_blur(
-                        &window,
-                        QUICK_SETTINGS_OUTER_MARGIN,
-                        scale,
-                        complete,
-                    );
+                } else {
+                    snap_anim_shell(shell, 1.0, 1.0);
                 }
-
-                if complete {
-                    anim_state.borrow_mut().active = false;
-
-                    if direction == AnimDirection::Closing {
-                        snap_anim_shell(&shell_clone, QUICK_SETTINGS_WIDGET, 0.0, ANIM_SCALE_FROM);
-                        if let Some(window) = window_weak.upgrade()
-                            && let Some(qs) = get_qs_window_data(&window)
-                        {
-                            qs.is_animating_out.set(false);
-                            qs.reset_ui_state();
-                            qs.window.set_visible(false);
-                        }
-                    } else {
-                        snap_anim_shell(&shell_clone, QUICK_SETTINGS_WIDGET, 1.0, 1.0);
-                    }
-                    return ControlFlow::Break;
-                }
-
-                ControlFlow::Continue
-            });
+            },
+        );
     }
 
     /// Temporarily release exclusive keyboard grab to allow external dialogs

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -1,21 +1,34 @@
-//! A container that simulates scale animation via symmetric rounded clip.
+//! A container that animates a true scale transform around its center.
 //!
-//! The child is always allocated at full size — the scale effect is achieved
-//! by clipping to a centered rect in `snapshot()` that grows from smaller to
-//! full size. Combined with opacity fade this approximates `transform: scale()`
-//! without any scale transforms in the render tree (which are observed to
-//! cause unbounded memory growth in GTK4).
+//! The child is always measured and allocated at full size — `snapshot()`
+//! applies a GSK scale transform about the widget center, so text, icons,
+//! and borders genuinely scale with the popover.
 //!
-//! `ScaleBox` can also draw an optional outline on the animated clip boundary.
-//! CSS borders live on the full-size child and would otherwise be clipped away
-//! until the final frame of the grow-in animation.
+//! ## Why the scale is quantized
 //!
-//! Only calls `queue_draw()` on scale changes — no layout or CSS resolution.
+//! The scale value is quantized to multiples of `1/QUANT_DENOM` when set.
+//! Text rendered under a transform is rasterized per unique
+//! effective scale, and renderer glyph caches key their entries by that
+//! scale. A continuous per-frame scale therefore creates an endless stream
+//! of single-use cache entries: cairo caps its caches (bounded bloat), but
+//! the GPU renderers grow without bound. Quantization keeps the set of text
+//! scales small and repeating, so the caches warm up once and stay flat.
+//!
+//! CSS `transform: scale()` transitions hit the same leak but offer no
+//! quantization hook, which is why the animation is driven from a tick
+//! callback instead of CSS.
 
 use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use std::cell::Cell;
+
+/// Quantization denominator: scale moves in steps of 1/128.
+const QUANT_DENOM: f64 = 128.0;
+
+fn quantize_scale(s: f64) -> f64 {
+    (s * QUANT_DENOM).round() / QUANT_DENOM
+}
 
 mod imp {
     use super::*;
@@ -23,11 +36,6 @@ mod imp {
     pub struct ScaleBox {
         /// Current scale factor (1.0 = normal size).
         pub(super) scale: Cell<f64>,
-        /// Border radius for the rounded clip (pixels).
-        pub(super) radius: Cell<f32>,
-        /// Optional animated outline width (pixels). 0 disables drawing.
-        pub(super) outline_width: Cell<f32>,
-        pub(super) outline_color: Cell<gtk4::gdk::RGBA>,
         /// The single child widget.
         pub(super) child: glib::WeakRef<gtk4::Widget>,
     }
@@ -36,9 +44,6 @@ mod imp {
         fn default() -> Self {
             Self {
                 scale: Cell::default(),
-                radius: Cell::default(),
-                outline_width: Cell::default(),
-                outline_color: Cell::new(gtk4::gdk::RGBA::TRANSPARENT),
                 child: glib::WeakRef::new(),
             }
         }
@@ -86,7 +91,7 @@ mod imp {
         }
 
         fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
-            // Full allocation — scale effect is purely visual via snapshot() clipping.
+            // Full allocation — the scale effect is purely visual via snapshot().
             if let Some(child) = self.child.upgrade() {
                 child.allocate(width, height, baseline, None);
             }
@@ -102,73 +107,31 @@ mod imp {
 
             if s >= 1.0 {
                 widget.snapshot_child(&child, snapshot);
-                let rect = gtk4::graphene::Rect::new(
-                    0.0,
-                    0.0,
-                    widget.width() as f32,
-                    widget.height() as f32,
-                );
-                self.snapshot_outline(snapshot, rect, self.radius.get());
                 return;
             }
             if s <= 0.0 {
                 return;
             }
 
-            // Rounded center-clip: crop edges uniformly, matching surface border radius.
-            let w = widget.width() as f32;
-            let h = widget.height() as f32;
-            let cw = w * s as f32;
-            let ch = h * s as f32;
-            let dx = (w - cw) / 2.0;
-            let dy = (h - ch) / 2.0;
-
-            let radius = self.radius.get();
-            let rect = gtk4::graphene::Rect::new(dx, dy, cw, ch);
-            let rounded = gtk4::gsk::RoundedRect::new(
-                rect,
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-            );
-
-            snapshot.push_rounded_clip(&rounded);
+            let cx = widget.width() as f32 / 2.0;
+            let cy = widget.height() as f32 / 2.0;
+            snapshot.save();
+            // Scale about the widget center: translate(c*(1-s)) then scale(s).
+            snapshot.translate(&gtk4::graphene::Point::new(
+                cx * (1.0 - s as f32),
+                cy * (1.0 - s as f32),
+            ));
+            snapshot.scale(s as f32, s as f32);
             widget.snapshot_child(&child, snapshot);
-            snapshot.pop();
-
-            self.snapshot_outline(snapshot, rect, radius);
-        }
-    }
-
-    impl ScaleBox {
-        fn snapshot_outline(
-            &self,
-            snapshot: &gtk4::Snapshot,
-            rect: gtk4::graphene::Rect,
-            radius: f32,
-        ) {
-            let width = self.outline_width.get();
-            let color = self.outline_color.get();
-            if width <= 0.0 || color.alpha() <= 0.0 {
-                return;
-            }
-
-            let outline = gtk4::gsk::RoundedRect::new(
-                rect,
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-                gtk4::graphene::Size::new(radius, radius),
-            );
-            snapshot.append_border(&outline, &[width; 4], &[color; 4]);
+            snapshot.restore();
         }
     }
 }
 
 glib::wrapper! {
-    /// A container that simulates scale via symmetric center-clip in `snapshot()`.
-    /// Child always gets full allocation. No scale transforms in the render tree.
+    /// A container that renders its child through an animated center scale
+    /// transform. Child always gets full allocation; the scale is quantized
+    /// (see module docs) to keep renderer glyph caches bounded.
     pub struct ScaleBox(ObjectSubclass<imp::ScaleBox>)
         @extends gtk4::Widget,
         @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
@@ -186,78 +149,16 @@ impl ScaleBox {
         glib::Object::builder().build()
     }
 
-    /// Get the current scale factor.
+    /// Get the current quantized scale factor.
     pub fn scale(&self) -> f64 {
         self.imp().scale.get()
     }
 
-    /// Set the border radius used for the rounded clip (pixels).
-    fn set_radius(&self, radius: f32) {
-        let imp = self.imp();
-        if (imp.radius.get() - radius).abs() < f32::EPSILON {
-            return;
-        }
-        imp.radius.set(radius);
-        self.queue_draw();
-    }
-
-    fn set_outline(&self, width: f32, color: gtk4::gdk::RGBA) {
-        let imp = self.imp();
-        let width = width.max(0.0);
-        let changed = (imp.outline_width.get() - width).abs() >= f32::EPSILON
-            || imp.outline_color.get() != color;
-        if !changed {
-            return;
-        }
-
-        imp.outline_width.set(width);
-        imp.outline_color.set(color);
-        self.queue_draw();
-    }
-
-    /// Toggle the outline used during scale-clip animations.
-    ///
-    /// CSS borders on the child remain at full child bounds, while this GSK
-    /// outline follows the animated clip. The child class temporarily hides
-    /// the duplicate CSS border during the handoff.
-    pub fn set_animated_outline(
-        &self,
-        active: bool,
-        radius: f32,
-        width: f32,
-        color: gtk4::gdk::RGBA,
-        suppress_child_class: &str,
-    ) {
-        let imp = self.imp();
-        self.set_radius(radius);
-
-        if !active || width <= 0.0 {
-            if let Some(child) = imp.child.upgrade() {
-                child.remove_css_class(suppress_child_class);
-            }
-            self.set_outline(0.0, gtk4::gdk::RGBA::TRANSPARENT);
-            return;
-        }
-
-        if let Some(child) = imp.child.upgrade() {
-            child.add_css_class(suppress_child_class);
-        }
-        self.set_outline(width, color);
-    }
-
-    /// Whether the managed child currently has `class`.
-    pub fn child_has_css_class(&self, class: &str) -> bool {
-        self.imp()
-            .child
-            .upgrade()
-            .is_some_and(|child| child.has_css_class(class))
-    }
-
     /// Set the scale factor and queue a repaint.
-    /// Values below 1.0 crop edges inward; only calls `queue_draw()`.
+    /// Only calls `queue_draw()` — no layout or CSS resolution.
     pub fn set_scale(&self, scale: f64) {
         let imp = self.imp();
-        let scale = scale.clamp(0.0, 1.0);
+        let scale = quantize_scale(scale.clamp(0.0, 1.0));
         if (imp.scale.get() - scale).abs() < f64::EPSILON {
             return;
         }
@@ -282,5 +183,24 @@ impl ScaleBox {
             child.unparent();
         }
         self.imp().child.set(None::<&gtk4::Widget>);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantize_scale_maps_animation_endpoints() {
+        assert_eq!(quantize_scale(0.94), 120.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(1.0), 1.0);
+    }
+
+    #[test]
+    fn quantize_scale_rounds_at_boundary() {
+        let midpoint = 120.5 / QUANT_DENOM;
+        assert_eq!(quantize_scale(midpoint - 1e-6), 120.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(midpoint), 121.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(midpoint + 1e-6), 121.0 / QUANT_DENOM);
     }
 }

--- a/crates/vibepanel/src/widgets/scale_box.rs
+++ b/crates/vibepanel/src/widgets/scale_box.rs
@@ -23,8 +23,8 @@ use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use std::cell::Cell;
 
-/// Quantization denominator: scale moves in steps of 1/128.
-const QUANT_DENOM: f64 = 128.0;
+/// Quantization denominator: scale moves in steps of 1/256.
+const QUANT_DENOM: f64 = 256.0;
 
 fn quantize_scale(s: f64) -> f64 {
     (s * QUANT_DENOM).round() / QUANT_DENOM
@@ -192,15 +192,15 @@ mod tests {
 
     #[test]
     fn quantize_scale_maps_animation_endpoints() {
-        assert_eq!(quantize_scale(0.94), 120.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(0.94), 241.0 / QUANT_DENOM);
         assert_eq!(quantize_scale(1.0), 1.0);
     }
 
     #[test]
     fn quantize_scale_rounds_at_boundary() {
-        let midpoint = 120.5 / QUANT_DENOM;
-        assert_eq!(quantize_scale(midpoint - 1e-6), 120.0 / QUANT_DENOM);
-        assert_eq!(quantize_scale(midpoint), 121.0 / QUANT_DENOM);
-        assert_eq!(quantize_scale(midpoint + 1e-6), 121.0 / QUANT_DENOM);
+        let midpoint = 241.5 / QUANT_DENOM;
+        assert_eq!(quantize_scale(midpoint - 1e-6), 241.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(midpoint), 242.0 / QUANT_DENOM);
+        assert_eq!(quantize_scale(midpoint + 1e-6), 242.0 / QUANT_DENOM);
     }
 }


### PR DESCRIPTION
The current popover open and close animations is a hack that was implemented because using CSS scale for them leaked memory. Likely a GTK bug.

This PR replaces the clip-based popover animation with GSK scale transforms. Scale transform was tested when clip was implemented but it would also leak.  I later learned that the leak can be prevented by quantizing the scale transform. By only using say 16 steps the leak is prevented without much loss in visual quality.

This means we get animations that are much closer, if not almost identical to the original CSS animations, while also being able to remove bespoke code for handling outlines during the clip animation and just simplify thing a bit overall.

Still a bit hacky, but less so than before, and stable memory :)