### PR TITLE
Notification activiationToken

### DIFF
--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -23,9 +23,10 @@
 //! - **sleep_watcher**: Shared resume-from-sleep notifications via logind
 //! - **weather**: Open-Meteo-backed weather and forecast data
 
-pub mod activation;
+mod wayland;
+pub use wayland::{activation, background_effect};
+
 pub mod audio;
-pub mod background_effect;
 pub mod bar_manager;
 pub mod battery;
 pub mod battery_alert;

--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -23,6 +23,7 @@
 //! - **sleep_watcher**: Shared resume-from-sleep notifications via logind
 //! - **weather**: Open-Meteo-backed weather and forecast data
 
+pub mod activation;
 pub mod audio;
 pub mod background_effect;
 pub mod bar_manager;

--- a/crates/vibepanel/src/services/activation.rs
+++ b/crates/vibepanel/src/services/activation.rs
@@ -1,0 +1,431 @@
+//! XDG activation token service.
+//!
+//! Creates `xdg_activation_v1` tokens for the notifications D-Bus
+//! `ActivationToken` signal, so that clicking a notification lets the target
+//! app (e.g. Firefox) raise its window with compositor blessing.
+//!
+//! Why not GDK's `AppLaunchContext::startup_notify_id()`? GTK only attaches a
+//! *surface* to the token when one of our windows has **keyboard** focus. The
+//! notification toast runs with `KeyboardMode::None`, so GDK produces a token
+//! carrying just a serial. wlroots-derived compositors (dwl/Mango) refuse to
+//! activate on tokens without a surface, and niri wants a fresh input serial.
+//! A token carrying **both** the clicked surface and the click serial
+//! satisfies every compositor.
+//!
+//! To know the serial and surface of the most recent input event we bind our
+//! own `wl_seat` (a client may bind the seat several times; the compositor
+//! mirrors input events to every binding), sharing GDK's connection the same
+//! way `background_effect.rs` does.
+
+use std::cell::RefCell;
+use std::os::fd::{AsFd, AsRawFd};
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::Cast;
+use tracing::{debug, warn};
+use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
+use wayland_client::protocol::wl_pointer::{self, WlPointer};
+use wayland_client::protocol::wl_registry;
+use wayland_client::protocol::wl_seat::{self, Capability as SeatCapability, WlSeat};
+use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::protocol::wl_touch::{self, WlTouch};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum};
+use wayland_protocols::xdg::activation::v1::client::{
+    xdg_activation_token_v1::{self, XdgActivationTokenV1},
+    xdg_activation_v1::XdgActivationV1,
+};
+
+/// Internal wayland-client dispatch state.
+struct ActivationState {
+    activation: Option<XdgActivationV1>,
+    /// first advertised seat only; multi-seat setups are unicorns.
+    seat: Option<WlSeat>,
+    pointer: Option<WlPointer>,
+    keyboard: Option<WlKeyboard>,
+    touch: Option<WlTouch>,
+    /// Surface currently under the pointer / holding keyboard focus (ours only).
+    pointer_surface: Option<WlSurface>,
+    keyboard_surface: Option<WlSurface>,
+    /// Serial + surface of the most recent input event that carried a serial.
+    last_input: Option<(u32, WlSurface)>,
+    /// Token string delivered by the compositor for an in-flight request.
+    pending_token: Option<String>,
+}
+
+impl ActivationState {
+    fn new() -> Self {
+        Self {
+            activation: None,
+            seat: None,
+            pointer: None,
+            keyboard: None,
+            touch: None,
+            pointer_surface: None,
+            keyboard_surface: None,
+            last_input: None,
+            pending_token: None,
+        }
+    }
+
+    fn record_input(&mut self, serial: u32, surface: Option<&WlSurface>) {
+        if let Some(surface) = surface {
+            self.last_input = Some((serial, surface.clone()));
+        }
+    }
+
+    fn forget_surface(&mut self, surface: &WlSurface) {
+        if self
+            .last_input
+            .as_ref()
+            .is_some_and(|(_, remembered)| remembered == surface)
+        {
+            self.last_input = None;
+        }
+    }
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "xdg_activation_v1" => {
+                    state.activation = Some(registry.bind(name, 1, qh, ()));
+                }
+                "wl_seat" if state.seat.is_none() => {
+                    let seat: WlSeat = registry.bind(name, version.min(5), qh, ());
+                    state.seat = Some(seat);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<XdgActivationV1, ()> for ActivationState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &XdgActivationV1,
+        _event: <XdgActivationV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        // xdg_activation_v1 has no events.
+    }
+}
+
+impl Dispatch<XdgActivationTokenV1, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        _proxy: &XdgActivationTokenV1,
+        event: xdg_activation_token_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let xdg_activation_token_v1::Event::Done { token } = event {
+            state.pending_token = Some(token);
+        }
+    }
+}
+
+impl Dispatch<WlSeat, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        seat: &WlSeat,
+        event: wl_seat::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_seat::Event::Capabilities {
+            capabilities: WEnum::Value(caps),
+        } = event
+        {
+            if caps.contains(SeatCapability::Pointer) {
+                if state.pointer.is_none() {
+                    state.pointer = Some(seat.get_pointer(qh, ()));
+                }
+            } else if let Some(pointer) = state.pointer.take() {
+                pointer.release();
+                if let Some(surface) = state.pointer_surface.take() {
+                    state.forget_surface(&surface);
+                }
+            }
+            if caps.contains(SeatCapability::Keyboard) {
+                if state.keyboard.is_none() {
+                    state.keyboard = Some(seat.get_keyboard(qh, ()));
+                }
+            } else if let Some(keyboard) = state.keyboard.take() {
+                keyboard.release();
+                if let Some(surface) = state.keyboard_surface.take() {
+                    state.forget_surface(&surface);
+                }
+            }
+            if caps.contains(SeatCapability::Touch) {
+                if state.touch.is_none() {
+                    state.touch = Some(seat.get_touch(qh, ()));
+                }
+            } else if let Some(touch) = state.touch.take() {
+                touch.release();
+            }
+        }
+    }
+}
+
+impl Dispatch<WlPointer, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlPointer,
+        event: wl_pointer::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_pointer::Event::Enter { surface, .. } => {
+                state.pointer_surface = Some(surface);
+            }
+            wl_pointer::Event::Leave { surface, .. } => {
+                state.forget_surface(&surface);
+                state.pointer_surface = None;
+            }
+            wl_pointer::Event::Button { serial, .. } => {
+                let surface = state.pointer_surface.clone();
+                state.record_input(serial, surface.as_ref());
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<WlKeyboard, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlKeyboard,
+        event: wl_keyboard::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_keyboard::Event::Enter { surface, .. } => {
+                state.keyboard_surface = Some(surface);
+            }
+            wl_keyboard::Event::Leave { surface, .. } => {
+                state.forget_surface(&surface);
+                state.keyboard_surface = None;
+            }
+            wl_keyboard::Event::Key { serial, .. } => {
+                let surface = state.keyboard_surface.clone();
+                state.record_input(serial, surface.as_ref());
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<WlTouch, ()> for ActivationState {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlTouch,
+        event: wl_touch::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let wl_touch::Event::Down {
+            serial, surface, ..
+        } = event
+        {
+            state.record_input(serial, Some(&surface));
+        }
+    }
+}
+
+// Thread-local singleton.
+
+thread_local! {
+    static INSTANCE: RefCell<Option<Rc<ActivationService>>> = const { RefCell::new(None) };
+}
+
+/// Creates xdg-activation tokens bound to the last input event on our surfaces.
+pub struct ActivationService {
+    state: RefCell<ActivationState>,
+    event_queue: RefCell<EventQueue<ActivationState>>,
+    qh: QueueHandle<ActivationState>,
+}
+
+impl ActivationService {
+    /// Initialize the global singleton.
+    ///
+    /// Must be called on the main thread after the GDK display exists. If the
+    /// compositor lacks `xdg_activation_v1` the singleton stays `None`.
+    pub fn init_global() {
+        INSTANCE.with(|cell| {
+            if cell.borrow().is_some() {
+                return;
+            }
+            let svc = Self::try_init();
+            *cell.borrow_mut() = svc.map(Rc::new);
+        });
+    }
+
+    /// Get a reference to the global service, if available.
+    pub fn global() -> Option<Rc<Self>> {
+        INSTANCE.with(|cell| cell.borrow().clone())
+    }
+
+    fn try_init() -> Option<Self> {
+        let gdk_display = gtk4::gdk::Display::default()?;
+        let wayland_display = gdk_display
+            .downcast::<gdk4_wayland::WaylandDisplay>()
+            .ok()?;
+
+        if !wayland_display.query_registry("xdg_activation_v1") {
+            debug!("Compositor does not advertise xdg_activation_v1, activation tokens disabled");
+            return None;
+        }
+
+        // Reuse GDK's connection; see BackgroundEffectManager for why a
+        // separate Backend must not be created.
+        let wl_display = wayland_display.wl_display()?;
+        let backend = wl_display.backend().upgrade()?;
+        let connection = Connection::from_backend(backend);
+
+        let mut event_queue: EventQueue<ActivationState> = connection.new_event_queue();
+        let qh = event_queue.handle();
+        let display = connection.display();
+        let _registry = display.get_registry(&qh, ());
+
+        let mut state = ActivationState::new();
+        // Two roundtrips: discover globals, then let the seat's `capabilities`
+        // event (triggered by the bind) arrive.
+        for _ in 0..2 {
+            if let Err(e) = event_queue.roundtrip(&mut state) {
+                warn!("Activation service roundtrip failed: {e}");
+                return None;
+            }
+        }
+        let _ = event_queue.flush();
+
+        if state.activation.is_none() || state.seat.is_none() {
+            debug!("xdg_activation_v1 or wl_seat not bound, activation tokens disabled");
+            return None;
+        }
+
+        debug!("Activation token service initialized");
+
+        let svc = Self {
+            state: RefCell::new(state),
+            event_queue: RefCell::new(event_queue),
+            qh,
+        };
+        svc.install_event_dispatch();
+        Some(svc)
+    }
+
+    /// Install a glib fd watcher to dispatch wayland events for our queue.
+    ///
+    /// Input events mirrored to our seat binding land in this queue whenever
+    /// the socket is read; draining them keeps the serial fresh and the buffer
+    /// bounded.
+    fn install_event_dispatch(&self) {
+        let raw_fd = self.event_queue.borrow().as_fd().as_raw_fd();
+
+        glib::unix_fd_add_local(raw_fd, glib::IOCondition::IN, move |_fd, _cond| {
+            INSTANCE.with(|cell| {
+                let borrow = cell.borrow();
+                let Some(svc) = borrow.as_ref() else {
+                    return glib::ControlFlow::Break;
+                };
+
+                let mut eq = svc.event_queue.borrow_mut();
+                let mut st = svc.state.borrow_mut();
+
+                if let Err(e) = eq.dispatch_pending(&mut *st) {
+                    warn!("Activation event dispatch error: {e}");
+                    return glib::ControlFlow::Continue;
+                }
+
+                if let Some(guard) = eq.prepare_read() {
+                    match guard.read() {
+                        Ok(_) => {
+                            let _ = eq.dispatch_pending(&mut *st);
+                        }
+                        Err(wayland_client::backend::WaylandError::Io(io_err))
+                            if io_err.kind() == std::io::ErrorKind::WouldBlock => {}
+                        Err(e) => {
+                            warn!("Activation wayland read error: {e}");
+                        }
+                    }
+                }
+
+                let _ = eq.flush();
+                glib::ControlFlow::Continue
+            })
+        });
+    }
+
+    /// Create an activation token tied to the most recent actionable input
+    /// event on one of our surfaces (the notification click that got us here).
+    ///
+    /// Returns `None` if no input has been observed yet or the compositor
+    /// never answers.
+    ///
+    /// This must be called synchronously from a handler for real user input.
+    /// GDK owns the recorded surfaces, so their liveness cannot be validated.
+    pub fn create_token(&self) -> Option<String> {
+        let mut eq = self.event_queue.borrow_mut();
+        let mut state = self.state.borrow_mut();
+
+        // Drain anything buffered so the click that triggered this call is in.
+        if let Err(e) = eq.dispatch_pending(&mut *state) {
+            warn!("Activation dispatch_pending failed: {e}");
+        }
+
+        let activation = state.activation.clone()?;
+        let seat = state.seat.clone()?;
+        let (serial, surface) = state.last_input.take()?;
+
+        state.pending_token = None;
+        let token = activation.get_activation_token(&self.qh, ());
+        token.set_serial(serial, &seat);
+        token.set_surface(&surface);
+        token.commit();
+
+        // One roundtrip normally suffices; the compositor sends `done` while
+        // processing the commit. Cap at 2 to stay bounded.
+        for _ in 0..2 {
+            if let Err(e) = eq.roundtrip(&mut *state) {
+                warn!("Activation token roundtrip failed: {e}");
+                break;
+            }
+            if state.pending_token.is_some() {
+                break;
+            }
+        }
+        token.destroy();
+
+        let result = state.pending_token.take();
+        debug!(
+            "Activation token created (serial={}, got_token={})",
+            serial,
+            result.is_some()
+        );
+        result.filter(|t| !t.is_empty())
+    }
+}

--- a/crates/vibepanel/src/services/notification.rs
+++ b/crates/vibepanel/src/services/notification.rs
@@ -57,6 +57,10 @@ const NOTIFICATIONS_XML: &str = r#"
       <arg name="id" type="u"/>
       <arg name="action_key" type="s"/>
     </signal>
+    <signal name="ActivationToken">
+      <arg name="id" type="u"/>
+      <arg name="activation_token" type="s"/>
+    </signal>
   </interface>
   <interface name="io.github.vibepanel.Notifications1">
     <method name="GetUnreadCount">
@@ -249,6 +253,9 @@ impl NotificationService {
             ready: Cell::new(false),
         });
 
+        // Initialize the xdg-activation token service used by the
+        // notifications ActivationToken D-Bus signal.
+        super::activation::ActivationService::init_global();
         Self::init_dbus(&service);
         service
     }
@@ -463,6 +470,10 @@ impl NotificationService {
         );
         if !self.notifications.borrow().contains_key(&id) {
             return;
+        }
+
+        if let Some(token) = Self::create_activation_token() {
+            self.emit_activation_token(id, &token);
         }
 
         self.emit_action_invoked(id, action_key);
@@ -880,7 +891,7 @@ impl NotificationService {
                 "vibepanel", // name
                 "vibepanel", // vendor
                 "1.0",       // version
-                "1.2",       // spec version
+                "1.2",       // Desktop Notifications spec version
             )
                 .to_variant(),
         ));
@@ -943,6 +954,26 @@ impl NotificationService {
                 "NotificationService: failed to emit NotificationClosed: {}",
                 e
             );
+        }
+    }
+
+    fn create_activation_token() -> Option<String> {
+        super::activation::ActivationService::global()?.create_token()
+    }
+
+    fn emit_activation_token(&self, id: u32, token: &str) {
+        let Some(ref bus) = *self.bus.borrow() else {
+            return;
+        };
+
+        if let Err(e) = bus.emit_signal(
+            None::<&str>,
+            NOTIFICATIONS_PATH,
+            NOTIFICATIONS_NAME,
+            "ActivationToken",
+            Some(&(id, token).to_variant()),
+        ) {
+            error!("NotificationService: failed to emit ActivationToken: {}", e);
         }
     }
 
@@ -1120,6 +1151,13 @@ mod tests {
             .lookup_interface(VIBEPANEL_NOTIFICATIONS_INTERFACE)
             .unwrap();
         assert!(interface.lookup_method(UNREAD_METHOD).is_some());
+    }
+
+    #[test]
+    fn activation_token_signal_is_exposed() {
+        let node_info = gio::DBusNodeInfo::for_xml(NOTIFICATIONS_XML).unwrap();
+        let interface = node_info.lookup_interface(NOTIFICATIONS_NAME).unwrap();
+        assert!(interface.lookup_signal("ActivationToken").is_some());
     }
 
     /// Mirror of the post-insert tail in handle_notify, which we can't call

--- a/crates/vibepanel/src/services/wayland/activation.rs
+++ b/crates/vibepanel/src/services/wayland/activation.rs
@@ -18,23 +18,23 @@
 //! way `background_effect.rs` does.
 
 use std::cell::RefCell;
-use std::os::fd::{AsFd, AsRawFd};
 use std::rc::Rc;
 
-use gtk4::glib;
-use gtk4::prelude::Cast;
+use gtk4::prelude::{Cast, SurfaceExt};
 use tracing::{debug, warn};
+use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
 use wayland_client::protocol::wl_pointer::{self, WlPointer};
 use wayland_client::protocol::wl_registry;
 use wayland_client::protocol::wl_seat::{self, Capability as SeatCapability, WlSeat};
-use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::protocol::wl_touch::{self, WlTouch};
 use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum};
 use wayland_protocols::xdg::activation::v1::client::{
     xdg_activation_token_v1::{self, XdgActivationTokenV1},
     xdg_activation_v1::XdgActivationV1,
 };
+
+use super::{SurfaceInfo, connection_from_gdk_display, install_event_dispatch};
 
 /// Internal wayland-client dispatch state.
 struct ActivationState {
@@ -44,11 +44,11 @@ struct ActivationState {
     pointer: Option<WlPointer>,
     keyboard: Option<WlKeyboard>,
     touch: Option<WlTouch>,
-    /// Surface currently under the pointer / holding keyboard focus (ours only).
-    pointer_surface: Option<WlSurface>,
-    keyboard_surface: Option<WlSurface>,
-    /// Serial + surface of the most recent input event that carried a serial.
-    last_input: Option<(u32, WlSurface)>,
+    /// Identity of the surface under the pointer / holding keyboard focus.
+    pointer_surface: Option<ObjectId>,
+    keyboard_surface: Option<ObjectId>,
+    /// Serial + surface identity of the most recent actionable input event.
+    last_input: Option<(u32, ObjectId)>,
     /// Token string delivered by the compositor for an in-flight request.
     pending_token: Option<String>,
 }
@@ -68,21 +68,32 @@ impl ActivationState {
         }
     }
 
-    fn record_input(&mut self, serial: u32, surface: Option<&WlSurface>) {
-        if let Some(surface) = surface {
-            self.last_input = Some((serial, surface.clone()));
+    fn record_input(&mut self, serial: u32, surface_id: Option<ObjectId>) {
+        if let Some(surface_id) = surface_id {
+            self.last_input = Some((serial, surface_id));
         }
     }
 
-    fn forget_surface(&mut self, surface: &WlSurface) {
+    fn forget_surface(&mut self, surface_id: &ObjectId) {
         if self
             .last_input
             .as_ref()
-            .is_some_and(|(_, remembered)| remembered == surface)
+            .is_some_and(|(_, remembered)| remembered == surface_id)
         {
             self.last_input = None;
         }
     }
+}
+
+// GDK-owned foreign proxies do not provide reliable wayland-client liveness
+// tracking. Keep only their ObjectId in state, then resolve a fresh proxy from
+// a live GDK toplevel immediately before issuing the activation request.
+fn live_surface(surface_id: &ObjectId) -> Option<SurfaceInfo> {
+    gtk4::Window::list_toplevels()
+        .into_iter()
+        .filter_map(|widget| SurfaceInfo::from_widget(&widget))
+        .filter(|surface| !surface.wayland_surface.is_destroyed())
+        .find(|surface| surface.surface_id.eq(surface_id))
 }
 
 impl Dispatch<wl_registry::WlRegistry, ()> for ActivationState {
@@ -161,8 +172,8 @@ impl Dispatch<WlSeat, ()> for ActivationState {
                 }
             } else if let Some(pointer) = state.pointer.take() {
                 pointer.release();
-                if let Some(surface) = state.pointer_surface.take() {
-                    state.forget_surface(&surface);
+                if let Some(surface_id) = state.pointer_surface.take() {
+                    state.forget_surface(&surface_id);
                 }
             }
             if caps.contains(SeatCapability::Keyboard) {
@@ -171,8 +182,8 @@ impl Dispatch<WlSeat, ()> for ActivationState {
                 }
             } else if let Some(keyboard) = state.keyboard.take() {
                 keyboard.release();
-                if let Some(surface) = state.keyboard_surface.take() {
-                    state.forget_surface(&surface);
+                if let Some(surface_id) = state.keyboard_surface.take() {
+                    state.forget_surface(&surface_id);
                 }
             }
             if caps.contains(SeatCapability::Touch) {
@@ -197,15 +208,14 @@ impl Dispatch<WlPointer, ()> for ActivationState {
     ) {
         match event {
             wl_pointer::Event::Enter { surface, .. } => {
-                state.pointer_surface = Some(surface);
+                state.pointer_surface = Some(surface.id());
             }
             wl_pointer::Event::Leave { surface, .. } => {
-                state.forget_surface(&surface);
+                state.forget_surface(&surface.id());
                 state.pointer_surface = None;
             }
             wl_pointer::Event::Button { serial, .. } => {
-                let surface = state.pointer_surface.clone();
-                state.record_input(serial, surface.as_ref());
+                state.record_input(serial, state.pointer_surface.clone());
             }
             _ => {}
         }
@@ -223,15 +233,14 @@ impl Dispatch<WlKeyboard, ()> for ActivationState {
     ) {
         match event {
             wl_keyboard::Event::Enter { surface, .. } => {
-                state.keyboard_surface = Some(surface);
+                state.keyboard_surface = Some(surface.id());
             }
             wl_keyboard::Event::Leave { surface, .. } => {
-                state.forget_surface(&surface);
+                state.forget_surface(&surface.id());
                 state.keyboard_surface = None;
             }
             wl_keyboard::Event::Key { serial, .. } => {
-                let surface = state.keyboard_surface.clone();
-                state.record_input(serial, surface.as_ref());
+                state.record_input(serial, state.keyboard_surface.clone());
             }
             _ => {}
         }
@@ -251,7 +260,7 @@ impl Dispatch<WlTouch, ()> for ActivationState {
             serial, surface, ..
         } = event
         {
-            state.record_input(serial, Some(&surface));
+            state.record_input(serial, Some(surface.id()));
         }
     }
 }
@@ -264,15 +273,17 @@ thread_local! {
 
 /// Creates xdg-activation tokens bound to the last input event on our surfaces.
 pub struct ActivationService {
-    state: RefCell<ActivationState>,
-    event_queue: RefCell<EventQueue<ActivationState>>,
+    state: Rc<RefCell<ActivationState>>,
+    event_queue: Rc<RefCell<EventQueue<ActivationState>>>,
     qh: QueueHandle<ActivationState>,
 }
 
 impl ActivationService {
     /// Initialize the global singleton.
     ///
-    /// Must be called on the main thread after the GDK display exists. If the
+    /// Must be called on the main thread after the GDK display exists.
+    /// Initializing before notification UI is shown ensures the private seat
+    /// binding observes the relevant surface focus and input events. If the
     /// compositor lacks `xdg_activation_v1` the singleton stays `None`.
     pub fn init_global() {
         INSTANCE.with(|cell| {
@@ -300,11 +311,7 @@ impl ActivationService {
             return None;
         }
 
-        // Reuse GDK's connection; see BackgroundEffectManager for why a
-        // separate Backend must not be created.
-        let wl_display = wayland_display.wl_display()?;
-        let backend = wl_display.backend().upgrade()?;
-        let connection = Connection::from_backend(backend);
+        let connection = connection_from_gdk_display(&wayland_display)?;
 
         let mut event_queue: EventQueue<ActivationState> = connection.new_event_queue();
         let qh = event_queue.handle();
@@ -330,64 +337,23 @@ impl ActivationService {
         debug!("Activation token service initialized");
 
         let svc = Self {
-            state: RefCell::new(state),
-            event_queue: RefCell::new(event_queue),
+            state: Rc::new(RefCell::new(state)),
+            event_queue: Rc::new(RefCell::new(event_queue)),
             qh,
         };
-        svc.install_event_dispatch();
+        install_event_dispatch(&svc.event_queue, &svc.state, "Activation");
         Some(svc)
-    }
-
-    /// Install a glib fd watcher to dispatch wayland events for our queue.
-    ///
-    /// Input events mirrored to our seat binding land in this queue whenever
-    /// the socket is read; draining them keeps the serial fresh and the buffer
-    /// bounded.
-    fn install_event_dispatch(&self) {
-        let raw_fd = self.event_queue.borrow().as_fd().as_raw_fd();
-
-        glib::unix_fd_add_local(raw_fd, glib::IOCondition::IN, move |_fd, _cond| {
-            INSTANCE.with(|cell| {
-                let borrow = cell.borrow();
-                let Some(svc) = borrow.as_ref() else {
-                    return glib::ControlFlow::Break;
-                };
-
-                let mut eq = svc.event_queue.borrow_mut();
-                let mut st = svc.state.borrow_mut();
-
-                if let Err(e) = eq.dispatch_pending(&mut *st) {
-                    warn!("Activation event dispatch error: {e}");
-                    return glib::ControlFlow::Continue;
-                }
-
-                if let Some(guard) = eq.prepare_read() {
-                    match guard.read() {
-                        Ok(_) => {
-                            let _ = eq.dispatch_pending(&mut *st);
-                        }
-                        Err(wayland_client::backend::WaylandError::Io(io_err))
-                            if io_err.kind() == std::io::ErrorKind::WouldBlock => {}
-                        Err(e) => {
-                            warn!("Activation wayland read error: {e}");
-                        }
-                    }
-                }
-
-                let _ = eq.flush();
-                glib::ControlFlow::Continue
-            })
-        });
     }
 
     /// Create an activation token tied to the most recent actionable input
     /// event on one of our surfaces (the notification click that got us here).
     ///
-    /// Returns `None` if no input has been observed yet or the compositor
-    /// never answers.
+    /// Returns `None` if no input has been observed or the compositor completes
+    /// the request without providing a token.
     ///
-    /// This must be called synchronously from a handler for real user input.
-    /// GDK owns the recorded surfaces, so their liveness cannot be validated.
+    /// This must be called synchronously from a handler for real user input. It
+    /// performs a Wayland roundtrip without a timeout and may block the GTK
+    /// thread if the compositor stops responding.
     pub fn create_token(&self) -> Option<String> {
         let mut eq = self.event_queue.borrow_mut();
         let mut state = self.state.borrow_mut();
@@ -399,24 +365,17 @@ impl ActivationService {
 
         let activation = state.activation.clone()?;
         let seat = state.seat.clone()?;
-        let (serial, surface) = state.last_input.take()?;
+        let (serial, surface_id) = state.last_input.take()?;
+        let surface = live_surface(&surface_id)?;
 
         state.pending_token = None;
         let token = activation.get_activation_token(&self.qh, ());
         token.set_serial(serial, &seat);
-        token.set_surface(&surface);
+        token.set_surface(&surface.wl_surface);
         token.commit();
 
-        // One roundtrip normally suffices; the compositor sends `done` while
-        // processing the commit. Cap at 2 to stay bounded.
-        for _ in 0..2 {
-            if let Err(e) = eq.roundtrip(&mut *state) {
-                warn!("Activation token roundtrip failed: {e}");
-                break;
-            }
-            if state.pending_token.is_some() {
-                break;
-            }
+        if let Err(e) = eq.roundtrip(&mut *state) {
+            warn!("Activation token roundtrip failed: {e}");
         }
         token.destroy();
 

--- a/crates/vibepanel/src/services/wayland/background_effect.rs
+++ b/crates/vibepanel/src/services/wayland/background_effect.rs
@@ -83,7 +83,6 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::os::fd::{AsFd, AsRawFd};
 use std::rc::Rc;
 
 use gdk4_wayland::prelude::*;
@@ -97,6 +96,8 @@ use wayland_protocols::ext::background_effect::v1::client::{
     ext_background_effect_manager_v1::{self, Capability, ExtBackgroundEffectManagerV1},
     ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
 };
+
+use super::{SurfaceInfo, connection_from_gdk_display, install_event_dispatch};
 
 const BLUR_SURFACE_RESIZE_WATCHED_KEY: &str = "vibepanel-blur-surface-watched";
 const BLUR_SURFACE_ACTIVE_KEY: &str = "vibepanel-blur-surface-active";
@@ -413,37 +414,7 @@ fn add_rounded_rect_to_region_with_outline(
 
 // ── Surface info helper ─────────────────────────────────────────────────────
 
-/// Resolved Wayland surface info for a GTK widget.
-///
-/// Extracts the `wl_surface`, GDK `WaylandSurface`, and a stable `ObjectId`
-/// for use as a cache key.  Avoids duplicating the same 15-line lookup
-/// boilerplate across every method that needs to interact with a surface.
-struct SurfaceInfo {
-    wl_surface: wayland_client::protocol::wl_surface::WlSurface,
-    wayland_surface: gdk4_wayland::WaylandSurface,
-    surface_id: wayland_client::backend::ObjectId,
-}
-
 impl SurfaceInfo {
-    /// Resolve surface info from any widget that has a native surface.
-    fn from_widget(widget: &impl gtk4::prelude::IsA<gtk4::Widget>) -> Option<Self> {
-        let native = widget.as_ref().native()?;
-        let gdk_surface = native.surface()?;
-        let wayland_surface = gdk_surface
-            .downcast::<gdk4_wayland::WaylandSurface>()
-            .ok()?;
-        let wl_surface = wayland_surface.wl_surface()?;
-        let surface_id =
-            <wayland_client::protocol::wl_surface::WlSurface as wayland_client::Proxy>::id(
-                &wl_surface,
-            );
-        Some(Self {
-            wl_surface,
-            wayland_surface,
-            surface_id,
-        })
-    }
-
     /// Surface width in logical pixels.
     fn width(&self) -> i32 {
         self.wayland_surface.width()
@@ -463,8 +434,8 @@ thread_local! {
 
 /// Manages `ext-background-effect-v1` blur region hints for all vibepanel surfaces.
 pub struct BackgroundEffectManager {
-    state: RefCell<BlurState>,
-    event_queue: RefCell<EventQueue<BlurState>>,
+    state: Rc<RefCell<BlurState>>,
+    event_queue: Rc<RefCell<EventQueue<BlurState>>>,
     qh: QueueHandle<BlurState>,
 }
 
@@ -490,30 +461,6 @@ impl BackgroundEffectManager {
         INSTANCE.with(|cell| cell.borrow().clone())
     }
 
-    /// Get the `wayland_client::Connection` that GDK uses internally.
-    ///
-    /// `gdk4_wayland::WaylandDisplay::connection()` is `pub(crate)` so we can't call
-    /// it directly. Instead we call `wl_display()` which internally creates and
-    /// caches the Connection in GObject qdata, then extract the Backend from the
-    /// returned proxy to reconstruct the *same* Connection.
-    ///
-    /// This is critical: creating a second `Backend::from_foreign_display()` would
-    /// allocate a separate libwayland event queue, and roundtrips on it can consume
-    /// events from the shared fd that GDK expects to read, causing missed
-    /// layer-shell configure events (bar appears in middle of screen).
-    fn connection_from_gdk_display(
-        wayland_display: &gdk4_wayland::WaylandDisplay,
-    ) -> Option<Connection> {
-        use wayland_client::Proxy;
-
-        // wl_display() internally calls the private connection() which creates
-        // and caches the Connection. The returned WlDisplay proxy holds a
-        // WeakBackend reference to that same Connection's backend.
-        let wl_display = wayland_display.wl_display()?;
-        let backend = wl_display.backend().upgrade()?;
-        Some(Connection::from_backend(backend))
-    }
-
     /// Attempt to initialize.
     fn try_init() -> Option<Self> {
         // Check we're on a Wayland display.
@@ -533,7 +480,7 @@ impl BackgroundEffectManager {
         debug!("ext_background_effect_manager_v1 found in registry, initializing blur service");
 
         // Build a wayland-client Connection from GDK's foreign wl_display.
-        let connection = Self::connection_from_gdk_display(&wayland_display)?;
+        let connection = connection_from_gdk_display(&wayland_display)?;
 
         // Create our own event queue on GDK's connection.
         let mut event_queue: EventQueue<BlurState> = connection.new_event_queue();
@@ -578,58 +525,15 @@ impl BackgroundEffectManager {
         );
 
         let mgr = Self {
-            state: RefCell::new(state),
-            event_queue: RefCell::new(event_queue),
+            state: Rc::new(RefCell::new(state)),
+            event_queue: Rc::new(RefCell::new(event_queue)),
             qh,
         };
 
         // Install fd watcher to dispatch incoming protocol events.
-        mgr.install_event_dispatch();
+        install_event_dispatch(&mgr.event_queue, &mgr.state, "Blur");
 
         Some(mgr)
-    }
-
-    /// Install a glib fd watcher to dispatch wayland events for our queue.
-    fn install_event_dispatch(&self) {
-        // We need a raw fd for glib::unix_fd_add_local.
-        // The fd is borrowed from the event queue which lives as long as Self (thread-local singleton).
-        let eq_ref = self.event_queue.borrow().as_fd().as_raw_fd();
-
-        // Use the global accessor from inside the callback to avoid lifetime issues.
-        glib::unix_fd_add_local(eq_ref, glib::IOCondition::IN, move |_fd, _cond| {
-            INSTANCE.with(|cell| {
-                let borrow = cell.borrow();
-                let Some(mgr) = borrow.as_ref() else {
-                    return glib::ControlFlow::Break;
-                };
-
-                let mut eq = mgr.event_queue.borrow_mut();
-                let mut st = mgr.state.borrow_mut();
-
-                if let Err(e) = eq.dispatch_pending(&mut *st) {
-                    warn!("Blur event dispatch error: {e}");
-                    // Continue: blur is cosmetic, protocol failures must not
-                    // destabilise the panel.
-                    return glib::ControlFlow::Continue;
-                }
-
-                if let Some(guard) = eq.prepare_read() {
-                    match guard.read() {
-                        Ok(_) => {
-                            let _ = eq.dispatch_pending(&mut *st);
-                        }
-                        Err(wayland_client::backend::WaylandError::Io(io_err))
-                            if io_err.kind() == std::io::ErrorKind::WouldBlock => {}
-                        Err(e) => {
-                            warn!("Blur wayland read error: {e}");
-                        }
-                    }
-                }
-
-                let _ = eq.flush();
-                glib::ControlFlow::Continue
-            })
-        });
     }
 
     /// Get or create the per-surface effect object and return it alongside
@@ -832,15 +736,17 @@ impl BackgroundEffectManager {
     /// `SurfaceInfo::from_widget()` can resolve the `wl_surface`.  If
     /// called from a late `Drop` after the surface is already unmapped or
     /// destroyed, this silently no-ops and the stale `effects` HashMap
-    /// entry persists.  This is intentional and benign: primary cleanup
-    /// always happens from mapped-surface paths (`connect_destroy`,
+    /// entry persists. Primary cleanup always happens from mapped-surface
+    /// paths (`connect_destroy`,
     /// `connect_closed`, fade-start removal, or `connect_map` stale
     /// cleanup on next show), so the `Drop` safety nets in consumers are
     /// defence-in-depth only.  Stale entries are small and bounded by the
     /// number of surfaces torn down without prior cleanup (typically zero
-    /// during normal operation).  `ObjectId` equality is instance-based, not
-    /// wire-integer based, so stale entries never alias new surfaces even if
-    /// wire IDs are reused.
+    /// during normal operation). For GDK-owned foreign proxies, `ObjectId`
+    /// equality compares the proxy address, wire ID, and interface. A stale
+    /// entry could therefore alias a new surface if both its address and wire
+    /// ID were reused, but the primary cleanup paths make that exceptionally
+    /// unlikely.
     pub fn remove_blur_region(&self, window: &impl gtk4::prelude::IsA<gtk4::Widget>) {
         let Some(info) = SurfaceInfo::from_widget(window) else {
             return;

--- a/crates/vibepanel/src/services/wayland/mod.rs
+++ b/crates/vibepanel/src/services/wayland/mod.rs
@@ -1,0 +1,94 @@
+//! Shared Wayland services and GDK connection integration.
+
+use std::cell::RefCell;
+use std::os::fd::{AsFd, AsRawFd};
+use std::rc::Rc;
+
+use gdk4_wayland::prelude::WaylandSurfaceExtManual;
+use gtk4::glib;
+use gtk4::prelude::{Cast, NativeExt, WidgetExt};
+use tracing::warn;
+use wayland_client::{Connection, EventQueue, Proxy};
+
+pub mod activation;
+pub mod background_effect;
+
+/// Resolved Wayland surface identity for a GTK widget.
+pub(super) struct SurfaceInfo {
+    wl_surface: wayland_client::protocol::wl_surface::WlSurface,
+    wayland_surface: gdk4_wayland::WaylandSurface,
+    surface_id: wayland_client::backend::ObjectId,
+}
+
+impl SurfaceInfo {
+    fn from_widget(widget: &impl gtk4::prelude::IsA<gtk4::Widget>) -> Option<Self> {
+        let native = widget.as_ref().native()?;
+        let gdk_surface = native.surface()?;
+        let wayland_surface = gdk_surface
+            .downcast::<gdk4_wayland::WaylandSurface>()
+            .ok()?;
+        let wl_surface = wayland_surface.wl_surface()?;
+        let surface_id = wl_surface.id();
+        Some(Self {
+            wl_surface,
+            wayland_surface,
+            surface_id,
+        })
+    }
+}
+
+/// Get the `wayland_client::Connection` that GDK uses internally.
+///
+/// `gdk4_wayland::WaylandDisplay::connection()` is private, so obtain the
+/// backend from GDK's cached display proxy and reconstruct the same connection.
+/// Creating another backend for the foreign display would compete with GDK for
+/// events and can cause it to miss layer-shell configure events.
+fn connection_from_gdk_display(
+    wayland_display: &gdk4_wayland::WaylandDisplay,
+) -> Option<Connection> {
+    let wl_display = wayland_display.wl_display()?;
+    let backend = wl_display.backend().upgrade()?;
+    Some(Connection::from_backend(backend))
+}
+
+/// Keep a private Wayland event queue moving from the GLib main loop.
+///
+/// GDK reads the shared connection continuously, which also accumulates events
+/// in private queues. Drain them even when a consumer is not making requests.
+fn install_event_dispatch<S: 'static>(
+    event_queue: &Rc<RefCell<EventQueue<S>>>,
+    state: &Rc<RefCell<S>>,
+    label: &'static str,
+) {
+    let raw_fd = event_queue.borrow().as_fd().as_raw_fd();
+    let event_queue = Rc::downgrade(event_queue);
+    let state = Rc::downgrade(state);
+
+    glib::unix_fd_add_local(raw_fd, glib::IOCondition::IN, move |_fd, _cond| {
+        let (Some(event_queue), Some(state)) = (event_queue.upgrade(), state.upgrade()) else {
+            return glib::ControlFlow::Break;
+        };
+
+        let mut event_queue = event_queue.borrow_mut();
+        let mut state = state.borrow_mut();
+
+        if let Err(error) = event_queue.dispatch_pending(&mut *state) {
+            warn!("{label} event dispatch error: {error}");
+            return glib::ControlFlow::Continue;
+        }
+
+        if let Some(guard) = event_queue.prepare_read() {
+            match guard.read() {
+                Ok(_) => {
+                    let _ = event_queue.dispatch_pending(&mut *state);
+                }
+                Err(wayland_client::backend::WaylandError::Io(error))
+                    if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => warn!("{label} wayland read error: {error}"),
+            }
+        }
+
+        let _ = event_queue.flush();
+        glib::ControlFlow::Continue
+    });
+}


### PR DESCRIPTION
Adds the Desktop Notifications `ActivationToken` signal allowing wayland clients to focus their window natively. Also consolidates the shared GDK/Wayland plumbing used by activation and background effects.

Confirmed with Brave on Niri and Mango. Firefox and Zen currently do not consume the token.

Closes #209.