### PR TITLE
fix(quick_settings): idle inhibitor no longer prevents sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://github.com/user-attachments/assets/fba27921-0886-4e7b-850d-b51341583693
   - **Bluetooth** - Manage and pair devices
   - **Wi-Fi** - Connect to and manage networks
   - **VPN** - Connect to NetworkManager-managed VPN connections
-  - **Idle Inhibitor** - Toggle idle inhibitor to prevent sleep
+  - **Idle Inhibitor** - Pause automatic idle actions
 - **Workspaces** - clickable indicators with tooltips
 - **Window title** - active window with app icon
 - **Keyboard layout** - layout indicator with click to cycle

--- a/crates/vibepanel/src/main.rs
+++ b/crates/vibepanel/src/main.rs
@@ -88,7 +88,7 @@ enum Command {
         #[command(subcommand)]
         action: VolumeAction,
     },
-    /// Control idle/sleep inhibitor
+    /// Control idle inhibitor
     Inhibit {
         #[command(subcommand)]
         action: InhibitAction,
@@ -184,7 +184,7 @@ enum MediaAction {
 
 #[derive(Subcommand, Debug)]
 enum InhibitAction {
-    /// Toggle idle/sleep inhibitor on the running panel
+    /// Toggle idle inhibitor on the running panel
     Toggle,
 }
 

--- a/crates/vibepanel/src/services.rs
+++ b/crates/vibepanel/src/services.rs
@@ -15,7 +15,7 @@
 //! - **window_title**: Focused window title monitoring
 //! - **tray**: StatusNotifierItem host for system tray icons
 //! - **vpn**: VPN connection management via NetworkManager
-//! - **idle_inhibitor**: System idle/sleep prevention
+//! - **idle_inhibitor**: System idle prevention
 //! - **state**: Persistent state storage (DND, VPN last used, notification history)
 //! - **system**: CPU, memory, and system resource monitoring
 //! - **gpu**: GPU utilization and VRAM monitoring (AMD sysfs, NVIDIA NVML)

--- a/crates/vibepanel/src/services/idle_inhibitor.rs
+++ b/crates/vibepanel/src/services/idle_inhibitor.rs
@@ -1,15 +1,15 @@
-//! IdleInhibitorService - Prevents system idle/sleep using systemd-logind.
+//! IdleInhibitorService - Prevents system idle using systemd-logind.
 //!
 //! This service uses the `org.freedesktop.login1.Manager.Inhibit` D-Bus API
 //! on the system bus to acquire an fd-based inhibit lock. Holding the fd
-//! prevents idle and sleep; dropping it releases the lock. This is the same
-//! mechanism used by systemd-inhibit(1) and is supported by all systemd-based
-//! systems regardless of which idle daemon is running (hypridle, swayidle, etc.).
+//! prevents automatic idle actions; dropping it releases the lock. This is the
+//! same mechanism used by systemd-inhibit(1) and idle managers that honor
+//! systemd idle inhibitors.
 //!
 //! ## Usage
 //!
 //! The service is a singleton that can be toggled on/off. When active,
-//! it prevents the system from going idle or suspending.
+//! it prevents automatic idle actions without blocking explicit suspend.
 
 use std::cell::RefCell;
 use std::os::unix::io::OwnedFd;
@@ -34,8 +34,8 @@ pub struct IdleInhibitorSnapshot {
 /// Shared, process-wide idle inhibitor service.
 ///
 /// Uses `org.freedesktop.login1.Manager.Inhibit` on the system bus to acquire
-/// an fd-based inhibit lock. The lock prevents idle and sleep while the fd is
-/// open. Dropping the fd releases the lock — the kernel guarantees cleanup
+/// an fd-based inhibit lock. The lock prevents automatic idle actions while the
+/// fd is open. Dropping the fd releases the lock — the kernel guarantees cleanup
 /// even on SIGKILL.
 pub struct IdleInhibitorService {
     /// Current snapshot of inhibitor state.
@@ -155,7 +155,7 @@ impl IdleInhibitorService {
 
         // Call org.freedesktop.login1.Manager.Inhibit(what, who, why, mode)
         let args = (
-            "idle:sleep",                     // what
+            "idle",                           // what
             "vibepanel",                      // who
             "User requested idle inhibition", // why
             "block",                          // mode


### PR DESCRIPTION
The idle inhibitor currently inhibits both idle and sleep, which means it also blocks explicit suspend requests and lid-close suspend - bad. This PR changes it to only inhibit idle.

Closes #214.