### PR TITLE
feat(notifications): add unread count CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ VibePanel is something between a simple status bar and a full desktop shell:
   - **Quick settings** – Native panel for Wi‑Fi, Bluetooth, audio, power profiles and more
 - **Minimal config** – Sensible defaults out of the box; customize with TOML, CSS only if needed.
 - **Modern aesthetics** – Defaults to a floating "island" design with instant hot‑reloading and features wallpaper adaptive theming that auto‑switches between light and dark.
-- **Integrated CLI** – Control volume, brightness, media playback, bar visibility, popovers and idle inhibition.
+- **Integrated CLI** – Control volume, brightness, media playback, bar visibility, popovers, idle inhibition, and more.
 
 ## Demo
 

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -87,6 +87,11 @@ enum Command {
         #[command(subcommand)]
         action: PopoverAction,
     },
+    /// Query notification state
+    Notifications {
+        #[command(subcommand)]
+        action: NotificationsAction,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -191,6 +196,12 @@ enum PopoverAction {
     },
 }
 
+#[derive(Subcommand, Debug)]
+enum NotificationsAction {
+    /// Print the number of unread notifications (requires Vibepanel to be the active notification daemon)
+    Unread,
+}
+
 fn main() -> ExitCode {
     // Return memory used by large, short-lived image decodes to the OS instead
     // of keeping it for reuse. Keep glibc's matching trim setting so smaller
@@ -278,6 +289,7 @@ fn handle_command(command: Command, config_path: Option<&Path>) -> ExitCode {
         Command::Media { action } => handle_media_command(action),
         Command::Bar { action } => handle_bar_command(action),
         Command::Popover { action } => handle_popover_command(action),
+        Command::Notifications { action } => handle_notifications_command(action),
     }
 }
 
@@ -576,6 +588,22 @@ fn handle_popover_command(action: PopoverAction) -> ExitCode {
     }
 }
 
+/// Handle notification subcommands via the active notification daemon.
+fn handle_notifications_command(action: NotificationsAction) -> ExitCode {
+    match action {
+        NotificationsAction::Unread => match services::notification::unread_notification_count() {
+            Ok(count) => {
+                println!("{}", count);
+                ExitCode::SUCCESS
+            }
+            Err(error) => {
+                eprintln!("Error: {}", error);
+                ExitCode::FAILURE
+            }
+        },
+    }
+}
+
 /// Initialize and run the GTK4 application.
 fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
     // Log the config source for diagnostics
@@ -855,5 +883,23 @@ fn run_gtk_app(config: Config, config_source: Option<PathBuf>) -> ExitCode {
     } else {
         error!("GTK application exited with error");
         ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn parses_notifications_unread_command() {
+        let args = Args::try_parse_from(["vibepanel", "notifications", "unread"])
+            .expect("command should parse");
+
+        assert!(matches!(
+            args.command,
+            Some(Command::Notifications {
+                action: NotificationsAction::Unread
+            })
+        ));
     }
 }

--- a/crates/vibepanel/src/services/callbacks.rs
+++ b/crates/vibepanel/src/services/callbacks.rs
@@ -145,7 +145,6 @@ impl<T> Callbacks<T> {
     }
 
     /// Returns true if no callbacks are registered.
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.inner.borrow().is_empty()
     }

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -5,11 +5,12 @@
 //! via the standard callback mechanism.
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::collections::{HashMap, HashSet};
+use std::rc::{Rc, Weak};
 
 use gtk4::gio::{self, prelude::*};
 use gtk4::glib::Variant;
+use gtk4::glib::variant::StaticVariantType;
 use tracing::{debug, error, info, warn};
 
 use super::callbacks::{CallbackId, Callbacks};
@@ -17,6 +18,9 @@ use super::state::{self, PersistedNotification};
 
 const NOTIFICATIONS_NAME: &str = "org.freedesktop.Notifications";
 const NOTIFICATIONS_PATH: &str = "/org/freedesktop/Notifications";
+const VIBEPANEL_NOTIFICATIONS_INTERFACE: &str = "io.github.vibepanel.Notifications1";
+const UNREAD_METHOD: &str = "GetUnreadCount";
+const DBUS_CALL_TIMEOUT_MS: i32 = 2_000;
 
 /// D-Bus introspection XML for org.freedesktop.Notifications
 const NOTIFICATIONS_XML: &str = r#"
@@ -53,6 +57,11 @@ const NOTIFICATIONS_XML: &str = r#"
       <arg name="id" type="u"/>
       <arg name="action_key" type="s"/>
     </signal>
+  </interface>
+  <interface name="io.github.vibepanel.Notifications1">
+    <method name="GetUnreadCount">
+      <arg direction="out" name="count" type="u"/>
+    </method>
   </interface>
 </node>
 "#;
@@ -156,10 +165,14 @@ impl From<PersistedNotification> for Notification {
 
 /// Shared, process-wide notification service implementing org.freedesktop.Notifications.
 pub struct NotificationService {
+    self_weak: Weak<NotificationService>,
+
     /// D-Bus connection
     bus: RefCell<Option<gio::DBusConnection>>,
     /// Registration ID for the exported interface
     registration_id: RefCell<Option<gio::RegistrationId>>,
+    /// Registration ID for the Vibepanel unread-query interface.
+    unread_registration_id: RefCell<Option<gio::RegistrationId>>,
 
     /// Current notifications by ID
     notifications: RefCell<HashMap<u32, Notification>>,
@@ -172,10 +185,21 @@ pub struct NotificationService {
     /// Whether notifications are muted (toasts suppressed, but notifications still stored)
     muted: Cell<bool>,
 
+    /// Exact read state by ID, independent of wall-clock ordering.
+    seen_ids: RefCell<HashSet<u32>>,
+    /// Visible toast copies by notification ID. Multiple monitors may show the same toast.
+    active_toasts: RefCell<HashMap<u32, u32>>,
+    /// Coalesces unread-state listener refreshes on the GLib main loop.
+    pending_unread_notify: Cell<bool>,
+
     /// Callbacks for state changes
     callbacks: Callbacks<NotificationService>,
     /// Whether the service is ready
     ready: Cell<bool>,
+}
+
+thread_local! {
+    static INSTANCE: Rc<NotificationService> = NotificationService::new();
 }
 
 impl NotificationService {
@@ -202,13 +226,25 @@ impl NotificationService {
             next_id
         );
 
-        let service = Rc::new(Self {
+        let seen_ids = notification_state
+            .seen_ids
+            .iter()
+            .copied()
+            .filter(|id| notifications.contains_key(id))
+            .collect();
+
+        let service = Rc::new_cyclic(|weak| Self {
+            self_weak: weak.clone(),
             bus: RefCell::new(None),
             registration_id: RefCell::new(None),
+            unread_registration_id: RefCell::new(None),
             notifications: RefCell::new(notifications),
             next_id: Cell::new(next_id),
             backend_available: Cell::new(false),
             muted: Cell::new(notification_state.muted),
+            seen_ids: RefCell::new(seen_ids),
+            active_toasts: RefCell::new(HashMap::new()),
+            pending_unread_notify: Cell::new(false),
             callbacks: Callbacks::new(),
             ready: Cell::new(false),
         });
@@ -219,10 +255,7 @@ impl NotificationService {
 
     /// Get the global NotificationService singleton.
     pub fn global() -> Rc<Self> {
-        thread_local! {
-            static INSTANCE: Rc<NotificationService> = NotificationService::new();
-        }
-        INSTANCE.with(|s| s.clone())
+        INSTANCE.with(Rc::clone)
     }
 
     /// Register a callback to be invoked when notification state changes.
@@ -297,9 +330,105 @@ impl NotificationService {
             .count()
     }
 
+    /// Count notifications not seen in a popover and no longer visible as toasts.
+    pub fn unread_count(&self) -> usize {
+        if !self.backend_available.get() {
+            return 0;
+        }
+
+        let seen_ids = self.seen_ids.borrow();
+        let active_toasts = self.active_toasts.borrow();
+        self.notifications
+            .borrow()
+            .values()
+            .filter(|notification| {
+                !notification.transient
+                    && !active_toasts.contains_key(&notification.id)
+                    && !seen_ids.contains(&notification.id)
+            })
+            .count()
+    }
+
+    /// Mark all current notifications as seen globally across monitors.
+    pub fn mark_as_seen(&self) {
+        let seen_ids = self
+            .notifications
+            .borrow()
+            .values()
+            .filter(|notification| !notification.transient)
+            .map(|notification| notification.id)
+            .collect();
+
+        if *self.seen_ids.borrow() == seen_ids {
+            return;
+        }
+
+        *self.seen_ids.borrow_mut() = seen_ids;
+        self.save_state();
+        self.schedule_unread_notify();
+    }
+
+    /// Register a visible toast copy for a notification.
+    pub fn toast_shown(&self, id: u32) {
+        // Toasts are registered before unread state is rendered in the same service
+        // update, so scheduling another listener refresh here would be redundant.
+        let mut active_toasts = self.active_toasts.borrow_mut();
+        *active_toasts.entry(id).or_insert(0) += 1;
+    }
+
+    /// Unregister a visible toast copy. Duplicate removals are ignored.
+    pub fn toast_hidden(&self, id: u32) {
+        let changed = {
+            let mut active_toasts = self.active_toasts.borrow_mut();
+            match active_toasts.get_mut(&id) {
+                Some(count) if *count > 1 => {
+                    *count -= 1;
+                    true
+                }
+                Some(_) => {
+                    active_toasts.remove(&id);
+                    true
+                }
+                None => false,
+            }
+        };
+
+        if changed {
+            self.schedule_unread_notify();
+        }
+    }
+
+    fn schedule_unread_notify(&self) {
+        // With no registered listeners, there is nobody to notify. This also avoids
+        // attaching a local source to another thread's main context in unit tests.
+        if self.callbacks.is_empty() {
+            return;
+        }
+
+        if self.pending_unread_notify.replace(true) {
+            return;
+        }
+
+        let weak = self.self_weak.clone();
+        gtk4::glib::idle_add_local_once(move || {
+            if let Some(service) = weak.upgrade() {
+                service.pending_unread_notify.set(false);
+                service.notify_listeners();
+            }
+        });
+    }
+
     /// Get a notification by ID.
     pub fn get(&self, id: u32) -> Option<Notification> {
         self.notifications.borrow().get(&id).cloned()
+    }
+
+    /// Check whether a notification is transient without cloning its payload.
+    pub fn is_transient(&self, id: u32) -> bool {
+        self.notifications
+            .borrow()
+            .get(&id)
+            .is_some_and(|notification| notification.transient)
     }
 
     /// Close a notification by ID (user dismissed).
@@ -392,8 +521,8 @@ impl NotificationService {
             }
         };
 
-        // Try to register the object - this may fail if another daemon is already
-        // exporting at the same path
+        // Object registration is connection-local; ownership of the well-known
+        // notification bus name is handled separately below.
         let registration = connection
             .register_object(NOTIFICATIONS_PATH, &interface_info)
             .method_call(
@@ -413,10 +542,49 @@ impl NotificationService {
                 );
             }
             Err(e) => {
-                // This is expected when another daemon is running - just log and continue.
-                // We'll know we don't own the name when on_name_lost is called.
+                error!("NotificationService: could not register object: {}", e);
+            }
+        }
+
+        let unread_interface_info =
+            match node_info.lookup_interface(VIBEPANEL_NOTIFICATIONS_INTERFACE) {
+                Some(i) => i,
+                None => {
+                    error!("NotificationService: unread interface not found in XML");
+                    return;
+                }
+            };
+
+        let unread_registration = connection
+            .register_object(NOTIFICATIONS_PATH, &unread_interface_info)
+            .method_call(
+                |_connection, _sender, _obj_path, _iface_name, method_name, _params, invocation| {
+                    if method_name != UNREAD_METHOD {
+                        invocation.return_error(
+                            gio::IOErrorEnum::InvalidArgument,
+                            &format!("Unknown method: {}", method_name),
+                        );
+                        return;
+                    }
+
+                    let count = NotificationService::global().unread_count();
+                    let count = u32::try_from(count).unwrap_or(u32::MAX);
+                    invocation.return_value(Some(&(count,).to_variant()));
+                },
+            )
+            .build();
+
+        match unread_registration {
+            Ok(id) => {
+                *self.unread_registration_id.borrow_mut() = Some(id);
                 debug!(
-                    "NotificationService: could not register object (likely another daemon running): {}",
+                    "NotificationService: exported {} at {}",
+                    VIBEPANEL_NOTIFICATIONS_INTERFACE, NOTIFICATIONS_PATH
+                );
+            }
+            Err(e) => {
+                error!(
+                    "NotificationService: failed to export unread interface: {}",
                     e
                 );
             }
@@ -669,15 +837,7 @@ impl NotificationService {
 
         let is_transient = notification.transient;
 
-        self.notifications.borrow_mut().insert(id, notification);
-
-        // Enforce notification limit to prevent unbounded memory growth.
-        // Remove oldest notifications (by timestamp) if we exceed the limit.
-        self.enforce_notification_limit();
-
-        // Persist state to disk
-        self.save_state();
-        self.notify_listeners();
+        self.store_notification(notification);
 
         // Return the notification ID
         invocation.return_value(Some(&(id,).to_variant()));
@@ -687,6 +847,16 @@ impl NotificationService {
         if is_transient && self.is_muted() {
             self.close_internal(id, CLOSE_REASON_DISMISSED);
         }
+    }
+
+    fn store_notification(&self, notification: Notification) {
+        self.seen_ids.borrow_mut().remove(&notification.id);
+        self.notifications
+            .borrow_mut()
+            .insert(notification.id, notification);
+        self.enforce_notification_limit();
+        self.save_state();
+        self.notify_listeners();
     }
 
     fn handle_close_notification(&self, params: &Variant, invocation: gio::DBusMethodInvocation) {
@@ -829,6 +999,12 @@ impl NotificationService {
 
         persisted.notifications.muted = self.muted.get();
         persisted.notifications.next_id = self.next_id.get();
+        let mut seen_ids = self.seen_ids.borrow_mut();
+        seen_ids.retain(|id| notifications.contains_key(id));
+        let mut persisted_seen_ids: Vec<u32> = seen_ids.iter().copied().collect();
+        persisted_seen_ids.sort_unstable();
+        drop(seen_ids);
+        persisted.notifications.seen_ids = persisted_seen_ids;
         persisted.notifications.history = history;
 
         state::save(&persisted);
@@ -838,6 +1014,43 @@ impl NotificationService {
 impl Drop for NotificationService {
     fn drop(&mut self) {
         debug!("NotificationService dropped");
+    }
+}
+
+/// Query the unread count from whichever process owns the notification D-Bus name.
+pub fn unread_notification_count() -> Result<u32, String> {
+    let connection = gio::bus_get_sync(gio::BusType::Session, None::<&gio::Cancellable>)
+        .map_err(|error| format!("could not connect to the session bus: {}", error))?;
+    let reply = connection.call_sync(
+        Some(NOTIFICATIONS_NAME),
+        NOTIFICATIONS_PATH,
+        VIBEPANEL_NOTIFICATIONS_INTERFACE,
+        UNREAD_METHOD,
+        None,
+        Some(&<(u32,)>::static_variant_type()),
+        gio::DBusCallFlags::NO_AUTO_START,
+        DBUS_CALL_TIMEOUT_MS,
+        None::<&gio::Cancellable>,
+    );
+
+    match reply {
+        Ok(reply) => reply
+            .get::<(u32,)>()
+            .map(|(count,)| count)
+            .ok_or_else(|| "notification daemon returned an invalid unread count".to_string()),
+        Err(error) => match error.kind::<gio::DBusError>() {
+            Some(gio::DBusError::ServiceUnknown | gio::DBusError::NameHasNoOwner) => {
+                Err("no notification daemon is running".to_string())
+            }
+            Some(gio::DBusError::UnknownInterface | gio::DBusError::UnknownMethod) => Err(
+                "the active notification daemon does not support Vibepanel unread queries"
+                    .to_string(),
+            ),
+            _ => Err(format!(
+                "could not query the active notification daemon: {}",
+                error
+            )),
+        },
     }
 }
 
@@ -864,13 +1077,18 @@ mod tests {
 
     fn make_service() -> Rc<NotificationService> {
         redirect_state_home();
-        Rc::new(NotificationService {
+        Rc::new_cyclic(|weak| NotificationService {
+            self_weak: weak.clone(),
             bus: RefCell::new(None),
             registration_id: RefCell::new(None),
+            unread_registration_id: RefCell::new(None),
             notifications: RefCell::new(HashMap::new()),
             next_id: Cell::new(1),
             backend_available: Cell::new(false),
             muted: Cell::new(false),
+            seen_ids: RefCell::new(HashSet::new()),
+            active_toasts: RefCell::new(HashMap::new()),
+            pending_unread_notify: Cell::new(false),
             callbacks: Callbacks::new(),
             ready: Cell::new(false),
         })
@@ -895,15 +1113,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn unread_query_wire_contract_matches_introspection() {
+        let node_info = gio::DBusNodeInfo::for_xml(NOTIFICATIONS_XML).unwrap();
+        let interface = node_info
+            .lookup_interface(VIBEPANEL_NOTIFICATIONS_INTERFACE)
+            .unwrap();
+        assert!(interface.lookup_method(UNREAD_METHOD).is_some());
+    }
+
     /// Mirror of the post-insert tail in handle_notify, which we can't call
     /// directly because it consumes D-Bus types.
     fn simulate_handle_notify(svc: &NotificationService, n: Notification) {
         let id = n.id;
         let is_transient = n.transient;
-        svc.notifications.borrow_mut().insert(id, n);
-        svc.enforce_notification_limit();
-        svc.save_state();
-        svc.notify_listeners();
+        svc.store_notification(n);
         if is_transient && svc.is_muted() {
             svc.close_internal(id, CLOSE_REASON_DISMISSED);
         }
@@ -1011,5 +1235,86 @@ mod tests {
                 1000 + i
             );
         }
+    }
+
+    #[test]
+    fn unread_count_uses_seen_ids_and_excludes_transients() {
+        let svc = make_service();
+        svc.backend_available.set(true);
+        svc.notifications
+            .borrow_mut()
+            .insert(1, make_notification(1, false, 10.0));
+        svc.notifications
+            .borrow_mut()
+            .insert(2, make_notification(2, false, 20.0));
+        svc.notifications
+            .borrow_mut()
+            .insert(3, make_notification(3, true, 30.0));
+
+        assert_eq!(svc.unread_count(), 2);
+        svc.seen_ids.borrow_mut().insert(1);
+        assert_eq!(svc.unread_count(), 1);
+        svc.seen_ids.borrow_mut().insert(2);
+        assert_eq!(svc.unread_count(), 0);
+    }
+
+    #[test]
+    fn unread_count_is_zero_without_notification_backend() {
+        let svc = make_service();
+        svc.notifications
+            .borrow_mut()
+            .insert(1, make_notification(1, false, 10.0));
+
+        assert_eq!(svc.unread_count(), 0);
+    }
+
+    #[test]
+    fn active_toasts_are_reference_counted_across_monitors() {
+        let svc = make_service();
+        svc.backend_available.set(true);
+        svc.notifications
+            .borrow_mut()
+            .insert(1, make_notification(1, false, 10.0));
+
+        svc.toast_shown(1);
+        svc.toast_shown(1);
+        assert_eq!(svc.unread_count(), 0);
+
+        svc.toast_hidden(1);
+        assert_eq!(svc.unread_count(), 0);
+
+        svc.toast_hidden(1);
+        assert_eq!(svc.unread_count(), 1);
+
+        svc.toast_hidden(1);
+        assert_eq!(svc.unread_count(), 1);
+        assert!(!svc.active_toasts.borrow().contains_key(&1));
+    }
+
+    #[test]
+    fn mark_as_seen_clears_current_unread_notifications() {
+        let svc = make_service();
+        svc.backend_available.set(true);
+        svc.notifications
+            .borrow_mut()
+            .insert(1, make_notification(1, false, 1.0));
+
+        assert_eq!(svc.unread_count(), 1);
+        svc.mark_as_seen();
+        assert_eq!(svc.unread_count(), 0);
+        assert!(svc.seen_ids.borrow().contains(&1));
+    }
+
+    #[test]
+    fn replacement_marks_notification_unread_again() {
+        let svc = make_service();
+        svc.backend_available.set(true);
+        simulate_handle_notify(&svc, make_notification(1, false, 1.0));
+        svc.mark_as_seen();
+
+        simulate_handle_notify(&svc, make_notification(1, false, 2.0));
+
+        assert_eq!(svc.unread_count(), 1);
+        assert!(!svc.seen_ids.borrow().contains(&1));
     }
 }

--- a/crates/vibepanel/src/services/state.rs
+++ b/crates/vibepanel/src/services/state.rs
@@ -45,6 +45,9 @@ pub struct NotificationState {
     pub muted: bool,
     /// Next notification ID to assign
     pub next_id: u32,
+    /// Notification IDs that have been seen in a popover
+    #[serde(default)]
+    pub seen_ids: Vec<u32>,
     /// Notification history (most recent first)
     pub history: Vec<PersistedNotification>,
 }
@@ -133,6 +136,17 @@ pub fn save(state: &PersistedState) {
             .history
             .truncate(MAX_PERSISTED_NOTIFICATIONS);
     }
+    // Truncating history can leave seen IDs without a persisted notification.
+    let persisted_ids: Vec<u32> = state
+        .notifications
+        .history
+        .iter()
+        .map(|notification| notification.id)
+        .collect();
+    state
+        .notifications
+        .seen_ids
+        .retain(|id| persisted_ids.contains(id));
 
     match serde_json::to_string_pretty(&state) {
         Ok(json) => {
@@ -145,5 +159,25 @@ pub fn save(state: &PersistedState) {
         Err(e) => {
             tracing::warn!("Failed to serialize state: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_notification_seen_ids_defaults_to_empty() {
+        let json = r#"{
+            "notifications": {
+                "muted": false,
+                "next_id": 1,
+                "last_seen_timestamp": 1234.5,
+                "history": []
+            }
+        }"#;
+
+        let state: PersistedState = serde_json::from_str(json).expect("valid legacy state");
+        assert!(state.notifications.seen_ids.is_empty());
     }
 }

--- a/crates/vibepanel/src/widgets/notifications.rs
+++ b/crates/vibepanel/src/widgets/notifications.rs
@@ -12,13 +12,11 @@
 //! - `notifications_popover.rs`: Popover content and notification list
 //! - `notifications_common.rs`: Shared constants and helper functions
 
-use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{Align, Application, Box as GtkBox, Orientation, Overlay, Widget};
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, warn};
 use vibepanel_core::config::WidgetEntry;
 
@@ -77,7 +75,6 @@ struct NotificationsWidgetInner {
     /// Toast IDs that should be closed when the service notification is closed.
     close_toast_on_close_ids: RefCell<HashSet<u32>>,
     toast_manager: RefCell<Option<Rc<NotificationToastManager>>>,
-    last_seen_timestamp: Cell<f64>,
     app: RefCell<Option<Application>>,
     menu_handle: RefCell<Option<Rc<MenuHandle>>>,
     /// Last known (id, timestamp) snapshot. Used to skip popover rebuilds on
@@ -102,7 +99,7 @@ impl NotificationsWidgetInner {
 
         // Update badge: unread since last popover open
         // Badge is shown as a simple dot (no text), count is only in tooltip
-        let unread = self.calculate_unread_count(service);
+        let unread = service.unread_count();
         debug!("NotificationsWidget: unread count = {}", unread);
         if unread > 0 {
             self.badge.set_visible(true);
@@ -181,58 +178,6 @@ impl NotificationsWidgetInner {
                 menu_handle.refresh_if_visible();
             }
         }
-    }
-
-    fn calculate_unread_count(&self, service: &NotificationService) -> usize {
-        if !service.backend_available() {
-            debug!("NotificationsWidget: backend not available, returning 0");
-            return 0;
-        }
-
-        let active_toast_ids = self
-            .toast_manager
-            .borrow()
-            .as_ref()
-            .map(|tm| tm.active_ids())
-            .unwrap_or_default();
-
-        let last_seen = self.last_seen_timestamp.get();
-
-        debug!(
-            "NotificationsWidget: calculate_unread_count - active_toast_ids={:?}, last_seen={}, notifications_count={}",
-            active_toast_ids,
-            last_seen,
-            service.history_count()
-        );
-
-        service
-            .history_notifications()
-            .iter()
-            .filter(|n| {
-                // Skip if currently shown as toast
-                if active_toast_ids.contains(&n.id) {
-                    debug!("NotificationsWidget: skipping {} (active toast)", n.id);
-                    return false;
-                }
-
-                // First run (never opened): count all non-toasted as unread
-                if last_seen <= 0.0 {
-                    debug!(
-                        "NotificationsWidget: counting {} (never opened popover)",
-                        n.id
-                    );
-                    return true;
-                }
-
-                // Count if delivered after last seen
-                let is_unread = n.timestamp > last_seen;
-                debug!(
-                    "NotificationsWidget: {} timestamp={} > last_seen={} = {}",
-                    n.id, n.timestamp, last_seen, is_unread
-                );
-                is_unread
-            })
-            .count()
     }
 
     fn show_new_toasts(&self, service: &NotificationService) {
@@ -347,22 +292,13 @@ impl NotificationsWidgetInner {
                     .and_then(|display| display.monitor_at_surface(&surface))
             })
     }
-
-    /// Mark notifications as seen (called when popover opens).
-    fn mark_as_seen(&self) {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs_f64())
-            .unwrap_or(0.0);
-        self.last_seen_timestamp.set(now);
-    }
 }
 
 /// Notification bell widget with popover showing notification list.
 pub struct NotificationsWidget {
     base: BaseWidget,
-    /// Kept for ownership: Weak references inside service/toast closures only
-    /// remain valid as long as this Rc is alive.
+    /// Kept for ownership: the service callback's Weak reference remains valid
+    /// as long as this Rc is alive.
     #[allow(dead_code)]
     inner: Rc<NotificationsWidgetInner>,
     /// Callback ID for NotificationService, used to disconnect on drop.
@@ -410,7 +346,6 @@ impl NotificationsWidget {
             known_ids: RefCell::new(HashMap::new()),
             close_toast_on_close_ids: RefCell::new(HashSet::new()),
             toast_manager: RefCell::new(None),
-            last_seen_timestamp: Cell::new(0.0),
             app: RefCell::new(None),
             menu_handle: RefCell::new(None),
             last_notif_ids: RefCell::new(Vec::new()),
@@ -419,11 +354,10 @@ impl NotificationsWidget {
 
         // Build menu before constructing Self so we can move base/inner cleanly.
         let suppress_rebuild = Rc::clone(&inner.suppress_rebuild);
-        let inner_for_menu = Rc::clone(&inner);
         let menu_handle = base.create_menu(|| GtkBox::new(Orientation::Vertical, 0).into());
         let handle_weak = Rc::downgrade(&menu_handle);
         menu_handle.set_builder_with_monitor(move |monitor| {
-            inner_for_menu.mark_as_seen();
+            NotificationService::global().mark_as_seen();
             let on_close: Option<ClosePopoverCallback> = handle_weak
                 .upgrade()
                 .map(|handle| Rc::new(move || handle.hide()) as ClosePopoverCallback);
@@ -440,35 +374,17 @@ impl NotificationsWidget {
             .map(|n| (n.id, n.timestamp))
             .collect();
 
-        // Initialize toast manager. Closures use Weak to avoid keeping inner
-        // alive after the widget is dropped.
         {
-            let service_for_action = NotificationService::global();
+            let service_for_action = Rc::clone(&service);
             let on_action = move |id: u32, action_id: &str| {
                 service_for_action.invoke_action(id, action_id);
             };
 
-            // When a toast is removed (dismissed or timed out), we need to recalculate
-            // the badge. However, we must NOT call on_service_update directly here
-            // because that would cause infinite recursion:
-            //   action → invoke_action → notify_listeners → on_service_update
-            //   → show_new_toasts → close toast → on_toast_removed → on_service_update → ...
-            //
-            // Instead, we use idle_add to defer the update to the next main loop iteration.
-            // This breaks the synchronous call chain and prevents stack overflow.
-            let inner_weak_for_toast = Rc::downgrade(&inner);
-            let on_toast_removed = move || {
-                let inner_weak = inner_weak_for_toast.clone();
-                glib::idle_add_local_once(move || {
-                    if let Some(inner) = inner_weak.upgrade() {
-                        let service = NotificationService::global();
-                        inner.on_service_update(&service);
-                    }
-                });
-            };
-
-            let manager =
-                NotificationToastManager::new(on_action, on_toast_removed, config.toast_position);
+            let manager = NotificationToastManager::new(
+                Rc::clone(&service),
+                on_action,
+                config.toast_position,
+            );
             *inner.toast_manager.borrow_mut() = Some(manager);
         }
 

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -9,7 +9,7 @@ use gtk4::prelude::*;
 use gtk4::{Align, Application, Box as GtkBox, Button, Image, Label, Orientation, Window, gdk};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 use tracing::debug;
 
@@ -120,6 +120,8 @@ struct ToastLayout {
 pub(super) struct NotificationToast {
     window: Window,
     notification_id: u32,
+    /// Runs from `Drop` so each visible toast copy is unregistered once.
+    on_hidden: ToastCallback,
     timeout_source: RefCell<Option<SourceId>>,
     current_bar_margin: Cell<i32>,
     animation_source: RefCell<Option<SourceId>>,
@@ -137,9 +139,9 @@ impl NotificationToast {
     fn new(
         context: ToastWindowContext<'_>,
         notification: &Notification,
-        on_dismiss: ToastCallback,
+        on_remove: ToastCallback,
+        on_hidden: ToastCallback,
         on_action: ToastActionCallback,
-        on_timeout: ToastCallback,
         on_height_measured: ToastCallback,
     ) -> Rc<Self> {
         let window = Window::builder()
@@ -185,6 +187,7 @@ impl NotificationToast {
         let toast = Rc::new(Self {
             window,
             notification_id,
+            on_hidden,
             timeout_source: RefCell::new(None),
             current_bar_margin: Cell::new(layout.initial_margin),
             animation_source: RefCell::new(None),
@@ -192,9 +195,20 @@ impl NotificationToast {
             height: Cell::new(TOAST_ESTIMATED_HEIGHT),
             theme_callback_guard: RefCell::new(None),
         });
-
-        toast.build_content(notification, on_dismiss.clone(), on_action);
-        toast.schedule_timeout(notification, on_timeout);
+        toast.build_content(notification, Rc::clone(&on_remove), on_action);
+        // Route GTK close requests through normal removal. This ensures manager
+        // teardown also removes transient service entries, while external GTK
+        // closes release map-owned toasts and balance active-toast accounting.
+        // Native gtk4-layer-shell >= 1.3 does not forward compositor closure here
+        // unless respect_close is enabled, so accounting lasts until timeout or teardown.
+        // Every window.close() re-enters removal, so never hold collection borrows
+        // across a close.
+        let on_window_close = Rc::clone(&on_remove);
+        toast.window.connect_close_request(move |_| {
+            on_window_close(notification_id);
+            glib::Propagation::Proceed
+        });
+        toast.schedule_timeout(notification, on_remove);
 
         // Measure actual height after window is mapped and laid out.
         // We use idle_add to defer measurement until after GTK has completed layout.
@@ -235,9 +249,8 @@ impl NotificationToast {
     pub fn update(
         self: &Rc<Self>,
         notification: &Notification,
-        on_dismiss: ToastCallback,
+        on_remove: ToastCallback,
         on_action: ToastActionCallback,
-        on_timeout: ToastCallback,
         on_height_measured: ToastCallback,
     ) {
         // Drop the existing timeout before scheduling a fresh one - replacement
@@ -246,8 +259,8 @@ impl NotificationToast {
             source_id.remove();
         }
 
-        self.build_content(notification, on_dismiss, on_action);
-        self.schedule_timeout(notification, on_timeout);
+        self.build_content(notification, Rc::clone(&on_remove), on_action);
+        self.schedule_timeout(notification, on_remove);
 
         // The window is already mapped, so connect_map won't fire again. Defer a
         // re-measurement to the next idle so GTK has time to lay out the new
@@ -561,6 +574,7 @@ fn build_toast_content(
 
 impl Drop for NotificationToast {
     fn drop(&mut self) {
+        (self.on_hidden)(self.notification_id);
         // Cancel any pending animation to free resources promptly
         if let Some(source_id) = self.animation_source.borrow_mut().take() {
             source_id.remove();
@@ -578,22 +592,22 @@ impl Drop for NotificationToast {
 pub(super) struct NotificationToastManager {
     toasts: RefCell<HashMap<u32, Rc<NotificationToast>>>,
     toast_order: RefCell<Vec<u32>>,
+    service: Rc<NotificationService>,
     on_action: ToastActionCallback,
-    on_toast_removed: Rc<dyn Fn()>,
     position: ToastPosition,
 }
 
 impl NotificationToastManager {
     pub fn new(
+        service: Rc<NotificationService>,
         on_action: impl Fn(u32, &str) + 'static,
-        on_toast_removed: impl Fn() + 'static,
         position: ToastPosition,
     ) -> Rc<Self> {
         Rc::new(Self {
             toasts: RefCell::new(HashMap::new()),
             toast_order: RefCell::new(Vec::new()),
+            service,
             on_action: Rc::new(on_action),
-            on_toast_removed: Rc::new(on_toast_removed),
             position,
         })
     }
@@ -604,48 +618,33 @@ impl NotificationToastManager {
         monitor: Option<&gdk::Monitor>,
         notification: &Notification,
     ) {
-        // Transient notifications must be removed from the service when their toast
-        // disappears (dismiss or timeout) so they never leak into the popover
-        // history. Close the service entry *before* tearing down the toast so the
-        // synchronous on_service_update fired by `service.close` does the work;
-        // the deferred update from `remove_toast` then sees no change and no-ops.
-        let is_transient = notification.transient;
-
-        let manager = Rc::clone(self);
-        let on_dismiss: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            if is_transient {
-                NotificationService::global().close(id);
+        // Transient notifications are toast-only, so remove the service entry when the toast goes away.
+        let manager = Rc::downgrade(self);
+        let service = Rc::clone(&self.service);
+        let on_remove: Rc<dyn Fn(u32)> = Rc::new(move |id| {
+            if service.is_transient(id) {
+                service.close(id);
             }
-            manager.remove_toast(id);
+            if let Some(manager) = manager.upgrade() {
+                manager.remove_toast(id);
+            }
         });
 
-        // When toast times out, we need to remove it and notify the widget to update badge
-        let manager_for_timeout = Rc::clone(self);
-        let on_timeout: Rc<dyn Fn(u32)> = Rc::new(move |id| {
-            if is_transient {
-                NotificationService::global().close(id);
-            }
-            manager_for_timeout.remove_toast(id);
-        });
-
-        // When toast height is measured, reposition all toasts. Constructed up
-        // front because both the in-place update path and the new-toast path
-        // need it.
-        let manager_for_height = Rc::clone(self);
+        let manager_for_height = Rc::downgrade(self);
         let on_height_measured: Rc<dyn Fn(u32)> = Rc::new(move |_id| {
-            manager_for_height.reposition_toasts();
+            if let Some(manager) = manager_for_height.upgrade() {
+                manager.reposition_toasts();
+            }
         });
 
-        // If a toast for this id is already on screen, mutate it in place so a
-        // notification replaced via `replaces_id` updates the existing toast
-        // (text, actions, timer) rather than stacking a new one on top.
         let existing = self.toasts.borrow().get(&notification.id).cloned();
         if let Some(toast) = existing {
+            // A replaces_id update mutates the existing toast instead of stacking
+            // a second toast for the same notification.
             toast.update(
                 notification,
-                on_dismiss,
+                Rc::clone(&on_remove),
                 Rc::clone(&self.on_action),
-                on_timeout,
                 on_height_measured,
             );
             return;
@@ -679,9 +678,12 @@ impl NotificationToastManager {
                 },
             },
             notification,
-            on_dismiss,
+            Rc::clone(&on_remove),
+            {
+                let service = Rc::clone(&self.service);
+                Rc::new(move |id| service.toast_hidden(id))
+            },
             Rc::clone(&self.on_action),
-            on_timeout,
             on_height_measured,
         );
 
@@ -689,29 +691,24 @@ impl NotificationToastManager {
             .borrow_mut()
             .insert(notification.id, Rc::clone(&toast));
         self.toast_order.borrow_mut().push(notification.id);
+        self.service.toast_shown(notification.id);
         toast.present();
     }
 
     pub fn remove_toast(&self, notification_id: u32) {
-        let had_toast = self.toasts.borrow_mut().remove(&notification_id).is_some();
-
-        if had_toast {
-            // Note: toast.close() is not called here because the toast may have
-            // already been closed (e.g., window.close() was called directly).
-            // The timeout source is already cleared by the toast itself.
-        }
+        let removed = self.toasts.borrow_mut().remove(&notification_id);
+        // Drop the toast after releasing the map borrow.
+        drop(removed);
 
         self.toast_order
             .borrow_mut()
             .retain(|&id| id != notification_id);
         self.reposition_toasts();
-
-        // Notify widget to recalculate badge
-        (self.on_toast_removed)();
     }
 
     pub fn close_toast(&self, notification_id: u32) {
-        if let Some(toast) = self.toasts.borrow_mut().remove(&notification_id) {
+        let toast = self.toasts.borrow_mut().remove(&notification_id);
+        if let Some(toast) = toast {
             toast.window.close();
         }
 
@@ -719,7 +716,6 @@ impl NotificationToastManager {
             .borrow_mut()
             .retain(|&id| id != notification_id);
         self.reposition_toasts();
-        (self.on_toast_removed)();
     }
 
     fn reposition_toasts(&self) {
@@ -734,9 +730,19 @@ impl NotificationToastManager {
             }
         }
     }
+}
 
-    pub fn active_ids(&self) -> HashSet<u32> {
-        self.toasts.borrow().keys().cloned().collect()
+impl Drop for NotificationToastManager {
+    fn drop(&mut self) {
+        let active_toasts: Vec<Rc<NotificationToast>> =
+            std::mem::take(&mut *self.toasts.borrow_mut())
+                .into_values()
+                .collect();
+        self.toast_order.borrow_mut().clear();
+
+        for toast in &active_toasts {
+            toast.window.close();
+        }
     }
 }
 

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -412,9 +412,9 @@ fn test_notification_toast_structure_contract() {
         );
 
         let notification = test_notification(URGENCY_CRITICAL);
-        let noop_dismiss: ToastCallback = Rc::new(|_| {});
+        let noop_remove: ToastCallback = Rc::new(|_| {});
+        let noop_hidden: ToastCallback = Rc::new(|_| {});
         let noop_action: ToastActionCallback = Rc::new(|_, _| {});
-        let noop_timeout: ToastCallback = Rc::new(|_| {});
         let noop_height: ToastCallback = Rc::new(|_| {});
         let toast = NotificationToast::new(
             ToastWindowContext {
@@ -426,9 +426,9 @@ fn test_notification_toast_structure_contract() {
                 },
             },
             &notification,
-            noop_dismiss,
+            noop_remove,
+            noop_hidden,
             noop_action,
-            noop_timeout,
             noop_height,
         );
         toast.present();


### PR DESCRIPTION
Adds a CLI command to print the current unread notification count so that it can be extracted and shown on your lock screen for example.

```sh
vibepanel notifications unread
```

VibePanel needs to be the active notification daemon. 
