### PR TITLE
fix(theme): make sure no gtk chrome leaks for sliders/bars

### DIFF
--- a/crates/vibepanel/src/services/icons.rs
+++ b/crates/vibepanel/src/services/icons.rs
@@ -1288,16 +1288,26 @@ pub fn get_app_icon_name(app_id: &str) -> String {
 /// # Returns
 /// The resolved icon name, or the fallback if no icon could be found.
 pub fn resolve_app_icon_name(app_id: &str, fallback: &str) -> String {
+    resolve_app_icon_name_with(app_id, fallback, |name| {
+        let Some(display) = gtk4::gdk::Display::default() else {
+            return false;
+        };
+        IconTheme::for_display(&display).has_icon(name)
+    })
+}
+
+fn resolve_app_icon_name_with(
+    app_id: &str,
+    fallback: &str,
+    has_icon: impl FnOnce(&str) -> bool,
+) -> String {
     let icon_name = get_app_icon_name(app_id);
     if !icon_name.is_empty() {
         return icon_name;
     }
     // Try the app_id directly as an icon name (some apps use their name)
-    if let Some(display) = gtk4::gdk::Display::default() {
-        let icon_theme = IconTheme::for_display(&display);
-        if icon_theme.has_icon(app_id) {
-            return app_id.to_string();
-        }
+    if has_icon(app_id) {
+        return app_id.to_string();
     }
     fallback.to_string()
 }
@@ -2486,9 +2496,10 @@ mod tests {
     #[test]
     fn resolve_app_icon_name_falls_back_without_matching_icon() {
         assert_eq!(
-            resolve_app_icon_name(
+            resolve_app_icon_name_with(
                 "vibepanel-test-definitely-missing-application",
-                "audio-x-generic"
+                "audio-x-generic",
+                |_| false,
             ),
             "audio-x-generic"
         );

--- a/crates/vibepanel/src/widgets/css/base.rs
+++ b/crates/vibepanel/src/widgets/css/base.rs
@@ -23,6 +23,27 @@ pub fn css(animations: bool) -> String {
         r#"
 /* ===== SHARED UTILITY CSS ===== */
 
+scale > trough {{
+    border: none;
+    outline: none;
+    box-shadow: none;
+    background-image: none;
+}}
+
+scale > trough > highlight,
+scale > trough > fill {{
+    margin: 0;
+    border: none;
+    box-shadow: none;
+    background-image: none;
+}}
+
+scale > trough > slider {{
+    border: none;
+    box-shadow: none;
+    background-image: none;
+}}
+
 /* Layer-shell popover window - transparent so content can have proper shadow */
 window.layer-shell-popover {{
     background: transparent;
@@ -533,4 +554,24 @@ button:hover {{
 }}
 "#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::css;
+
+    #[test]
+    fn scales_clear_gtk_theme_chrome() {
+        let css = css(false);
+
+        assert!(css.contains(
+            "scale > trough {\n    border: none;\n    outline: none;\n    box-shadow: none;\n    background-image: none;\n}"
+        ));
+        assert!(css.contains(
+            "scale > trough > highlight,\nscale > trough > fill {\n    margin: 0;\n    border: none;\n    box-shadow: none;\n    background-image: none;\n}"
+        ));
+        assert!(css.contains(
+            "scale > trough > slider {\n    border: none;\n    box-shadow: none;\n    background-image: none;\n}"
+        ));
+    }
 }

--- a/crates/vibepanel/src/widgets/css/system.rs
+++ b/crates/vibepanel/src/widgets/css/system.rs
@@ -34,6 +34,9 @@ pub fn css() -> &'static str {
 .system-progress-bar trough,
 .system-core-bar trough {
     background-color: var(--color-slider-track);
+    background-image: none;
+    border: none;
+    box-shadow: none;
     border-radius: var(--slider-radius);
     min-height: var(--slider-height);
 }
@@ -41,6 +44,10 @@ pub fn css() -> &'static str {
 .system-progress-bar trough progress,
 .system-core-bar trough progress {
     background-color: var(--color-accent-slider, var(--color-accent-primary));
+    background-image: none;
+    border: none;
+    box-shadow: none;
+    margin: 0;
     border-radius: var(--slider-radius);
     min-height: var(--slider-height);
 }
@@ -80,4 +87,23 @@ button.system-expander-header > overlay > box {
 .system-gpu-metrics {
 }
 "#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::css;
+
+    #[test]
+    fn progress_bars_clear_gtk_theme_chrome() {
+        let css = css();
+
+        for property in [
+            "background-image: none;",
+            "border: none;",
+            "box-shadow: none;",
+        ] {
+            assert_eq!(css.matches(property).count(), 2);
+        }
+        assert!(css.contains("margin: 0;"));
+    }
 }


### PR DESCRIPTION
Some GTK themes have styling for bars and sliders that would leak through to VibePanel which was never intended. I didnt know about it because my theme wasnt one of them.

Left is how it looks with those themes, right is how I intend for it to look and how it looks after this PR.

<img width="275" height="185" alt="image" src="https://github.com/user-attachments/assets/ca3abd52-5efa-4765-aecf-114536a4467b" />
<img width="275" height="185" alt="image" src="https://github.com/user-attachments/assets/7b2e5c20-fb59-413d-b696-06b27aab0511" />
<img width="285" height="155" alt="image" src="https://github.com/user-attachments/assets/552821de-2882-49d2-b345-9823cbd7b366" />
<img width="285" height="155" alt="image" src="https://github.com/user-attachments/assets/617a14d4-b8b2-4b14-bc19-134af49b9ae0" />
