### PR TITLE
perf(popovers): avoid per-frame surface resizes

### DIFF
--- a/crates/vibepanel/src/services/background_effect.rs
+++ b/crates/vibepanel/src/services/background_effect.rs
@@ -90,7 +90,6 @@ use gdk4_wayland::prelude::*;
 use gtk4::glib;
 use gtk4::prelude::*;
 use tracing::{debug, trace, warn};
-use vibepanel_core::config::BarPosition;
 use wayland_client::protocol::wl_compositor::WlCompositor;
 use wayland_client::protocol::wl_registry;
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
@@ -99,8 +98,8 @@ use wayland_protocols::ext::background_effect::v1::client::{
     ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
 };
 
-const BLUR_REGION_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-resize-watched";
 const BLUR_SURFACE_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-surface-watched";
+const BLUR_SURFACE_ACTIVE_KEY: &str = "vibepanel-blur-surface-active";
 
 /// Attach the standard blur lifecycle for standalone GTK windows.
 ///
@@ -412,41 +411,6 @@ fn add_rounded_rect_to_region_with_outline(
     }
 }
 
-/// Compute effective shadow margins and border radius for a blur region.
-///
-/// Resolves the base `shadow_margin` through `SurfaceStyleManager` (respecting
-/// the `shadows_enabled` flag) and applies the asymmetric layout where the
-/// bar-adjacent side gets 0 margin.
-///
-/// Returns `(margin_top, margin_bottom, margin_start, margin_end, radius)`.
-fn compute_shadow_layout(shadow_margin: i32) -> (i32, i32, i32, i32, i32) {
-    let effective_margin = if shadow_margin > 0 {
-        crate::services::surfaces::SurfaceStyleManager::global().shadow_margin(shadow_margin)
-    } else {
-        0
-    };
-
-    let m = effective_margin;
-    let (margin_top, margin_bottom, margin_start, margin_end) = if m > 0 {
-        match crate::services::config_manager::ConfigManager::global().bar_position() {
-            BarPosition::Top => (0, m, m, m),
-            BarPosition::Bottom => (m, 0, m, m),
-            BarPosition::Left => (m, m, 0, m),
-            BarPosition::Right => (m, m, m, 0),
-        }
-    } else {
-        (0, 0, 0, 0)
-    };
-
-    let radius = if shadow_margin > 0 {
-        crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32
-    } else {
-        0
-    };
-
-    (margin_top, margin_bottom, margin_start, margin_end, radius)
-}
-
 // ── Surface info helper ─────────────────────────────────────────────────────
 
 /// Resolved Wayland surface info for a GTK widget.
@@ -706,32 +670,6 @@ impl BackgroundEffectManager {
         }
     }
 
-    /// Install a one-shot resize watcher on a window's GDK surface.
-    ///
-    /// Watches both `width` and `height`; either dimension may change
-    /// independently. Handler is idempotent.
-    ///
-    /// The watcher is installed at most once per window.
-    fn install_resize_watcher(
-        window: &gtk4::ApplicationWindow,
-        on_resize: impl Fn() + 'static + Clone,
-    ) {
-        unsafe {
-            if window
-                .data::<bool>(BLUR_REGION_RESIZE_WATCHED_KEY)
-                .is_some()
-            {
-                return;
-            }
-            window.set_data(BLUR_REGION_RESIZE_WATCHED_KEY, true);
-        }
-        if let Some(gdk_surface) = window.native().and_then(|n| n.surface()) {
-            let on_resize_w = on_resize.clone();
-            gdk_surface.connect_notify_local(Some("width"), move |_, _| on_resize_w());
-            gdk_surface.connect_notify_local(Some("height"), move |_, _| on_resize());
-        }
-    }
-
     /// Install a resize watcher for [`apply_blur_surface`](Self::apply_blur_surface)
     /// on a generic widget's GDK surface.
     ///
@@ -775,8 +713,16 @@ impl BackgroundEffectManager {
                 let radius_fn = radius_fn.clone();
                 let outline_visible_fn = outline_visible_fn.clone();
                 glib::idle_add_local_once(move || {
+                    // A queued resize may outlive blur removal; require the active marker
+                    // so this watcher cannot recreate the effect during fade-out.
                     if let Some(rc) = root_weak.upgrade()
                         && let Some(cc) = content_weak.upgrade()
+                        && rc
+                            .native()
+                            .and_then(|n| n.surface())
+                            .is_some_and(|s| unsafe {
+                                s.data::<bool>(BLUR_SURFACE_ACTIVE_KEY).is_some()
+                            })
                         && crate::services::config_manager::ConfigManager::global().blur_enabled()
                         && let Some(blur) = Self::global()
                     {
@@ -792,102 +738,6 @@ impl BackgroundEffectManager {
         };
         gdk_surface.connect_notify_local(Some("width"), make_handler());
         gdk_surface.connect_notify_local(Some("height"), make_handler());
-    }
-
-    /// Apply a blur region hint to the given window's surface.
-    ///
-    /// `shadow_margin` is the padding (in surface-local px) between the layer-shell
-    /// surface edge and the visible content. The margins are applied asymmetrically
-    /// to match `SurfaceStyleManager::apply_shadow_margins`: the bar-adjacent side
-    /// gets 0 margin (content is flush against the bar), while the other three
-    /// sides are inset by `shadow_margin`.
-    ///
-    /// If the surface has no size yet (first map), this schedules a one-shot idle
-    /// retry so the blur region is applied once GTK has committed dimensions.
-    ///
-    /// Commits the surface explicitly so the double-buffered blur region takes
-    /// effect even when this runs from a deferred idle or resize callback with
-    /// no guaranteed subsequent GTK frame commit.
-    pub fn apply_blur_region(&self, window: &gtk4::ApplicationWindow, shadow_margin: i32) {
-        let Some(info) = SurfaceInfo::from_widget(window) else {
-            trace!("No wl_surface for window, skipping blur");
-            return;
-        };
-
-        let width = info.width();
-        let height = info.height();
-
-        if width <= 0 || height <= 0 {
-            // Surface not sized yet (common on first map). Schedule a one-shot
-            // idle retry so we apply the region once GTK has committed actual
-            // dimensions. A set_data guard prevents stacking multiple retries if
-            // this is called several times before the surface gets sized.
-            const RETRY_KEY: &str = "vibepanel-blur-region-retry-pending";
-            if unsafe { window.data::<bool>(RETRY_KEY) }.is_some() {
-                trace!("Idle retry already pending, skipping duplicate");
-                return;
-            }
-            unsafe { window.set_data(RETRY_KEY, true) };
-            trace!("Surface has no size yet, deferring blur region to idle");
-            let win_clone = window.clone();
-            glib::idle_add_local_once(move || {
-                unsafe { win_clone.steal_data::<bool>(RETRY_KEY) };
-                if crate::services::config_manager::ConfigManager::global().blur_enabled()
-                    && let Some(blur) = Self::global()
-                {
-                    blur.apply_blur_region(&win_clone, shadow_margin);
-                }
-            });
-            return;
-        }
-
-        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
-            return;
-        };
-
-        let (margin_top, margin_bottom, margin_start, margin_end, radius) =
-            compute_shadow_layout(shadow_margin);
-
-        let region = compositor.create_region(&self.qh, ());
-        let x = margin_start;
-        let y = margin_top;
-        let w = width - margin_start - margin_end;
-        let h = height - margin_top - margin_bottom;
-
-        add_rounded_rect_to_region_with_outline(
-            &region,
-            x,
-            y,
-            w,
-            h,
-            radius,
-            crate::services::config_manager::ConfigManager::global().surface_outline_visible(),
-        );
-
-        effect.set_blur_region(Some(&region));
-        region.destroy();
-        info.wl_surface.commit();
-        self.flush();
-
-        debug!(
-            "Applied blur region: {}x{} at ({},{}) r={} margins t={} b={} s={} e={} (surface {}x{})",
-            w, h, x, y, radius, margin_top, margin_bottom, margin_start, margin_end, width, height
-        );
-
-        // Install a resize watcher (once per window) so the blur region
-        // is re-applied whenever the surface dimensions change — e.g. when
-        // a Revealer expands and the layer-shell surface reconfigures.
-        // Use a weak ref to avoid a GObject ref cycle
-        // (GdkSurface → closure → Window → GdkSurface).
-        let win_weak = window.downgrade();
-        Self::install_resize_watcher(window, move || {
-            if let Some(win) = win_weak.upgrade()
-                && crate::services::config_manager::ConfigManager::global().blur_enabled()
-                && let Some(blur) = BackgroundEffectManager::global()
-            {
-                blur.apply_blur_region(&win, shadow_margin);
-            }
-        });
     }
 
     /// Apply a blur region for the bar surface.
@@ -919,6 +769,7 @@ impl BackgroundEffectManager {
 
         // Opaque/translucent bar: blur only the bar_box bounds, not the full surface.
         // Using apply_blur_surface so compute_bounds accounts for any margin/padding.
+        Self::mark_blur_surface_active(window);
         self.apply_blur_surface_with_outline(
             window,
             bar_box,
@@ -994,6 +845,10 @@ impl BackgroundEffectManager {
         let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
         };
+        unsafe {
+            info.wayland_surface
+                .steal_data::<bool>(BLUR_SURFACE_ACTIVE_KEY);
+        }
 
         let mut state = self.state.borrow_mut();
         if let Some(effect) = state.effects.remove(&info.surface_id) {
@@ -1011,70 +866,36 @@ impl BackgroundEffectManager {
         }
     }
 
-    /// Apply a blur region that tracks the ScaleBox grow-in animation.
+    /// Apply scaled content bounds from a GTK frame-clock tick.
     ///
     /// During the open animation the ScaleBox scales its child around the center.
     /// This method sets the blur region to the transformed bounds so the compositor
     /// blur grows in sync with the visual.
     ///
-    /// `scale` should be the current ScaleBox scale (ANIM_SCALE_FROM → 1.0).
-    /// At `scale == 1.0` this produces the same region as `apply_blur_region`.
+    /// Use the current ScaleBox scale for grow-in animations and `1.0` for an
+    /// ordinary content-bounds frame update.
     pub fn apply_blur_region_animated(
         &self,
         window: &gtk4::ApplicationWindow,
-        shadow_margin: i32,
+        content: &impl gtk4::prelude::IsA<gtk4::Widget>,
         scale: f64,
     ) {
         let Some(info) = SurfaceInfo::from_widget(window) else {
             return;
         };
 
-        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
-            return;
-        };
-
-        let width = info.width();
-        let height = info.height();
-
-        if width <= 0 || height <= 0 {
-            return;
-        }
-
-        let (margin_top, margin_bottom, margin_start, margin_end, radius) =
-            compute_shadow_layout(shadow_margin);
-
-        // Content area within shadow margins (= ScaleBox allocation).
-        let content_w = (width - margin_start - margin_end) as f64;
-        let content_h = (height - margin_top - margin_bottom) as f64;
-
-        // ScaleBox transforms to centered bounds of size content * scale.
-        let scaled_w = content_w * scale;
-        let scaled_h = content_h * scale;
-        let scaled_radius = (radius as f64 * scale).round() as i32;
-        let dx = (content_w - scaled_w) / 2.0;
-        let dy = (content_h - scaled_h) / 2.0;
-
-        // Final rect in surface coordinates.
-        let x = margin_start as f64 + dx;
-        let y = margin_top as f64 + dy;
-
-        let region = compositor.create_region(&self.qh, ());
-        add_rounded_rect_to_region_with_outline(
-            &region,
-            x.round() as i32,
-            y.round() as i32,
-            scaled_w.round() as i32,
-            scaled_h.round() as i32,
-            scaled_radius,
+        if self.set_blur_surface_region(
+            &info,
+            window.upcast_ref(),
+            content.as_ref(),
+            crate::services::config_manager::ConfigManager::global().surface_border_radius() as i32,
             crate::services::config_manager::ConfigManager::global().surface_outline_visible(),
-        );
-
-        effect.set_blur_region(Some(&region));
-        region.destroy();
-        // Called only from GTK frame-clock ticks; GTK commits the surface for
-        // that frame, so this path intentionally avoids an extra commit per
-        // animation frame.
-        self.flush();
+            scale,
+        ) {
+            // Called only from GTK frame-clock ticks; GTK commits the surface for
+            // that frame, so this path intentionally avoids an extra commit.
+            self.flush();
+        }
     }
 
     /// Apply blur for the popover/Quick Settings opening animation.
@@ -1085,23 +906,24 @@ impl BackgroundEffectManager {
     pub fn apply_open_animation_blur(
         &self,
         window: &gtk4::ApplicationWindow,
-        shadow_margin: i32,
+        content: &impl gtk4::prelude::IsA<gtk4::Widget>,
         scale: f64,
         complete: bool,
     ) {
         if complete {
-            self.apply_blur_region(window, shadow_margin);
+            self.apply_blur_surface(window, content, || {
+                crate::services::config_manager::ConfigManager::global().surface_border_radius()
+                    as i32
+            });
         } else {
-            self.apply_blur_region_animated(window, shadow_margin, scale);
+            self.apply_blur_region_animated(window, content, scale);
         }
     }
 
     /// Apply a blur region matching a content widget's allocation within its surface.
     ///
-    /// Designed for surfaces without explicit shadow margins (OSD, notification
-    /// toast, tray menu popover, media pop-out) where the surface may be
-    /// slightly larger than the visible content due to CSS box-shadow expansion.
-    /// The `content` widget's allocation provides the exact bounds to blur.
+    /// The surface may be larger than its visible content due to CSS shadows or
+    /// animation wrappers. The `content` allocation provides exact blur bounds.
     ///
     /// `surface_root` is any widget whose `GtkNative` owns the `wl_surface`
     /// (a `gtk4::Window`, `gtk4::ApplicationWindow`, or `gtk4::Popover`);
@@ -1123,9 +945,19 @@ impl BackgroundEffectManager {
         content: &impl gtk4::prelude::IsA<gtk4::Widget>,
         radius_fn: impl Fn() -> i32 + Clone + 'static,
     ) {
+        Self::mark_blur_surface_active(surface_root);
         self.apply_blur_surface_with_outline(surface_root, content, radius_fn, || {
             crate::services::config_manager::ConfigManager::global().surface_outline_visible()
         });
+    }
+
+    fn mark_blur_surface_active(surface_root: &impl gtk4::prelude::IsA<gtk4::Widget>) {
+        let Some(info) = SurfaceInfo::from_widget(surface_root) else {
+            return;
+        };
+        unsafe {
+            info.wayland_surface.set_data(BLUR_SURFACE_ACTIVE_KEY, true);
+        }
     }
 
     fn apply_blur_surface_with_outline(
@@ -1140,69 +972,21 @@ impl BackgroundEffectManager {
             return;
         };
 
-        let width = info.width();
-        let height = info.height();
-
         let surface_root_widget = surface_root.as_ref();
         let content_widget = content.as_ref();
-
-        // Validate that the surface has a real size (not the initial 1×1
-        // placeholder) and that compute_bounds returns sensible values.
-        let surface_ready = width > 1 && height > 1;
-        let bounds = content_widget.compute_bounds(surface_root_widget);
-        let bounds_valid = bounds
-            .as_ref()
-            .is_some_and(|b| b.x() >= 0.0 && b.y() >= 0.0 && b.width() > 0.0 && b.height() > 0.0);
-
-        if !surface_ready || !bounds_valid {
-            debug!(
-                "apply_blur_surface: not ready (surface {}x{}, bounds {:?}), deferring",
-                width, height, bounds
-            );
-            // Install a resize watcher so we re-try once the surface gets a
-            // real size.  The watcher also handles subsequent resizes after
-            // the initial apply succeeds.
-            Self::install_surface_resize_watcher(
-                surface_root_widget,
-                content_widget,
-                radius_fn,
-                outline_visible_fn,
-            );
-            return;
-        }
-
-        let bounds = bounds.unwrap();
-        let bx = bounds.x().round() as i32;
-        let by = bounds.y().round() as i32;
-        let bw = bounds.width().round() as i32;
-        let bh = bounds.height().round() as i32;
-
-        let Some((effect, compositor)) = self.get_or_create_effect(&info) else {
-            return;
-        };
-
-        let region = compositor.create_region(&self.qh, ());
         let radius = radius_fn();
-        add_rounded_rect_to_region_with_outline(
-            &region,
-            bx,
-            by,
-            bw,
-            bh,
+        if self.set_blur_surface_region(
+            &info,
+            surface_root_widget,
+            content_widget,
             radius,
             outline_visible_fn(),
-        );
-
-        effect.set_blur_region(Some(&region));
-        region.destroy();
-        // Commit the surface so the double-buffered blur region takes effect
-        // immediately.  Without this, the region stays pending until GTK's
-        // next wl_surface.commit -- which may never come for surfaces whose
-        // layout is already complete (e.g. tray popovers reached via the
-        // deferred idle path).  Safe for the same reason as the commit in
-        // remove_blur_region: we only touch blur state GDK doesn't manage.
-        info.wl_surface.commit();
-        self.flush();
+            1.0,
+        ) {
+            // Deferred and resize callbacks have no guaranteed GTK frame commit.
+            info.wl_surface.commit();
+            self.flush();
+        }
 
         // Install a resize watcher so the blur region is updated if the
         // surface dimensions change after initial layout.  The idempotency
@@ -1214,11 +998,56 @@ impl BackgroundEffectManager {
             radius_fn,
             outline_visible_fn,
         );
+    }
 
-        debug!(
+    fn set_blur_surface_region(
+        &self,
+        info: &SurfaceInfo,
+        surface_root: &gtk4::Widget,
+        content: &gtk4::Widget,
+        radius: i32,
+        outline_visible: bool,
+        scale: f64,
+    ) -> bool {
+        let surface_width = info.width();
+        let surface_height = info.height();
+        let bounds = content.compute_bounds(surface_root);
+        let bounds_valid = bounds
+            .as_ref()
+            .is_some_and(|b| b.x() >= 0.0 && b.y() >= 0.0 && b.width() > 0.0 && b.height() > 0.0);
+
+        if surface_width <= 1 || surface_height <= 1 || !bounds_valid {
+            trace!(
+                "apply_blur_surface: not ready (surface {}x{}, bounds {:?})",
+                surface_width, surface_height, bounds
+            );
+            return false;
+        }
+
+        let bounds = bounds.unwrap();
+        let width = bounds.width() as f64;
+        let height = bounds.height() as f64;
+        let scaled_width = width * scale;
+        let scaled_height = height * scale;
+        let bx = (bounds.x() as f64 + (width - scaled_width) / 2.0).round() as i32;
+        let by = (bounds.y() as f64 + (height - scaled_height) / 2.0).round() as i32;
+        let bw = scaled_width.round() as i32;
+        let bh = scaled_height.round() as i32;
+        let radius = (radius as f64 * scale).round() as i32;
+        let Some((effect, compositor)) = self.get_or_create_effect(info) else {
+            return false;
+        };
+
+        let region = compositor.create_region(&self.qh, ());
+        add_rounded_rect_to_region_with_outline(&region, bx, by, bw, bh, radius, outline_visible);
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+
+        trace!(
             "Applied blur surface: {}x{} at ({},{}) r={} (surface {}x{})",
-            bw, bh, bx, by, radius, width, height
+            bw, bh, bx, by, radius, surface_width, surface_height
         );
+        true
     }
 }
 

--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -103,7 +103,11 @@ impl HyprlandBackend {
     ///
     /// Session-scoped, only set on startup and not persisted anywhere
     fn apply_layer_rules(&self) {
-        let cmd = "keyword layerrule no_anim on, match:namespace ^vibepanel-.*-popover$";
+        let cmd = if self.supports_lua_dispatch.load(Ordering::Relaxed) {
+            "eval hl.layer_rule({ match = { namespace = \"^vibepanel-.*-popover$\" }, no_anim = true })"
+        } else {
+            "keyword layerrule no_anim on, match:namespace ^vibepanel-.*-popover$"
+        };
         match self.send_command(cmd) {
             Some(response) if Self::response_is_ok(&response) => {
                 info!("Applied Hyprland layerrule: no_anim for vibepanel surfaces");
@@ -1130,10 +1134,10 @@ impl CompositorBackend for HyprlandBackend {
             return;
         }
 
+        self.probe_lua_dispatch_support();
+
         // Disable compositor-level layer animations for our surfaces.
         self.apply_layer_rules();
-
-        self.probe_lua_dispatch_support();
 
         // Store callbacks
         *self.callbacks.lock().unwrap_or_else(|e| e.into_inner()) =

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -189,15 +189,18 @@ pub(crate) fn snap_anim_shell(shell: &ScaleBox, opacity: f64, scale: f64) {
 
 /// Drive a popover animation, preserving progress during mid-flight reversals.
 ///
-/// `blur_target` pairs the target window with its shadow margin. `on_complete`
-/// runs once with the direction of the completed segment.
+/// `blur_target` contains the target window and content. `on_complete` runs once
+/// with the completed segment direction.
 pub(crate) fn run_popover_animation(
     shell: &ScaleBox,
     anim_state: &Rc<RefCell<AnimState>>,
     anim_generation: &Rc<Cell<u32>>,
     generation: u32,
     direction: AnimDirection,
-    blur_target: Option<(glib::WeakRef<ApplicationWindow>, i32)>,
+    blur_target: Option<(
+        glib::WeakRef<ApplicationWindow>,
+        glib::WeakRef<gtk4::Widget>,
+    )>,
     on_complete: impl Fn(AnimDirection, &ScaleBox) + 'static,
 ) {
     let start_time_us = shell.frame_clock().map(|fc| fc.frame_time()).unwrap_or(0);
@@ -241,11 +244,12 @@ pub(crate) fn run_popover_animation(
             && ConfigManager::global().blur_enabled()
             && let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
-            && let Some((ref window_weak, blur_margin)) = blur_target
+            && let Some((ref window_weak, ref content_weak)) = blur_target
             && let Some(window) = window_weak.upgrade()
+            && let Some(content) = content_weak.upgrade()
         {
             // Match the blur to the quantized scale that ScaleBox renders.
-            blur.apply_open_animation_blur(&window, blur_margin, shell.scale(), complete);
+            blur.apply_open_animation_blur(&window, &content, shell.scale(), complete);
         }
 
         if complete {
@@ -527,6 +531,297 @@ where
         }
     });
     window.add_controller(key_controller);
+}
+
+const HEIGHT_FREEZE_DATA_KEY: &str = "vibepanel-surface-height-freeze";
+const HEIGHT_FREEZE_RELEASE_HOOK_KEY: &str = "vibepanel-surface-height-freeze-release-hook";
+
+/// Keeps a shrink-wrapped layer-shell surface at a constant height while child
+/// revealers animate. Expansion pins the final height; collapse pins the initial
+/// height, avoiding per-frame Wayland surface configures and buffer reallocations.
+struct SurfaceHeightFreeze {
+    window: glib::WeakRef<ApplicationWindow>,
+    blur_widget: glib::WeakRef<gtk4::Widget>,
+    active: RefCell<Vec<gtk4::Revealer>>,
+    frozen_height: Cell<i32>,
+    blur_generation: Cell<u32>,
+}
+
+impl SurfaceHeightFreeze {
+    fn new(window: &ApplicationWindow, blur_widget: &impl IsA<gtk4::Widget>) -> Rc<Self> {
+        Rc::new(Self {
+            window: window.downgrade(),
+            blur_widget: blur_widget.as_ref().downgrade(),
+            active: RefCell::new(Vec::new()),
+            frozen_height: Cell::new(0),
+            blur_generation: Cell::new(0),
+        })
+    }
+
+    fn begin_expand(self: &Rc<Self>, revealer: &gtk4::Revealer) {
+        if !ConfigManager::global().animations_enabled()
+            || self.active.borrow().iter().any(|active| active == revealer)
+        {
+            return;
+        }
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        if !window.is_mapped() {
+            return;
+        }
+        if revealer.child().is_none() {
+            return;
+        }
+        let Some(root) = window.child() else {
+            return;
+        };
+        let (root_min_width, _, _, _) = root.measure(Orientation::Horizontal, -1);
+
+        let mut revealers = self.active.borrow().clone();
+        revealers.push(revealer.clone());
+        let mut old_height_requests = Vec::with_capacity(revealers.len());
+        for active in revealers {
+            let Some(child) = active.child() else {
+                continue;
+            };
+            // Revealers retain their parent-allocated width while collapsed.
+            let (child_min_width, _, _, _) = child.measure(Orientation::Horizontal, -1);
+            let (_, child_nat, _, _) =
+                child.measure(Orientation::Vertical, active.width().max(child_min_width));
+            old_height_requests.push((active.clone(), active.height_request()));
+            active.set_height_request(child_nat);
+        }
+        let (_, target, _, _) =
+            root.measure(Orientation::Vertical, root.width().max(root_min_width));
+        for (active, request) in old_height_requests {
+            active.set_height_request(request);
+        }
+
+        // Active collapses may over-reserve space, but avoid another surface resize.
+        let target = target.max(self.frozen_height.get());
+        if target <= 0 {
+            return;
+        }
+
+        let first = self.active.borrow().is_empty();
+        self.active.borrow_mut().push(revealer.clone());
+        self.frozen_height.set(target);
+        self.apply(target);
+        if first {
+            self.start_blur_tracking();
+        }
+    }
+
+    fn begin_collapse(self: &Rc<Self>, revealer: &gtk4::Revealer) {
+        if !ConfigManager::global().animations_enabled()
+            || self.active.borrow().iter().any(|active| active == revealer)
+        {
+            return;
+        }
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        let current = window.height();
+        if current <= 0 {
+            return;
+        }
+
+        let first = self.active.borrow().is_empty();
+        self.active.borrow_mut().push(revealer.clone());
+        if first {
+            self.frozen_height.set(current);
+            self.apply(current);
+            self.start_blur_tracking();
+        }
+    }
+
+    fn apply(&self, height: i32) {
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        if let Some(widget) = window.child() {
+            // Match the content alignment to the layer-shell edge anchoring.
+            widget.set_valign(if popover_bar_edge() == Edge::Top {
+                gtk4::Align::Start
+            } else {
+                gtk4::Align::End
+            });
+        }
+        // This is a floor: excess stays transparent; shortages resize naturally.
+        window.set_size_request(-1, height);
+    }
+
+    fn end(self: &Rc<Self>, revealer: &gtk4::Revealer) {
+        let removed = {
+            let mut active = self.active.borrow_mut();
+            let old_len = active.len();
+            active.retain(|active| active != revealer);
+            active.len() != old_len
+        };
+        if !removed {
+            return;
+        }
+        if !self.active.borrow().is_empty() {
+            return;
+        }
+        self.release();
+        if !ConfigManager::global().blur_enabled() {
+            return;
+        }
+
+        let generation = self.blur_generation.get();
+        let weak_self = Rc::downgrade(self);
+        // Expansion needs an explicit final commit because releasing its equal
+        // height floor does not resize; collapse is corrected by the resize watcher.
+        glib::idle_add_local_once(move || {
+            let Some(freeze) = weak_self.upgrade() else {
+                return;
+            };
+            if freeze.blur_generation.get() != generation || !ConfigManager::global().blur_enabled()
+            {
+                return;
+            }
+            let (Some(window), Some(content)) =
+                (freeze.window.upgrade(), freeze.blur_widget.upgrade())
+            else {
+                return;
+            };
+            if let Some(blur) =
+                crate::services::background_effect::BackgroundEffectManager::global()
+            {
+                blur.apply_blur_surface(&window, &content, || {
+                    ConfigManager::global().surface_border_radius() as i32
+                });
+            }
+        });
+    }
+
+    fn clear(&self) {
+        self.active.borrow_mut().clear();
+        self.blur_generation
+            .set(self.blur_generation.get().wrapping_add(1));
+        self.release();
+    }
+
+    fn release(&self) {
+        self.frozen_height.set(0);
+        if let Some(window) = self.window.upgrade() {
+            window.set_size_request(-1, -1);
+            if let Some(widget) = window.child() {
+                widget.set_valign(gtk4::Align::Fill);
+            }
+        }
+    }
+
+    fn start_blur_tracking(self: &Rc<Self>) {
+        if !ConfigManager::global().blur_enabled() {
+            return;
+        }
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        let generation = self.blur_generation.get().wrapping_add(1);
+        self.blur_generation.set(generation);
+        let weak_self = Rc::downgrade(self);
+        window.add_tick_callback(move |_, _| {
+            let Some(freeze) = weak_self.upgrade() else {
+                return ControlFlow::Break;
+            };
+            if freeze.blur_generation.get() != generation || freeze.active.borrow().is_empty() {
+                return ControlFlow::Break;
+            }
+            freeze.apply_blur();
+            ControlFlow::Continue
+        });
+    }
+
+    fn apply_blur(&self) {
+        if !ConfigManager::global().blur_enabled() {
+            return;
+        }
+        let (Some(window), Some(content)) = (self.window.upgrade(), self.blur_widget.upgrade())
+        else {
+            return;
+        };
+        if let Some(blur) = crate::services::background_effect::BackgroundEffectManager::global() {
+            blur.apply_blur_region_animated(&window, &content, 1.0);
+        }
+    }
+}
+
+/// Install shared revealer surface-freeze handling on a popover window.
+pub(crate) fn install_surface_height_freeze(
+    window: &ApplicationWindow,
+    blur_widget: &impl IsA<gtk4::Widget>,
+) {
+    unsafe {
+        window.set_data(
+            HEIGHT_FREEZE_DATA_KEY,
+            SurfaceHeightFreeze::new(window, blur_widget),
+        );
+    }
+}
+
+fn surface_height_freeze_for(widget: &impl IsA<gtk4::Widget>) -> Option<Rc<SurfaceHeightFreeze>> {
+    let window = widget
+        .as_ref()
+        .root()?
+        .downcast::<ApplicationWindow>()
+        .ok()?;
+    unsafe {
+        window
+            .data::<Rc<SurfaceHeightFreeze>>(HEIGHT_FREEZE_DATA_KEY)
+            .map(|freeze| freeze.as_ref().clone())
+    }
+}
+
+pub(crate) fn clear_surface_height_freeze(window: &ApplicationWindow) {
+    unsafe {
+        if let Some(freeze) = window.data::<Rc<SurfaceHeightFreeze>>(HEIGHT_FREEZE_DATA_KEY) {
+            freeze.as_ref().clear();
+        }
+    }
+}
+
+/// Animate a revealer without resizing its layer-shell surface every frame.
+pub(crate) fn animate_reveal(revealer: &gtk4::Revealer, expanding: bool) {
+    if revealer.reveals_child() == expanding {
+        return;
+    }
+    if let Some(freeze) = surface_height_freeze_for(revealer) {
+        if expanding {
+            freeze.begin_expand(revealer);
+        } else {
+            freeze.begin_collapse(revealer);
+        }
+        ensure_height_freeze_release_hook(revealer, &freeze);
+    }
+    revealer.set_reveal_child(expanding);
+}
+
+fn ensure_height_freeze_release_hook(revealer: &gtk4::Revealer, freeze: &Rc<SurfaceHeightFreeze>) {
+    unsafe {
+        if revealer
+            .data::<bool>(HEIGHT_FREEZE_RELEASE_HOOK_KEY)
+            .is_some()
+        {
+            return;
+        }
+        revealer.set_data(HEIGHT_FREEZE_RELEASE_HOOK_KEY, true);
+    }
+    let weak_freeze = Rc::downgrade(freeze);
+    revealer.connect_child_revealed_notify(move |revealer| {
+        if let Some(freeze) = weak_freeze.upgrade() {
+            freeze.end(revealer);
+        }
+    });
+    let weak_freeze = Rc::downgrade(freeze);
+    revealer.connect_unmap(move |revealer| {
+        if let Some(freeze) = weak_freeze.upgrade() {
+            freeze.end(revealer);
+        }
+    });
 }
 
 /// A layer-shell popover for widget menus.
@@ -827,6 +1122,8 @@ impl LayerShellPopover {
             return;
         };
 
+        clear_surface_height_freeze(&window);
+
         // Release keyboard grab while hiding.
         window.set_keyboard_mode(KeyboardMode::None);
 
@@ -874,6 +1171,10 @@ impl LayerShellPopover {
         let Some(anim_shell) = self.anim_shell.borrow().as_ref().cloned() else {
             return;
         };
+
+        if let Some(ref window) = *self.window.borrow() {
+            clear_surface_height_freeze(window);
+        }
 
         anim_shell.remove_child();
 
@@ -1039,6 +1340,7 @@ impl LayerShellPopover {
             SurfaceStyleManager::global().apply_shadow_margins(&outer, POPOVER_SHADOW_MARGIN);
             outer.append(&anim_shell);
             window.set_child(Some(&outer));
+            install_surface_height_freeze(&window, &anim_shell);
         }
 
         // Restore keyboard mode (hide() sets it to None).
@@ -1163,12 +1465,11 @@ impl LayerShellPopover {
             });
         }
 
-        // Apply blur on every map (first show and re-show).  Close calls
+        // Apply blur on every map (first show and re-show). Close calls
         // set_visible(false) which unmaps the surface, so connect_map fires
-        // again when the window is re-shown.  On first map the surface has no
-        // size yet, so apply_blur_region defers via idle.  On re-show it sets
-        // the full-size region, which the animation tick overwrites with a
-        // scaled region within 1-2 frames.
+        // again when the window is re-shown. The content-bounds resize watcher
+        // handles first-map readiness. On re-show the animation tick overwrites
+        // the full-size region with a scaled region within 1-2 frames.
         //
         // The else-branch removes any stale protocol object left from a
         // previous map cycle.  This handles the case where blur was enabled
@@ -1179,12 +1480,17 @@ impl LayerShellPopover {
         // Known limitation: config changes to `theme.blur` or border radius
         // while the popover is open take effect on next open, not immediately.
         // Popovers grab focus so config edits are unlikely while open.
+        let weak_self = Rc::downgrade(self);
         window.connect_map(move |win| {
             if ConfigManager::global().blur_enabled() {
                 if let Some(blur) =
                     crate::services::background_effect::BackgroundEffectManager::global()
+                    && let Some(popover) = weak_self.upgrade()
+                    && let Some(anim_shell) = popover.anim_shell.borrow().as_ref().cloned()
                 {
-                    blur.apply_blur_region(win, POPOVER_SHADOW_MARGIN);
+                    blur.apply_blur_surface(win, &anim_shell, || {
+                        ConfigManager::global().surface_border_radius() as i32
+                    });
                 }
             } else if let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
@@ -1253,6 +1559,7 @@ impl LayerShellPopover {
 
         let window = self.window.borrow().as_ref().cloned();
         let window_for_complete = window.as_ref().map(|w| w.downgrade());
+        let blur_content = anim_shell.clone().upcast::<gtk4::Widget>().downgrade();
         let on_close = self.on_close.borrow().clone();
 
         run_popover_animation(
@@ -1261,9 +1568,7 @@ impl LayerShellPopover {
             &self.anim_generation,
             generation,
             direction,
-            window
-                .as_ref()
-                .map(|w| (w.downgrade(), POPOVER_SHADOW_MARGIN)),
+            window.as_ref().map(|w| (w.downgrade(), blur_content)),
             move |direction, shell| {
                 if direction == AnimDirection::Closing {
                     // Close complete — remove content and hide window.

--- a/crates/vibepanel/src/widgets/layer_shell_popover.rs
+++ b/crates/vibepanel/src/widgets/layer_shell_popover.rs
@@ -576,8 +576,6 @@ impl SurfaceHeightFreeze {
         let Some(root) = window.child() else {
             return;
         };
-        let (root_min_width, _, _, _) = root.measure(Orientation::Horizontal, -1);
-
         let mut revealers = self.active.borrow().clone();
         revealers.push(revealer.clone());
         let mut old_height_requests = Vec::with_capacity(revealers.len());
@@ -592,6 +590,7 @@ impl SurfaceHeightFreeze {
             old_height_requests.push((active.clone(), active.height_request()));
             active.set_height_request(child_nat);
         }
+        let (root_min_width, _, _, _) = root.measure(Orientation::Horizontal, -1);
         let (_, target, _, _) =
             root.measure(Orientation::Vertical, root.width().max(root_min_width));
         for (active, request) in old_height_requests {

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -453,7 +453,7 @@ fn build_notification_row(
 
         // Fade out the row content and collapse height via the Revealer
         card_for_dismiss.add_css_class(notif::ROW_DISMISSING);
-        revealer_for_dismiss.set_reveal_child(false);
+        crate::widgets::layer_shell_popover::animate_reveal(&revealer_for_dismiss, false);
 
         // Remove immediately when animations are disabled.
         let duration = if ConfigManager::global().animations_enabled() {

--- a/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/ui_helpers.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use crate::services::icons::{CairoSpinner, IconHandle, IconsService};
 use crate::styles::{button, color, icon, qs, row, state};
 use crate::widgets::base::add_ripple_to_row;
+use crate::widgets::layer_shell_popover::animate_reveal;
 use gtk4::pango::EllipsizeMode;
 use gtk4::prelude::*;
 use gtk4::{
@@ -401,7 +402,7 @@ impl AccordionManager {
                 accordion.collapse_others(revealer);
             }
 
-            revealer.set_reveal_child(expanding);
+            animate_reveal(revealer, expanding);
 
             if let Some(ref arrow) = arrow {
                 if expanding {

--- a/crates/vibepanel/src/widgets/quick_settings/vpn_card.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/vpn_card.rs
@@ -25,6 +25,7 @@ use crate::services::surfaces::SurfaceStyleManager;
 use crate::services::vpn::{VpnConnection, VpnService, VpnSnapshot};
 use crate::services::vpn_secret_agent::VpnAuthRequest;
 use crate::styles::{button, color, icon, qs, row, state};
+use crate::widgets::layer_shell_popover::animate_reveal;
 
 // Global state for VPN keyboard grab management.
 // Thread-local so it survives QS window hide/show cycles and bar teardown.
@@ -708,7 +709,7 @@ fn show_vpn_auth_dialog(state: &Rc<VpnCardState>, request: &VpnAuthRequest) {
 
     // Expand the VPN card revealer so the auth row is visible
     if let Some(revealer) = state.base.revealer.borrow().as_ref() {
-        revealer.set_reveal_child(true);
+        animate_reveal(revealer, true);
     }
     if let Some(arrow) = state.base.arrow.borrow().as_ref() {
         arrow.set_icon("pan-up-symbolic");

--- a/crates/vibepanel/src/widgets/quick_settings/window.rs
+++ b/crates/vibepanel/src/widgets/quick_settings/window.rs
@@ -31,11 +31,12 @@ use crate::services::updates::UpdatesService;
 use crate::services::vpn::VpnService;
 use crate::styles::{qs, state, surface};
 use crate::widgets::layer_shell_popover::{
-    ANIM_SCALE_FROM, AnimDirection, AnimState, Dismissible, PopoverAnchor,
+    ANIM_SCALE_FROM, AnimDirection, AnimState, Dismissible, PopoverAnchor, animate_reveal,
     calculate_bar_exclusive_zone, calculate_popover_bar_margin, calculate_popover_bottom_margin,
-    calculate_popover_right_margin, configure_popover_layer_anchors, create_click_catcher,
-    is_keynav_key, popover_bar_edge, popover_keyboard_mode, reset_popover_margins,
-    run_popover_animation, setup_esc_handler, snap_anim_shell,
+    calculate_popover_right_margin, clear_surface_height_freeze, configure_popover_layer_anchors,
+    create_click_catcher, install_surface_height_freeze, is_keynav_key, popover_bar_edge,
+    popover_keyboard_mode, reset_popover_margins, run_popover_animation, setup_esc_handler,
+    snap_anim_shell,
 };
 use crate::widgets::scale_box::ScaleBox;
 
@@ -283,6 +284,7 @@ impl QuickSettingsWindow {
 
         // Store outer container reference.
         *qs.outer_container.borrow_mut() = Some(outer.clone());
+        install_surface_height_freeze(&qs.window, &outer);
 
         // Apply Pango font attributes to all labels if enabled in config.
         // This is the central hook for quick settings - widgets create standard
@@ -302,10 +304,9 @@ impl QuickSettingsWindow {
             });
         }
 
-        // Apply blur when mapped.  On first map the surface has no size yet
-        // so apply_blur_region defers via idle.  On re-show, anim_shell is at
-        // opacity 0 (transparent) until the animation tick overwrites the region
-        // with a scaled version within 1-2 frames.
+        // Apply blur when mapped. The content-bounds resize watcher handles
+        // first-map readiness. On re-show, anim_shell is transparent until the
+        // animation tick overwrites the region with a scaled version.
         //
         // The else-branch removes any stale protocol object left from a
         // previous map cycle.  This handles the case where blur was enabled
@@ -316,12 +317,16 @@ impl QuickSettingsWindow {
         // Known limitation: config changes to `theme.blur` or border radius
         // while Quick Settings is open take effect on next open, not
         // immediately.  QS grabs focus so config edits are unlikely while open.
+        let outer_weak = outer.downgrade();
         window.connect_map(move |win| {
             if ConfigManager::global().blur_enabled() {
                 if let Some(blur) =
                     crate::services::background_effect::BackgroundEffectManager::global()
+                    && let Some(outer) = outer_weak.upgrade()
                 {
-                    blur.apply_blur_region(win, QUICK_SETTINGS_OUTER_MARGIN);
+                    blur.apply_blur_surface(win, &outer, || {
+                        ConfigManager::global().surface_border_radius() as i32
+                    });
                 }
             } else if let Some(blur) =
                 crate::services::background_effect::BackgroundEffectManager::global()
@@ -1067,7 +1072,7 @@ impl QuickSettingsWindow {
             let arrow = audio_widgets.arrow_handle.clone();
             audio_widgets.expander_button.connect_clicked(move |_| {
                 let expanding = !revealer.reveals_child();
-                revealer.set_reveal_child(expanding);
+                animate_reveal(&revealer, expanding);
                 if expanding {
                     arrow.widget().add_css_class(state::EXPANDED);
                 } else {
@@ -1163,7 +1168,7 @@ impl QuickSettingsWindow {
             let arrow = mic_widgets.arrow_handle.clone();
             mic_widgets.expander_button.connect_clicked(move |_| {
                 let expanding = !revealer.reveals_child();
-                revealer.set_reveal_child(expanding);
+                animate_reveal(&revealer, expanding);
                 if expanding {
                     arrow.widget().add_css_class(state::EXPANDED);
                 } else {
@@ -1632,6 +1637,10 @@ impl QuickSettingsWindow {
         // Restore keyboard mode if it was released for VPN password dialogs
         vpn_card::restore_keyboard_if_released();
 
+        // Drop any in-flight surface height freeze so the hidden window
+        // returns to natural sizing for the next open.
+        clear_surface_height_freeze(&self.window);
+
         // Clear the global QS window reference so card-level actions
         // (e.g., show_wifi_password_dialog) don't fire while hidden.
         clear_current_qs_window();
@@ -1713,6 +1722,11 @@ impl QuickSettingsWindow {
     /// that point with proportional timing — no snapping.
     fn start_animation(&self, direction: AnimDirection, generation: u32) {
         let window_weak = self.window.downgrade();
+        let blur_content = self
+            .outer_container
+            .borrow()
+            .as_ref()
+            .map(|outer| outer.clone().upcast::<gtk4::Widget>().downgrade());
 
         run_popover_animation(
             &self.anim_shell,
@@ -1720,7 +1734,7 @@ impl QuickSettingsWindow {
             &self.anim_generation,
             generation,
             direction,
-            Some((self.window.downgrade(), QUICK_SETTINGS_OUTER_MARGIN)),
+            blur_content.map(|content| (self.window.downgrade(), content)),
             move |direction, shell| {
                 if direction == AnimDirection::Closing {
                     snap_anim_shell(shell, 0.0, ANIM_SCALE_FROM);

--- a/crates/vibepanel/src/widgets/system_popover.rs
+++ b/crates/vibepanel/src/widgets/system_popover.rs
@@ -36,6 +36,7 @@ use crate::services::gpu::{GpuService, GpuSnapshot};
 use crate::services::icons::{IconHandle, IconsService};
 use crate::services::system::{SystemService, SystemSnapshot, format_bytes_long, format_speed};
 use crate::styles::{button, card, color, icon, surface, system_popover as sp};
+use crate::widgets::layer_shell_popover::animate_reveal;
 
 /// A single pre-allocated per-core row with its updatable widgets.
 #[derive(Clone)]
@@ -182,7 +183,7 @@ impl SystemPopoverController {
     fn toggle_cores(&self) {
         let expanded = !self.cores_expanded.get();
         self.cores_expanded.set(expanded);
-        self.cores_revealer.set_reveal_child(expanded);
+        animate_reveal(&self.cores_revealer, expanded);
 
         let chevron = if expanded {
             "pan-up-symbolic"


### PR DESCRIPTION
Expanding menus inside popovers resizes the layer shell surface every frame, this made quick settings feel laggy on low power devices. 

This PR freezes the surface at its post-animation size during expansion and its current size during collapse and avoids a resize on every frame. It also simplifies blur handling and fixes a Hyprland animation issue