### PR TITLE
fix(notifications): truncate and add show more to toasts

### DIFF
--- a/crates/vibepanel/src/services/compositor/hyprland.rs
+++ b/crates/vibepanel/src/services/compositor/hyprland.rs
@@ -96,7 +96,7 @@ impl HyprlandBackend {
         true
     }
 
-    /// Disable Hyprland's compositor-level layer animations for our popover surfaces.
+    /// Disable Hyprland's compositor-level layer animations for popovers and toasts.
     ///
     /// Hyprland animates layer surface resize/move by default which clashes
     /// with GTK4 animations and causes a visible content-shift glitch.
@@ -104,9 +104,9 @@ impl HyprlandBackend {
     /// Session-scoped, only set on startup and not persisted anywhere
     fn apply_layer_rules(&self) {
         let cmd = if self.supports_lua_dispatch.load(Ordering::Relaxed) {
-            "eval hl.layer_rule({ match = { namespace = \"^vibepanel-.*-popover$\" }, no_anim = true })"
+            "eval hl.layer_rule({ match = { namespace = \"^vibepanel-(.*-popover|toast)$\" }, no_anim = true })"
         } else {
-            "keyword layerrule no_anim on, match:namespace ^vibepanel-.*-popover$"
+            "keyword layerrule no_anim on, match:namespace ^vibepanel-(.*-popover|toast)$"
         };
         match self.send_command(cmd) {
             Some(response) if Self::response_is_ok(&response) => {

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -215,12 +215,12 @@ window.notification-toast-wrapper,
     min-width: 300px;
 }}
 
-/* Let overflowing body scrollbars use the dismiss column instead of covering text. */
-.notification-toast-content .notification-scroll {{
+.notification-toast-content .notification-body-container {{
+    min-width: 26px;
     margin-right: -26px;
 }}
 
-.notification-toast-content .notification-scroll .notification-toast-body {{
+.notification-toast-content .notification-body-container .notification-toast-body {{
     margin-right: 26px;
 }}
 "#

--- a/crates/vibepanel/src/widgets/css/notifications.rs
+++ b/crates/vibepanel/src/widgets/css/notifications.rs
@@ -76,10 +76,13 @@ pub fn css(animations: bool) -> String {
     font-weight: 500;
 }}
 
+.notification-body-container {{
+    margin-top: 2px;
+}}
+
 .notification-body,
 .notification-toast-body {{
     font-size: var(--font-size-sm);
-    margin-top: 2px;
 }}
 
 /* Shared dismiss button styling (row + toast) */
@@ -212,20 +215,13 @@ window.notification-toast-wrapper,
     min-width: 300px;
 }}
 
-.notification-toast-actions {{
-    margin-top: 10px;
-    padding-top: 8px;
+/* Let overflowing body scrollbars use the dismiss column instead of covering text. */
+.notification-toast-content .notification-scroll {{
+    margin-right: -26px;
 }}
 
-button.notification-toast-action {{
-    min-height: 0;
-    border-radius: var(--radius-widget);
-    color: var(--color-accent-primary);
-}}
-
-button.notification-toast-action label {{
-    font-size: var(--font-size-sm);
-    padding: 4px 8px;
+.notification-toast-content .notification-scroll .notification-toast-body {{
+    margin-right: 26px;
 }}
 "#
     )

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -7,15 +7,18 @@ use gtk4::gdk;
 use gtk4::gdk_pixbuf::Pixbuf;
 use gtk4::prelude::*;
 use gtk4::{
-    Box as GtkBox, Button, Image, Label, Orientation, PolicyType, ScrolledWindow, Widget, pango,
+    Align, Box as GtkBox, Button, EventControllerMotion, Image, Label, Orientation, Overflow,
+    Overlay, PolicyType, Revealer, RevealerTransitionType, ScrolledWindow, Widget, pango,
 };
 
 use crate::services::battery::normalize_battery_icon_name;
+use crate::services::config_manager::ConfigManager;
 use crate::services::icons::{IconsService, get_app_icon_name};
 use crate::services::notification::{Notification, NotificationImage};
 use crate::styles::{button, color, notification as notif};
 use std::cell::Cell;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::rc::Rc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Toast display duration in ms
 pub const TOAST_TIMEOUT_MS: u32 = 5000;
@@ -37,6 +40,13 @@ pub const POPOVER_WIDTH: i32 = 400;
 pub const SURFACE_SHADOW_MARGIN: i32 = 8;
 
 const PREVIEW_LINES: usize = 2;
+const BODY_ANIMATION_MS: u32 = 200;
+const PREWARM_HOVER_DELAY: Duration = Duration::from_millis(150);
+const PREWARM_SCROLL_QUIET_US: i64 = 150_000;
+
+fn scroll_is_quiet(last_scroll: i64, now: i64) -> bool {
+    now.saturating_sub(last_scroll) >= PREWARM_SCROLL_QUIET_US
+}
 
 /// Split sanitized markup into standalone physical lines. Pango applies label
 /// line limits per paragraph, so separate labels enforce one shared preview limit.
@@ -99,6 +109,8 @@ pub struct NotificationBody {
     pub root: GtkBox,
     /// Visible when structural or measured layout overflow requires expansion.
     pub expand_button: Button,
+    /// Attach to the popover card so deliberate card hover can prepare expansion.
+    pub prewarm_controller: Option<EventControllerMotion>,
 }
 
 /// Open label links without GTK's default URI launcher, which can violate
@@ -129,21 +141,24 @@ pub fn create_notification_body(
     body: &str,
     label_css_class: &str,
     expanded_max_height: Option<i32>,
+    last_scroll: Option<Rc<Cell<i64>>>,
     after_link_open: impl Fn() + Clone + 'static,
 ) -> NotificationBody {
+    let stage_first_expand = last_scroll.is_some();
     let markup = sanitize_body_markup(body);
+    let markup = markup.trim_end_matches('\n');
 
     let root = GtkBox::new(Orientation::Vertical, 0);
     root.add_css_class(notif::BODY_CONTAINER);
 
     let full_label = body_label(label_css_class);
-    full_label.set_markup(&markup);
+    full_label.set_markup(markup);
     full_label.set_wrap(true);
     full_label.set_wrap_mode(pango::WrapMode::WordChar);
     connect_notification_link(&full_label, after_link_open.clone());
 
     let preview = GtkBox::new(Orientation::Vertical, 0);
-    let lines = split_markup_lines(markup.trim_end());
+    let lines = split_markup_lines(markup);
     let structural_overflow = lines.len() > PREVIEW_LINES;
     let mut preview_labels = Vec::new();
 
@@ -183,15 +198,76 @@ pub fn create_notification_body(
         }
         None => full_label.clone().upcast(),
     };
-    expanded.set_visible(false);
+    // Overlay children do not affect layout: the preview/spacer supplies the
+    // collapsed height while the Revealer animates only the extra body height.
+    let extra_height = GtkBox::new(Orientation::Vertical, 0);
+    let collapsed_spacer = GtkBox::new(Orientation::Vertical, 0);
+    collapsed_spacer.set_visible(false);
+    let height_revealer = Revealer::new();
+    height_revealer.set_transition_type(RevealerTransitionType::SlideDown);
+    height_revealer
+        .set_transition_duration(ConfigManager::global().animation_duration(BODY_ANIMATION_MS));
+    height_revealer.set_child(Some(&extra_height));
 
-    root.append(&preview);
-    root.append(&expanded);
+    let sizing_box = GtkBox::new(Orientation::Vertical, 0);
+    sizing_box.append(&preview);
+    sizing_box.append(&collapsed_spacer);
+    sizing_box.append(&height_revealer);
+
+    let body_overlay = Overlay::new();
+    body_overlay.set_overflow(Overflow::Hidden);
+    body_overlay.set_child(Some(&sizing_box));
+    expanded.set_halign(Align::Fill);
+    expanded.set_valign(Align::Start);
+    expanded.set_visible(false);
+    body_overlay.add_overlay(&expanded);
+    preview.set_halign(Align::Fill);
+    preview.set_valign(Align::Start);
+    root.append(&body_overlay);
 
     let expand_button = crate::widgets::base::vp_button_with_label("Show more");
     expand_button.add_css_class(notif::ACTION_BTN);
     expand_button.add_css_class(button::GHOST);
     expand_button.set_visible(structural_overflow);
+
+    let prewarm_controller = last_scroll.map(|last_scroll| {
+        let motion = EventControllerMotion::new();
+        let pending = Rc::new(Cell::new(false));
+        let label = full_label.clone();
+        let expanded = expanded.clone();
+        let button = expand_button.clone();
+        let schedule: Rc<dyn Fn(&EventControllerMotion)> = Rc::new(move |motion| {
+            if label.width() != 0 || !button.is_visible() || pending.replace(true) {
+                return;
+            }
+
+            let motion = motion.downgrade();
+            let pending = Rc::clone(&pending);
+            let label = label.clone();
+            let expanded = expanded.clone();
+            let button = button.clone();
+            let last_scroll = Rc::clone(&last_scroll);
+            gtk4::glib::timeout_add_local_once(PREWARM_HOVER_DELAY, move || {
+                pending.set(false);
+                let Some(motion) = motion.upgrade() else {
+                    return;
+                };
+                if motion.contains_pointer()
+                    && button.is_visible()
+                    && label.width() == 0
+                    && scroll_is_quiet(last_scroll.get(), gtk4::glib::monotonic_time())
+                {
+                    expanded.set_opacity(0.0);
+                    expanded.set_can_target(false);
+                    expanded.set_visible(true);
+                }
+            });
+        });
+        let schedule_enter = Rc::clone(&schedule);
+        motion.connect_enter(move |motion, _, _| schedule_enter(motion));
+        motion.connect_motion(move |motion, _, _| schedule(motion));
+        motion
+    });
 
     let mapped_labels = preview_labels.clone();
     let mapped_button = expand_button.downgrade();
@@ -213,19 +289,28 @@ pub fn create_notification_body(
     });
 
     let is_expanded = Cell::new(false);
+    let preview_for_reveal = preview.clone();
+    let expanded_for_reveal = expanded.clone();
+    let button_for_reveal = expand_button.downgrade();
+    height_revealer.connect_child_revealed_notify(move |revealer| {
+        if !revealer.is_child_revealed() {
+            expanded_for_reveal.set_visible(false);
+            preview_for_reveal.set_visible(true);
+        }
+        if let Some(button) = button_for_reveal.upgrade() {
+            button.set_sensitive(true);
+        }
+    });
+
+    let preview_in_sizing_box = Cell::new(true);
+    let first_expand = Cell::new(true);
     expand_button.connect_clicked(move |btn| {
         let expanded_now = !is_expanded.get();
         is_expanded.set(expanded_now);
 
         if let Some((container, scroll, label, max_height)) = &scroll_limit {
             if expanded_now && scroll.child().is_none() {
-                // The unconstrained label layout does not include wrapping at the
-                // toast width, so measure it using the allocated preview width.
-                let layout = label.layout().copy();
-                layout.set_width(preview.width() * pango::SCALE);
-                let (_, height) = layout.pixel_size();
-
-                if height > *max_height {
+                if label.measure(Orientation::Vertical, preview.width()).1 > *max_height {
                     container.remove(label);
                     scroll.set_child(Some(label));
                     container.append(scroll);
@@ -235,8 +320,52 @@ pub fn create_notification_body(
             }
         }
 
-        preview.set_visible(!expanded_now);
-        expanded.set_visible(expanded_now);
+        btn.set_sensitive(false);
+        if expanded_now {
+            let preview_width = preview.width();
+            let preview_height = preview.height();
+            collapsed_spacer.set_height_request(preview_height);
+            if preview_in_sizing_box.replace(false) {
+                collapsed_spacer.set_visible(true);
+                sizing_box.remove(&preview);
+                body_overlay.add_overlay(&preview);
+            }
+            // Cold allocation of a long label can consume the whole animation.
+            // Keep the preview stable until allocation completes, then reveal.
+            if stage_first_expand && first_expand.replace(false) && full_label.width() == 0 {
+                expanded.set_opacity(0.0);
+                expanded.set_can_target(false);
+                expanded.set_visible(true);
+
+                let label = full_label.clone();
+                let expanded = expanded.clone();
+                let extra_height = extra_height.clone();
+                let preview = preview.clone();
+                height_revealer.add_tick_callback(move |revealer, _| {
+                    if label.width() == 0 {
+                        return gtk4::glib::ControlFlow::Continue;
+                    }
+                    extra_height.set_height_request((expanded.height() - preview_height).max(0));
+                    expanded.set_opacity(1.0);
+                    expanded.set_can_target(true);
+                    preview.set_visible(false);
+                    crate::widgets::layer_shell_popover::animate_reveal(revealer, true);
+                    gtk4::glib::ControlFlow::Break
+                });
+            } else {
+                preview.set_visible(false);
+                expanded.set_opacity(1.0);
+                expanded.set_can_target(true);
+                expanded.set_visible(true);
+                extra_height.set_height_request(
+                    (expanded.measure(Orientation::Vertical, preview_width).1 - preview_height)
+                        .max(0),
+                );
+                crate::widgets::layer_shell_popover::animate_reveal(&height_revealer, true);
+            }
+        } else {
+            crate::widgets::layer_shell_popover::animate_reveal(&height_revealer, false);
+        }
         btn.set_label(if expanded_now {
             "Show less"
         } else {
@@ -247,6 +376,7 @@ pub fn create_notification_body(
     NotificationBody {
         root,
         expand_button,
+        prewarm_controller,
     }
 }
 
@@ -639,6 +769,12 @@ fn notification_logical_icon_name(icon_name: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prewarm_waits_for_scroll_quiet_period() {
+        assert!(!scroll_is_quiet(1_000_000, 1_149_999));
+        assert!(scroll_is_quiet(1_000_000, 1_150_000));
+    }
 
     #[test]
     fn test_sanitize_plain_text() {

--- a/crates/vibepanel/src/widgets/notifications_common.rs
+++ b/crates/vibepanel/src/widgets/notifications_common.rs
@@ -6,12 +6,15 @@
 use gtk4::gdk;
 use gtk4::gdk_pixbuf::Pixbuf;
 use gtk4::prelude::*;
-use gtk4::{Image, Widget};
+use gtk4::{
+    Box as GtkBox, Button, Image, Label, Orientation, PolicyType, ScrolledWindow, Widget, pango,
+};
 
 use crate::services::battery::normalize_battery_icon_name;
 use crate::services::icons::{IconsService, get_app_icon_name};
 use crate::services::notification::{Notification, NotificationImage};
-use crate::styles::notification as notif;
+use crate::styles::{button, color, notification as notif};
+use std::cell::Cell;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Toast display duration in ms
@@ -33,9 +36,219 @@ pub const POPOVER_WIDTH: i32 = 400;
 /// at the layer-shell surface boundary.
 pub const SURFACE_SHADOW_MARGIN: i32 = 8;
 
-/// Threshold for body text length before we show the expand button.
-/// Bodies shorter than this are shown in full without expand/collapse UI.
-pub const BODY_TRUNCATE_THRESHOLD: usize = 80;
+const PREVIEW_LINES: usize = 2;
+
+/// Split sanitized markup into standalone physical lines. Pango applies label
+/// line limits per paragraph, so separate labels enforce one shared preview limit.
+fn split_markup_lines(markup: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    // (tag name, opening tag with attributes)
+    let mut open: Vec<(String, String)> = Vec::new();
+    let mut idx = 0;
+
+    while let Some(ch) = markup[idx..].chars().next() {
+        match ch {
+            '\n' => {
+                for (name, _) in open.iter().rev() {
+                    current.push_str(&format!("</{}>", name));
+                }
+                lines.push(std::mem::take(&mut current));
+                for (_, opening) in &open {
+                    current.push_str(opening);
+                }
+                idx += ch.len_utf8();
+            }
+            '<' => {
+                let rest = &markup[idx..];
+                let Some(end) = rest.find('>') else {
+                    current.push(ch);
+                    idx += ch.len_utf8();
+                    continue;
+                };
+                let tag = &rest[..=end];
+                let inner = &rest[1..end];
+
+                if let Some(name) = inner.strip_prefix('/') {
+                    let name = name.trim().to_ascii_lowercase();
+                    if let Some(pos) = open.iter().rposition(|(open_name, _)| *open_name == name) {
+                        open.remove(pos);
+                    }
+                } else {
+                    let name_end = inner
+                        .find(|c: char| !c.is_ascii_alphabetic())
+                        .unwrap_or(inner.len());
+                    open.push((inner[..name_end].to_ascii_lowercase(), tag.to_string()));
+                }
+
+                current.push_str(tag);
+                idx += end + 1;
+            }
+            _ => {
+                current.push(ch);
+                idx += ch.len_utf8();
+            }
+        }
+    }
+
+    lines.push(current);
+    lines
+}
+
+pub struct NotificationBody {
+    pub root: GtkBox,
+    /// Visible when structural or measured layout overflow requires expansion.
+    pub expand_button: Button,
+}
+
+/// Open label links without GTK's default URI launcher, which can violate
+/// layer-shell focus constraints on Wayland.
+fn connect_notification_link(label: &Label, after_open: impl Fn() + 'static) {
+    label.connect_activate_link(move |_, uri| {
+        let command = format!("xdg-open '{}'", uri.replace("'", "'\\''"));
+        let _ = gtk4::glib::spawn_command_line_async(&command);
+        after_open();
+        gtk4::glib::Propagation::Stop
+    });
+}
+
+fn body_label(css_class: &str) -> Label {
+    let label = Label::new(None);
+    label.add_css_class(css_class);
+    label.add_css_class(color::MUTED);
+    label.set_xalign(0.0);
+    label
+}
+
+/// Build a notification body showing its first two lines until expanded.
+///
+/// The preview preserves text, formatting, and links. With
+/// `expanded_max_height`, the expanded body scrolls beyond that height instead
+/// of growing.
+pub fn create_notification_body(
+    body: &str,
+    label_css_class: &str,
+    expanded_max_height: Option<i32>,
+    after_link_open: impl Fn() + Clone + 'static,
+) -> NotificationBody {
+    let markup = sanitize_body_markup(body);
+
+    let root = GtkBox::new(Orientation::Vertical, 0);
+    root.add_css_class(notif::BODY_CONTAINER);
+
+    let full_label = body_label(label_css_class);
+    full_label.set_markup(&markup);
+    full_label.set_wrap(true);
+    full_label.set_wrap_mode(pango::WrapMode::WordChar);
+    connect_notification_link(&full_label, after_link_open.clone());
+
+    let preview = GtkBox::new(Orientation::Vertical, 0);
+    let lines = split_markup_lines(markup.trim_end());
+    let structural_overflow = lines.len() > PREVIEW_LINES;
+    let mut preview_labels = Vec::new();
+
+    for (index, line) in lines.iter().take(PREVIEW_LINES).enumerate() {
+        let line_label = body_label(label_css_class);
+        line_label.set_markup(if line.is_empty() { "\u{2060}" } else { line });
+        line_label.set_ellipsize(pango::EllipsizeMode::End);
+
+        if index == 0 && !line.is_empty() {
+            line_label.set_wrap(true);
+            line_label.set_wrap_mode(pango::WrapMode::WordChar);
+            line_label.set_lines(PREVIEW_LINES as i32);
+        } else {
+            line_label.set_single_line_mode(true);
+        }
+        connect_notification_link(&line_label, after_link_open.clone());
+
+        preview.append(&line_label);
+        preview_labels.push(line_label);
+    }
+
+    let mut scroll_limit = None;
+    let expanded: Widget = match expanded_max_height {
+        Some(max_height) => {
+            // Keep short expanded bodies outside the scroller. GTK can allocate
+            // max-content dead space for wrapped labels, pushing actions down.
+            let container = GtkBox::new(Orientation::Vertical, 0);
+            container.append(&full_label);
+
+            let scroll = ScrolledWindow::new();
+            scroll.set_policy(PolicyType::Never, PolicyType::Automatic);
+            scroll.set_propagate_natural_height(false);
+            scroll.add_css_class(notif::SCROLL);
+            scroll.set_height_request(max_height);
+            scroll_limit = Some((container.clone(), scroll, full_label.clone(), max_height));
+            container.upcast()
+        }
+        None => full_label.clone().upcast(),
+    };
+    expanded.set_visible(false);
+
+    root.append(&preview);
+    root.append(&expanded);
+
+    let expand_button = crate::widgets::base::vp_button_with_label("Show more");
+    expand_button.add_css_class(notif::ACTION_BTN);
+    expand_button.add_css_class(button::GHOST);
+    expand_button.set_visible(structural_overflow);
+
+    let mapped_labels = preview_labels.clone();
+    let mapped_button = expand_button.downgrade();
+    preview.connect_map(move |_| {
+        let labels = mapped_labels.clone();
+        let button = mapped_button.clone();
+        gtk4::glib::idle_add_local_once(move || {
+            let first_uses_budget =
+                labels.len() > 1 && labels[0].layout().line_count() >= PREVIEW_LINES as i32;
+            if first_uses_budget && let Some(second) = labels.get(1) {
+                second.set_visible(false);
+            }
+            if (first_uses_budget || labels.iter().any(|label| label.layout().is_ellipsized()))
+                && let Some(button) = button.upgrade()
+            {
+                button.set_visible(true);
+            }
+        });
+    });
+
+    let is_expanded = Cell::new(false);
+    expand_button.connect_clicked(move |btn| {
+        let expanded_now = !is_expanded.get();
+        is_expanded.set(expanded_now);
+
+        if let Some((container, scroll, label, max_height)) = &scroll_limit {
+            if expanded_now && scroll.child().is_none() {
+                // The unconstrained label layout does not include wrapping at the
+                // toast width, so measure it using the allocated preview width.
+                let layout = label.layout().copy();
+                layout.set_width(preview.width() * pango::SCALE);
+                let (_, height) = layout.pixel_size();
+
+                if height > *max_height {
+                    container.remove(label);
+                    scroll.set_child(Some(label));
+                    container.append(scroll);
+                }
+            } else if !expanded_now && scroll.child().is_some() {
+                scroll.vadjustment().set_value(0.0);
+            }
+        }
+
+        preview.set_visible(!expanded_now);
+        expanded.set_visible(expanded_now);
+        btn.set_label(if expanded_now {
+            "Show less"
+        } else {
+            "Show more"
+        });
+    });
+
+    NotificationBody {
+        root,
+        expand_button,
+    }
+}
 
 /// Format a timestamp as a human-readable relative time.
 pub fn format_timestamp(timestamp: f64) -> String {
@@ -68,7 +281,7 @@ enum TagBalance {
 
 /// Sanitize notification body text for Pango markup rendering.
 /// Returns markup safe for use with `Label::set_markup()`.
-pub fn sanitize_body_markup(body: &str) -> String {
+fn sanitize_body_markup(body: &str) -> String {
     let mut result = String::with_capacity(body.len());
     let mut chars = body.char_indices().peekable();
     let mut open_tags: Vec<String> = Vec::new();
@@ -78,7 +291,11 @@ pub fn sanitize_body_markup(body: &str) -> String {
             '&' => {
                 // Check if this is an existing XML entity - preserve it
                 if let Some(entity) = try_parse_entity(&body[i..]) {
-                    result.push_str(entity);
+                    if let Some(separator) = numeric_line_separator(entity) {
+                        result.push(separator);
+                    } else {
+                        result.push_str(entity);
+                    }
                     // Skip past the entity
                     for _ in 0..entity.len() - 1 {
                         chars.next();
@@ -147,6 +364,8 @@ pub fn sanitize_body_markup(body: &str) -> String {
     }
 
     result
+        .replace("\r\n", "\n")
+        .replace(['\r', '\u{2028}', '\u{2029}'], "\n")
 }
 
 /// Try to parse an XML entity at the start of `s`.
@@ -176,6 +395,19 @@ fn try_parse_entity(s: &str) -> Option<&str> {
                     && name[2..].chars().all(|c| c.is_ascii_hexdigit()))));
 
     if valid { Some(entity) } else { None }
+}
+
+fn numeric_line_separator(entity: &str) -> Option<char> {
+    let value = entity.strip_prefix("&#")?.strip_suffix(';')?;
+    let value = if let Some(hex) = value.strip_prefix('x') {
+        u32::from_str_radix(hex, 16).ok()
+    } else {
+        value.parse::<u32>().ok()
+    }?;
+
+    matches!(value, 0x0a | 0x0d | 0x2028 | 0x2029)
+        .then(|| char::from_u32(value))
+        .flatten()
 }
 
 /// Try to parse an allowed HTML tag at the start of `s`.
@@ -236,10 +468,7 @@ fn try_parse_tag(s: &str) -> Option<(String, usize, TagBalance)> {
                 ))
             }
         }
-        "br" => {
-            // Convert <br> to space
-            Some((" ".to_string(), full_len, TagBalance::None))
-        }
+        "br" => Some(("\n".to_string(), full_len, TagBalance::None)),
         "img" => {
             // Strip <img> tags entirely
             Some((String::new(), full_len, TagBalance::None))
@@ -417,6 +646,27 @@ mod tests {
     }
 
     #[test]
+    fn split_markup_lines_keeps_blank_lines_and_tag_contents() {
+        assert_eq!(split_markup_lines("a\n\nb"), ["a", "", "b"]);
+        assert_eq!(split_markup_lines("a\nb\n".trim_end()), ["a", "b"]);
+        assert_eq!(
+            split_markup_lines("<a\n href=\"https://example.com\">link</a>"),
+            ["<a\n href=\"https://example.com\">link</a>"]
+        );
+    }
+
+    #[test]
+    fn split_markup_lines_reopens_formatting_and_links() {
+        assert_eq!(
+            split_markup_lines("<a href=\"https://x.test\">link\ntext</a>"),
+            [
+                "<a href=\"https://x.test\">link</a>",
+                "<a href=\"https://x.test\">text</a>"
+            ]
+        );
+    }
+
+    #[test]
     fn test_notification_battery_icon_normalization() {
         assert_eq!(
             notification_logical_icon_name("battery-low-symbolic"),
@@ -458,9 +708,20 @@ mod tests {
 
     #[test]
     fn test_sanitize_br() {
-        assert_eq!(sanitize_body_markup("Line 1<br>Line 2"), "Line 1 Line 2");
-        assert_eq!(sanitize_body_markup("Line 1<br/>Line 2"), "Line 1 Line 2");
-        assert_eq!(sanitize_body_markup("Line 1<br />Line 2"), "Line 1 Line 2");
+        assert_eq!(sanitize_body_markup("Line 1<br>Line 2"), "Line 1\nLine 2");
+        assert_eq!(sanitize_body_markup("Line 1<br/>Line 2"), "Line 1\nLine 2");
+        assert_eq!(sanitize_body_markup("Line 1<br />Line 2"), "Line 1\nLine 2");
+    }
+
+    #[test]
+    fn test_sanitize_line_boundaries() {
+        let markup =
+            sanitize_body_markup("one\r\ntwo\rthree\u{2028}four\u{2029}five&#10;six&#xA;seven");
+        assert_eq!(markup, "one\ntwo\nthree\nfour\nfive\nsix\nseven");
+        assert_eq!(
+            split_markup_lines(&sanitize_body_markup("one&#10;two&#10;three")),
+            ["one", "two", "three"]
+        );
     }
 
     #[test]
@@ -506,7 +767,7 @@ mod tests {
     #[test]
     fn test_case_insensitive_tags() {
         assert_eq!(sanitize_body_markup("<B>BOLD</B>"), "<b>BOLD</b>");
-        assert_eq!(sanitize_body_markup("<BR>"), " ");
+        assert_eq!(sanitize_body_markup("<BR>"), "\n");
     }
 
     #[test]

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -102,7 +102,13 @@ pub(super) fn build_popover_content(
     let notification_list = GtkBox::new(Orientation::Vertical, 4);
     notification_list.add_css_class(notif::LIST);
 
-    populate_notification_list(&notification_list, on_close, &suppress_rebuild);
+    let last_scroll = Rc::new(Cell::new(0));
+    populate_notification_list(
+        &notification_list,
+        on_close,
+        &suppress_rebuild,
+        &last_scroll,
+    );
 
     let max_height = compute_max_scroll_height(monitor);
 
@@ -111,6 +117,10 @@ pub(super) fn build_popover_content(
     scrolled.set_propagate_natural_height(true);
     scrolled.set_max_content_height(max_height);
     scrolled.add_css_class(notif::SCROLL);
+    let last_scroll_for_adjustment = Rc::clone(&last_scroll);
+    scrolled.vadjustment().connect_value_changed(move |_| {
+        last_scroll_for_adjustment.set(glib::monotonic_time());
+    });
 
     scrolled.set_child(Some(&notification_list));
     root.append(&scrolled);
@@ -229,6 +239,7 @@ fn populate_notification_list(
     list: &GtkBox,
     on_close: Option<ClosePopoverCallback>,
     suppress_rebuild: &Rc<Cell<bool>>,
+    last_scroll: &Rc<Cell<i64>>,
 ) {
     let service = NotificationService::global();
 
@@ -269,6 +280,7 @@ fn populate_notification_list(
             list,
             &revealer,
             suppress_rebuild,
+            last_scroll,
         );
         revealer.set_child(Some(&row));
         list.append(&revealer);
@@ -308,6 +320,7 @@ fn build_notification_row(
     list: &GtkBox,
     revealer: &Revealer,
     suppress_rebuild: &Rc<Cell<bool>>,
+    last_scroll: &Rc<Cell<i64>>,
 ) -> GtkBox {
     let card = GtkBox::new(Orientation::Vertical, 0);
     card.add_css_class(notif::ROW);
@@ -374,13 +387,22 @@ fn build_notification_row(
 
     if !notification.body.is_empty() {
         let on_close_link = on_close.clone();
-        let body = create_notification_body(&notification.body, notif::BODY, None, move || {
-            if let Some(ref close_cb) = on_close_link {
-                close_cb();
-            }
-        });
+        let body = create_notification_body(
+            &notification.body,
+            notif::BODY,
+            None,
+            Some(Rc::clone(last_scroll)),
+            move || {
+                if let Some(ref close_cb) = on_close_link {
+                    close_cb();
+                }
+            },
+        );
 
         content.append(&body.root);
+        if let Some(controller) = body.prewarm_controller {
+            card.add_controller(controller);
+        }
         body_expand_button = Some(body.expand_button);
     }
 

--- a/crates/vibepanel/src/widgets/notifications_popover.rs
+++ b/crates/vibepanel/src/widgets/notifications_popover.rs
@@ -24,8 +24,7 @@ use crate::styles::{button, card, color, notification as notif, surface};
 use super::css::DISMISS_ANIMATION_MS;
 use super::layer_shell_popover::{calculate_bar_exclusive_zone, calculate_popover_bar_margin};
 use super::notifications_common::{
-    BODY_TRUNCATE_THRESHOLD, POPOVER_WIDTH, create_notification_image_widget, format_timestamp,
-    sanitize_body_markup,
+    POPOVER_WIDTH, create_notification_body, create_notification_image_widget, format_timestamp,
 };
 
 /// Callback type for closing the popover from within the content.
@@ -371,56 +370,18 @@ fn build_notification_row(
         content.append(&summary_label);
     }
 
-    // Body with expandable support for long text
-    // Use a single label with dynamic line limiting to avoid breaking markup tags
-    let mut body_label_opt: Option<Label> = None;
+    let mut body_expand_button = None;
 
     if !notification.body.is_empty() {
-        // Sanitize markup and clean up for display
-        let body_markup = sanitize_body_markup(&notification.body);
-        let body_clean = body_markup.trim();
-        let needs_expansion = body_clean.chars().count() > BODY_TRUNCATE_THRESHOLD;
-
-        let body_label = Label::new(None);
-        body_label.set_markup(body_clean);
-        body_label.add_css_class(notif::BODY);
-        body_label.add_css_class(color::MUTED);
-        body_label.set_xalign(0.0);
-        body_label.set_wrap(true);
-        body_label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
-
-        if needs_expansion {
-            // Start collapsed: limit to 2 lines with ellipsis
-            body_label.set_lines(2);
-            body_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-            body_label.set_vexpand(false);
-            body_label_opt = Some(body_label.clone());
-        } else {
-            // Short body - no line limit
-            body_label.set_lines(-1);
-            body_label.set_ellipsize(gtk4::pango::EllipsizeMode::None);
-        }
-
-        // Handle link activation manually to avoid Wayland protocol errors.
-        // Protocol error 71 often occurs when gtk_show_uri triggers a focus switch or
-        // interaction that conflicts with the layer shell surface state.
         let on_close_link = on_close.clone();
-        body_label.connect_activate_link(move |_, uri| {
-            // Use xdg-open via spawn_command_line_async for a detached process
-            let cmd = format!("xdg-open '{}'", uri.replace("'", "'\\''"));
-            // We ignore the result here because this is a fire-and-forget operation
-            // and we can't do much if xdg-open fails to launch from here anyway.
-            let _ = glib::spawn_command_line_async(&cmd);
-
-            // Close popover when user navigates away via link
+        let body = create_notification_body(&notification.body, notif::BODY, None, move || {
             if let Some(ref close_cb) = on_close_link {
                 close_cb();
             }
-
-            glib::Propagation::Stop // Stop propagation to default handler
         });
 
-        content.append(&body_label);
+        content.append(&body.root);
+        body_expand_button = Some(body.expand_button);
     }
 
     main_row.append(&content);
@@ -485,7 +446,7 @@ fn build_notification_row(
         .filter(|(id, _)| id != "default")
         .collect();
 
-    let has_expand = body_label_opt.is_some();
+    let has_expand = body_expand_button.is_some();
 
     // Determine primary action (default or explicit "Open")
     let mut default_action: Option<String> = None;
@@ -500,47 +461,25 @@ fn build_notification_row(
     }
 
     let primary_action = default_action.clone().or(open_action.clone());
+    let has_other_actions = !non_default_actions.is_empty() || primary_action.is_some();
 
     if !non_default_actions.is_empty() || has_expand || primary_action.is_some() {
         let actions_row = GtkBox::new(Orientation::Horizontal, 8);
         actions_row.add_css_class(notif::ACTIONS);
 
-        // Optional expand button on the left
-        if let Some(body_label) = body_label_opt {
-            let expand_btn = crate::widgets::base::vp_button_with_label("Show more");
-            expand_btn.add_css_class(notif::ACTION_BTN);
-            expand_btn.add_css_class(button::GHOST);
-
-            // Store expanded state in a Cell
-            let is_expanded = Rc::new(Cell::new(false));
-            let is_expanded_clone = Rc::clone(&is_expanded);
-
-            expand_btn.connect_clicked(move |btn| {
-                let expanded = is_expanded_clone.get();
-                let new_state = !expanded;
-                is_expanded_clone.set(new_state);
-
-                if new_state {
-                    // Expanded: remove line limit and ellipsis
-                    body_label.set_lines(-1);
-                    body_label.set_ellipsize(gtk4::pango::EllipsizeMode::None);
-                    // Ensure the label can expand vertically in the container
-                    body_label.set_vexpand(true);
-                    btn.set_label("Show less");
-                } else {
-                    // Collapsed: limit to 2 lines with ellipsis
-                    body_label.set_lines(2);
-                    body_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-                    body_label.set_vexpand(false);
-                    btn.set_label("Show more");
-                }
-            });
-
+        if let Some(expand_btn) = body_expand_button {
             actions_row.append(&expand_btn);
+
+            if !has_other_actions {
+                expand_btn
+                    .bind_property("visible", &actions_row, "visible")
+                    .sync_create()
+                    .build();
+            }
         }
 
         // Spacer between expand button and actions
-        if has_expand && (!non_default_actions.is_empty() || primary_action.is_some()) {
+        if has_expand && has_other_actions {
             let spacer = GtkBox::new(Orientation::Horizontal, 0);
             spacer.set_hexpand(true);
             actions_row.append(&spacer);

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -6,7 +6,10 @@
 
 use gtk4::glib::{self, SourceId};
 use gtk4::prelude::*;
-use gtk4::{Align, Application, Box as GtkBox, Button, Image, Label, Orientation, Window, gdk};
+use gtk4::{
+    Align, Application, Box as GtkBox, Button, EventControllerMotion, Image, Label, Orientation,
+    Window, gdk,
+};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -28,9 +31,18 @@ use crate::styles::{button, color, notification as notif};
 
 use super::notifications_common::{
     POPOVER_WIDTH, SURFACE_SHADOW_MARGIN, TOAST_EDGE_MARGIN, TOAST_ESTIMATED_HEIGHT, TOAST_GAP,
-    TOAST_SIDE_MARGIN, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS,
-    create_notification_image_widget, sanitize_body_markup,
+    TOAST_SIDE_MARGIN, TOAST_TIMEOUT_CRITICAL_MS, TOAST_TIMEOUT_MS, create_notification_body,
+    create_notification_image_widget,
 };
+
+const TOAST_BODY_FALLBACK_MAX_HEIGHT: i32 = 500;
+
+fn max_toast_body_height(monitor_height: Option<i32>) -> i32 {
+    monitor_height
+        .filter(|height| *height > 0)
+        .map(|height| height * 2 / 3)
+        .unwrap_or(TOAST_BODY_FALLBACK_MAX_HEIGHT)
+}
 
 fn toast_surface_margin() -> i32 {
     SURFACE_SHADOW_MARGIN
@@ -123,11 +135,16 @@ pub(super) struct NotificationToast {
     /// Runs from `Drop` so each visible toast copy is unregistered once.
     on_hidden: ToastCallback,
     timeout_source: RefCell<Option<SourceId>>,
+    /// Auto-dismiss duration; 0 means the toast never times out.
+    timeout_ms: Cell<u32>,
+    on_timeout: ToastCallback,
+    pointer_hovered: Cell<bool>,
     current_bar_margin: Cell<i32>,
     animation_source: RefCell<Option<SourceId>>,
     bar_edge: Edge,
-    /// Actual rendered height, measured after window is mapped
+    /// Actual rendered height, updated when the surface size changes.
     height: Cell<i32>,
+    max_body_height: i32,
     /// Theme-change callback guard; disconnected automatically on `Drop`.
     theme_callback_guard: RefCell<Option<ThemeCallbackGuard>>,
 }
@@ -189,13 +206,19 @@ impl NotificationToast {
             notification_id,
             on_hidden,
             timeout_source: RefCell::new(None),
+            timeout_ms: Cell::new(0),
+            on_timeout: Rc::clone(&on_remove),
+            pointer_hovered: Cell::new(false),
             current_bar_margin: Cell::new(layout.initial_margin),
             animation_source: RefCell::new(None),
             bar_edge: vertical_edge,
             height: Cell::new(TOAST_ESTIMATED_HEIGHT),
+            max_body_height: max_toast_body_height(context.monitor.map(|m| m.geometry().height())),
             theme_callback_guard: RefCell::new(None),
         });
-        toast.build_content(notification, Rc::clone(&on_remove), on_action);
+        toast.install_timeout_hover_controller();
+        toast.install_height_watcher(on_height_measured);
+        toast.build_content(notification, Rc::clone(&toast.on_timeout), on_action);
         // Route GTK close requests through normal removal. This ensures manager
         // teardown also removes transient service entries, while external GTK
         // closes release map-owned toasts and balance active-toast accounting.
@@ -208,26 +231,7 @@ impl NotificationToast {
             on_window_close(notification_id);
             glib::Propagation::Proceed
         });
-        toast.schedule_timeout(notification, on_remove);
-
-        // Measure actual height after window is mapped and laid out.
-        // We use idle_add to defer measurement until after GTK has completed layout.
-        let toast_weak = Rc::downgrade(&toast);
-        let notification_id = notification.id;
-        toast.window.connect_map(move |win| {
-            let win_clone = win.clone();
-            let toast_weak = toast_weak.clone();
-            let on_height_measured = on_height_measured.clone();
-            glib::idle_add_local_once(move || {
-                let height = win_clone.height();
-                if let Some(toast) = toast_weak.upgrade()
-                    && height > 0
-                {
-                    toast.height.set(height);
-                    on_height_measured(notification_id);
-                }
-            });
-        });
+        toast.schedule_timeout(notification);
 
         let theme_callback_guard = attach_blur_surface_lifecycle(
             &toast.window,
@@ -246,39 +250,34 @@ impl NotificationToast {
     /// notification that was replaced via `replaces_id`. The on-screen position
     /// is preserved; height is re-measured after layout so neighbour toasts can
     /// reposition if the new content is a different size.
-    pub fn update(
-        self: &Rc<Self>,
-        notification: &Notification,
-        on_remove: ToastCallback,
-        on_action: ToastActionCallback,
-        on_height_measured: ToastCallback,
-    ) {
-        // Drop the existing timeout before scheduling a fresh one - replacement
-        // resets the auto-dismiss countdown.
-        if let Some(source_id) = self.timeout_source.borrow_mut().take() {
-            source_id.remove();
-        }
+    pub fn update(self: &Rc<Self>, notification: &Notification, on_action: ToastActionCallback) {
+        self.build_content(notification, Rc::clone(&self.on_timeout), on_action);
+        self.schedule_timeout(notification);
+    }
 
-        self.build_content(notification, Rc::clone(&on_remove), on_action);
-        self.schedule_timeout(notification, on_remove);
-
-        // The window is already mapped, so connect_map won't fire again. Defer a
-        // re-measurement to the next idle so GTK has time to lay out the new
-        // child; if the height changed, the manager repositions the stack.
+    fn install_height_watcher(self: &Rc<Self>, on_height_measured: ToastCallback) {
         let toast_weak = Rc::downgrade(self);
-        let notification_id = notification.id;
-        glib::idle_add_local_once(move || {
-            if let Some(toast) = toast_weak.upgrade() {
-                let height = toast.window.height();
+        self.window.connect_realize(move |window| {
+            let Some(surface) = window.surface() else {
+                return;
+            };
+
+            let toast_weak = toast_weak.clone();
+            let on_height_measured = Rc::clone(&on_height_measured);
+            surface.connect_notify_local(Some("height"), move |surface, _| {
+                let Some(toast) = toast_weak.upgrade() else {
+                    return;
+                };
+                let height = surface.height();
                 if height > 0 && height != toast.height.get() {
                     toast.height.set(height);
-                    on_height_measured(notification_id);
+                    on_height_measured(toast.notification_id);
                 }
-            }
+            });
         });
     }
 
-    fn schedule_timeout(self: &Rc<Self>, notification: &Notification, on_timeout: ToastCallback) {
+    fn schedule_timeout(self: &Rc<Self>, notification: &Notification) {
         let timeout_ms = if notification.urgency == URGENCY_CRITICAL {
             TOAST_TIMEOUT_CRITICAL_MS
         } else if notification.expire_timeout > 0 {
@@ -292,12 +291,33 @@ impl NotificationToast {
             notification.id, timeout_ms, notification.urgency, notification.expire_timeout
         );
 
+        self.timeout_ms.set(timeout_ms);
+
+        // A toast replaced under the pointer waits for the pointer to leave.
+        if self.pointer_hovered.get() {
+            self.pause_timeout();
+        } else {
+            self.restart_timeout();
+        }
+    }
+
+    fn pause_timeout(&self) {
+        if let Some(source_id) = self.timeout_source.borrow_mut().take() {
+            source_id.remove();
+        }
+    }
+
+    fn restart_timeout(self: &Rc<Self>) {
+        self.pause_timeout();
+
+        let timeout_ms = self.timeout_ms.get();
         if timeout_ms == 0 {
             return;
         }
 
         let toast_weak = Rc::downgrade(self);
-        let notification_id = notification.id;
+        let notification_id = self.notification_id;
+        let on_timeout = Rc::clone(&self.on_timeout);
         let source_id = glib::timeout_add_local_once(
             std::time::Duration::from_millis(timeout_ms as u64),
             move || {
@@ -325,13 +345,39 @@ impl NotificationToast {
         *self.timeout_source.borrow_mut() = Some(source_id);
     }
 
+    /// Hovering pauses the dismiss timer; leaving restarts it in full.
+    fn install_timeout_hover_controller(self: &Rc<Self>) {
+        let toast_for_enter = Rc::downgrade(self);
+        let toast_for_leave = Rc::downgrade(self);
+        let motion = EventControllerMotion::new();
+        motion.connect_enter(move |_, _, _| {
+            if let Some(toast) = toast_for_enter.upgrade() {
+                toast.pointer_hovered.set(true);
+                toast.pause_timeout();
+            }
+        });
+        motion.connect_leave(move |_| {
+            if let Some(toast) = toast_for_leave.upgrade() {
+                toast.pointer_hovered.set(false);
+                toast.restart_timeout();
+            }
+        });
+        self.window.add_controller(motion);
+    }
+
     fn build_content(
-        &self,
+        self: &Rc<Self>,
         notification: &Notification,
         on_dismiss: ToastCallback,
         on_action: ToastActionCallback,
     ) {
-        let outer = build_toast_content(notification, on_dismiss, on_action, &self.window);
+        let outer = build_toast_content(
+            notification,
+            on_dismiss,
+            on_action,
+            &self.window,
+            self.max_body_height,
+        );
         self.window.set_child(Some(&outer));
     }
 
@@ -404,6 +450,7 @@ fn build_toast_content(
     on_dismiss: ToastCallback,
     on_action: ToastActionCallback,
     close_window: &Window,
+    max_body_height: i32,
 ) -> GtkBox {
     let outer = GtkBox::new(Orientation::Vertical, 0);
     outer.add_css_class(notif::TOAST_CONTAINER);
@@ -428,7 +475,7 @@ fn build_toast_content(
 
     let has_default_action = notification.actions.iter().any(|(id, _)| id == "default");
 
-    let main_row = GtkBox::new(Orientation::Horizontal, 10);
+    let main_row = GtkBox::new(Orientation::Horizontal, 8);
 
     // App icon / avatar in a centered column
     let icon_container = GtkBox::new(Orientation::Vertical, 0);
@@ -452,7 +499,6 @@ fn build_toast_content(
     app_label.add_css_class(color::MUTED);
     app_label.set_xalign(0.0);
     app_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-    app_label.set_margin_bottom(4);
     content.append(&app_label);
 
     if !notification.summary.is_empty() {
@@ -464,18 +510,16 @@ fn build_toast_content(
         content.append(&summary_label);
     }
 
+    let mut body_expand_button = None;
     if !notification.body.is_empty() {
-        let body_markup = sanitize_body_markup(&notification.body);
-        let body_label = Label::new(None);
-        body_label.set_markup(&body_markup);
-        body_label.add_css_class(notif::TOAST_BODY);
-        body_label.add_css_class(color::MUTED);
-        body_label.set_xalign(0.0);
-        body_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-        body_label.set_lines(2);
-        body_label.set_wrap(true);
-        body_label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
-        content.append(&body_label);
+        let body = create_notification_body(
+            &notification.body,
+            notif::TOAST_BODY,
+            Some(max_body_height),
+            || {},
+        );
+        content.append(&body.root);
+        body_expand_button = Some(body.expand_button);
     }
 
     main_row.append(&content);
@@ -536,13 +580,35 @@ fn build_toast_content(
         .filter(|(id, _)| id != "default")
         .collect();
 
-    if !non_default_actions.is_empty() {
+    let has_expand = body_expand_button.is_some();
+
+    if has_expand || !non_default_actions.is_empty() {
         let actions_box = GtkBox::new(Orientation::Horizontal, 8);
+        actions_box.add_css_class(notif::ACTIONS);
         actions_box.add_css_class(notif::TOAST_ACTIONS);
-        actions_box.set_halign(Align::End);
+
+        if let Some(expand_btn) = body_expand_button {
+            expand_btn.add_css_class(notif::TOAST_ACTION);
+            expand_btn.set_focusable(false);
+            actions_box.append(&expand_btn);
+
+            if !non_default_actions.is_empty() {
+                let spacer = GtkBox::new(Orientation::Horizontal, 0);
+                spacer.set_hexpand(true);
+                actions_box.append(&spacer);
+            } else {
+                expand_btn
+                    .bind_property("visible", &actions_box, "visible")
+                    .sync_create()
+                    .build();
+            }
+        } else {
+            actions_box.set_halign(Align::End);
+        }
 
         for (action_id, action_label) in non_default_actions {
             let action_btn = crate::widgets::base::vp_button_with_label(action_label);
+            action_btn.add_css_class(notif::ACTION_BTN);
             action_btn.add_css_class(notif::TOAST_ACTION);
             action_btn.add_css_class(button::GHOST);
             action_btn.set_focusable(false);
@@ -618,6 +684,14 @@ impl NotificationToastManager {
         monitor: Option<&gdk::Monitor>,
         notification: &Notification,
     ) {
+        let existing = self.toasts.borrow().get(&notification.id).cloned();
+        if let Some(toast) = existing {
+            // A replaces_id update mutates the existing toast instead of stacking
+            // a second toast for the same notification.
+            toast.update(notification, Rc::clone(&self.on_action));
+            return;
+        }
+
         // Transient notifications are toast-only, so remove the service entry when the toast goes away.
         let manager = Rc::downgrade(self);
         let service = Rc::clone(&self.service);
@@ -636,19 +710,6 @@ impl NotificationToastManager {
                 manager.reposition_toasts();
             }
         });
-
-        let existing = self.toasts.borrow().get(&notification.id).cloned();
-        if let Some(toast) = existing {
-            // A replaces_id update mutates the existing toast instead of stacking
-            // a second toast for the same notification.
-            toast.update(
-                notification,
-                Rc::clone(&on_remove),
-                Rc::clone(&self.on_action),
-                on_height_measured,
-            );
-            return;
-        }
 
         // Calculate initial margin from existing toasts.
         // Each toast window includes shadow margins (sm on each side), making

--- a/crates/vibepanel/src/widgets/notifications_toast.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast.rs
@@ -399,9 +399,13 @@ impl NotificationToast {
     pub fn update_bar_margin(self: &Rc<Self>, target_margin: i32, animate: bool) {
         let current = self.current_bar_margin.get();
 
-        if !animate || current == target_margin {
+        if !animate {
+            self.cancel_animation();
             self.current_bar_margin.set(target_margin);
             self.window.set_margin(self.bar_edge, target_margin);
+            return;
+        }
+        if current == target_margin {
             return;
         }
 
@@ -516,6 +520,7 @@ fn build_toast_content(
             &notification.body,
             notif::TOAST_BODY,
             Some(max_body_height),
+            None,
             || {},
         );
         content.append(&body.root);
@@ -707,7 +712,9 @@ impl NotificationToastManager {
         let manager_for_height = Rc::downgrade(self);
         let on_height_measured: Rc<dyn Fn(u32)> = Rc::new(move |_id| {
             if let Some(manager) = manager_for_height.upgrade() {
-                manager.reposition_toasts();
+                // Height is already animated by the body Revealer. Track it
+                // directly instead of adding a second, lagging margin animation.
+                manager.reposition_toasts(false);
             }
         });
 
@@ -764,7 +771,7 @@ impl NotificationToastManager {
         self.toast_order
             .borrow_mut()
             .retain(|&id| id != notification_id);
-        self.reposition_toasts();
+        self.reposition_toasts(true);
     }
 
     pub fn close_toast(&self, notification_id: u32) {
@@ -776,17 +783,20 @@ impl NotificationToastManager {
         self.toast_order
             .borrow_mut()
             .retain(|&id| id != notification_id);
-        self.reposition_toasts();
+        self.reposition_toasts(true);
     }
 
-    fn reposition_toasts(&self) {
+    fn reposition_toasts(&self, animate: bool) {
         let order = self.toast_order.borrow();
         let toasts = self.toasts.borrow();
         let sm = toast_surface_margin();
         let mut y_offset = (TOAST_EDGE_MARGIN - sm).max(0);
         for &id in order.iter() {
             if let Some(toast) = toasts.get(&id) {
-                toast.update_bar_margin(y_offset, ConfigManager::global().animations_enabled());
+                toast.update_bar_margin(
+                    y_offset,
+                    animate && ConfigManager::global().animations_enabled(),
+                );
                 y_offset += (toast.height() - 2 * sm).max(0) + TOAST_GAP;
             }
         }

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -222,6 +222,7 @@ fn run_test_notification_toast_structure() {
 
     let mut config = Config::default();
     config.theme.mode = "dark".to_string();
+    config.theme.animations = false;
     ConfigManager::replace_global_for_test(config.clone());
     let _css_provider =
         CssProviderGuard::for_config(&config, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -312,7 +313,7 @@ fn run_test_notification_toast_structure() {
     flush_gtk();
 
     let blank_line_window = gtk4::Window::new();
-    let blank_line_body = create_notification_body("a\n\nb", notif::TOAST_BODY, None, || {});
+    let blank_line_body = create_notification_body("a\n\nb", notif::TOAST_BODY, None, None, || {});
     blank_line_window.set_child(Some(&blank_line_body.root));
     blank_line_window.present();
     flush_gtk();
@@ -338,6 +339,7 @@ fn run_test_notification_toast_structure() {
     let wrapped_body = create_notification_body(
         "Alertmanager notification could not be sent: message length exceeds Telegram limits.\n   Please check the template used for producing the message content.",
         notif::TOAST_BODY,
+        None,
         None,
         || {},
     );
@@ -366,6 +368,7 @@ fn run_test_notification_toast_structure() {
     let exact_body = create_notification_body(
         "This notification wraps across exactly two displayed lines.",
         notif::TOAST_BODY,
+        None,
         None,
         || {},
     );

--- a/crates/vibepanel/src/widgets/notifications_toast_tests.rs
+++ b/crates/vibepanel/src/widgets/notifications_toast_tests.rs
@@ -12,6 +12,24 @@ fn test_app() -> Application {
     registered_test_app("dev.vibepanel.toast-ui-regression")
 }
 
+fn mapped_body_labels(root: &gtk4::Widget, css_class: &str) -> Vec<Label> {
+    let mut labels = Vec::new();
+    if root.has_css_class(css_class)
+        && root.is_mapped()
+        && let Some(label) = root.downcast_ref::<Label>()
+    {
+        labels.push(label.clone());
+    }
+
+    let mut child = root.first_child();
+    while let Some(widget) = child {
+        labels.extend(mapped_body_labels(&widget, css_class));
+        child = widget.next_sibling();
+    }
+
+    labels
+}
+
 fn test_notification(urgency: u8) -> Notification {
     Notification {
         id: u32::from(urgency) + 1,
@@ -145,6 +163,16 @@ fn test_toast_horizontal_layout_contract() {
 }
 
 #[test]
+fn test_max_toast_body_height_uses_two_thirds_monitor() {
+    assert_eq!(max_toast_body_height(Some(1080)), 720);
+    assert_eq!(
+        max_toast_body_height(Some(0)),
+        TOAST_BODY_FALLBACK_MAX_HEIGHT
+    );
+    assert_eq!(max_toast_body_height(None), TOAST_BODY_FALLBACK_MAX_HEIGHT);
+}
+
+#[test]
 fn test_toast_surface_margin_independent_of_shadow_setting() {
     let mut config = Config::default();
     config.theme.shadows = false;
@@ -208,10 +236,18 @@ fn run_test_notification_toast_structure() {
         .default_width(220)
         .default_height(120)
         .build();
-    let notification = test_notification(URGENCY_CRITICAL);
+    let mut notification = test_notification(URGENCY_CRITICAL);
+    notification.body =
+        "First\n<a href=\"https://example.com\">linked preview</a>\nThird".to_string();
     let noop_dismiss: ToastCallback = Rc::new(|_| {});
     let noop_action: ToastActionCallback = Rc::new(|_, _| {});
-    let surface = build_toast_content(&notification, noop_dismiss, noop_action, &window);
+    let surface = build_toast_content(
+        &notification,
+        noop_dismiss,
+        noop_action,
+        &window,
+        TOAST_BODY_FALLBACK_MAX_HEIGHT,
+    );
     surface.set_size_request(180, 80);
     window.set_child(Some(&surface));
     window.present();
@@ -234,12 +270,150 @@ fn run_test_notification_toast_structure() {
         label_with_text(&child, "Toast summary"),
         "toast should render the notification summary"
     );
-    assert!(
-        label_with_text(&child, "Toast body"),
-        "toast should render the notification body"
+    let preview_labels = mapped_body_labels(&child, notif::TOAST_BODY);
+    assert_eq!(
+        preview_labels
+            .iter()
+            .map(|label| label.text().to_string())
+            .collect::<Vec<_>>(),
+        ["First", "linked preview"],
+        "collapsed body should preserve the first two physical lines"
+    );
+    assert!(preview_labels[1].label().contains("<a href="));
+
+    let expand_button = find_descendant_with_class(&child, notif::ACTION_BTN)
+        .expect("a body longer than two lines should offer an expand action")
+        .downcast::<Button>()
+        .expect("expand action should be a button");
+
+    expand_button.emit_clicked();
+    flush_gtk();
+
+    assert!(label_with_text(&child, "Show less"));
+    assert_eq!(
+        mapped_body_labels(&child, notif::TOAST_BODY)[0].text(),
+        "First\nlinked preview\nThird",
+        "expanded body should render the complete body text"
+    );
+
+    expand_button.emit_clicked();
+    flush_gtk();
+
+    assert_eq!(
+        mapped_body_labels(&child, notif::TOAST_BODY)
+            .iter()
+            .map(|label| label.text().to_string())
+            .collect::<Vec<_>>(),
+        ["First", "linked preview"],
+        "collapsing should restore the two-line preview"
     );
 
     window.close();
+    flush_gtk();
+
+    let blank_line_window = gtk4::Window::new();
+    let blank_line_body = create_notification_body("a\n\nb", notif::TOAST_BODY, None, || {});
+    blank_line_window.set_child(Some(&blank_line_body.root));
+    blank_line_window.present();
+    flush_gtk();
+
+    let blank_line_labels = mapped_body_labels(
+        &blank_line_window
+            .child()
+            .expect("blank-line preview should be attached"),
+        notif::TOAST_BODY,
+    );
+    assert_eq!(blank_line_labels.len(), 2);
+    assert_eq!(blank_line_labels[0].text(), "a");
+    assert_eq!(blank_line_labels[1].text(), "\u{2060}");
+    assert!(blank_line_labels[1].height() > 0);
+
+    blank_line_window.close();
+    flush_gtk();
+
+    let wrapped_window = gtk4::Window::builder()
+        .default_width(220)
+        .resizable(false)
+        .build();
+    let wrapped_body = create_notification_body(
+        "Alertmanager notification could not be sent: message length exceeds Telegram limits.\n   Please check the template used for producing the message content.",
+        notif::TOAST_BODY,
+        None,
+        || {},
+    );
+    wrapped_window.set_child(Some(&wrapped_body.root));
+    wrapped_window.present();
+    flush_gtk();
+
+    let wrapped_labels = mapped_body_labels(
+        &wrapped_window
+            .child()
+            .expect("wrapped preview should be attached"),
+        notif::TOAST_BODY,
+    );
+    assert_eq!(wrapped_labels.len(), 1);
+    assert_eq!(wrapped_labels[0].layout().line_count(), 2);
+    assert!(wrapped_labels[0].layout().is_ellipsized());
+    assert!(wrapped_body.expand_button.is_visible());
+
+    wrapped_window.close();
+    flush_gtk();
+
+    let exact_window = gtk4::Window::builder()
+        .default_width(220)
+        .resizable(false)
+        .build();
+    let exact_body = create_notification_body(
+        "This notification wraps across exactly two displayed lines.",
+        notif::TOAST_BODY,
+        None,
+        || {},
+    );
+    exact_window.set_child(Some(&exact_body.root));
+    exact_window.present();
+    flush_gtk();
+
+    let exact_labels = mapped_body_labels(
+        &exact_window
+            .child()
+            .expect("exact two-line preview should be attached"),
+        notif::TOAST_BODY,
+    );
+    assert_eq!(exact_labels.len(), 1);
+    assert_eq!(exact_labels[0].layout().line_count(), 2);
+    assert!(!exact_labels[0].layout().is_ellipsized());
+    assert!(!exact_body.expand_button.is_visible());
+
+    exact_window.close();
+    flush_gtk();
+
+    let linked_window = gtk4::Window::builder()
+        .default_width(POPOVER_WIDTH)
+        .resizable(false)
+        .build();
+    let mut linked_notification = test_notification(URGENCY_CRITICAL);
+    linked_notification.body = "<a href=\"https://example.com\">the full report with enough additional text to exceed the notification preview threshold and require expansion</a>".to_string();
+    let linked_surface = build_toast_content(
+        &linked_notification,
+        Rc::new(|_| {}),
+        Rc::new(|_, _| {}),
+        &linked_window,
+        TOAST_BODY_FALLBACK_MAX_HEIGHT,
+    );
+    linked_window.set_child(Some(&linked_surface));
+    linked_window.present();
+    flush_gtk();
+
+    let linked_child = linked_window
+        .child()
+        .expect("linked toast should be attached");
+    let linked_labels = mapped_body_labels(&linked_child, notif::TOAST_BODY);
+    assert!(linked_labels[0].layout().is_ellipsized());
+    let linked_expand = find_descendant_with_class(&linked_child, notif::ACTION_BTN)
+        .expect("ellipsized linked body should offer an expand action");
+    assert!(linked_expand.is_visible());
+
+    linked_window.close();
     flush_gtk();
 }
 
@@ -292,7 +466,13 @@ fn toast_surface_fixture(
     let notification = blank_notification();
     let noop_dismiss: ToastCallback = Rc::new(|_| {});
     let noop_action: ToastActionCallback = Rc::new(|_, _| {});
-    let surface = build_toast_content(&notification, noop_dismiss, noop_action, &window);
+    let surface = build_toast_content(
+        &notification,
+        noop_dismiss,
+        noop_action,
+        &window,
+        TOAST_BODY_FALLBACK_MAX_HEIGHT,
+    );
     surface.set_size_request(180, 80);
     window.set_child(Some(&surface));
     window.present();


### PR DESCRIPTION
Truncates body and adds a "show more" button to notification toats when the body exceeds two lines. Also updates timeout logic so notifications pause while hovered.

Closes #212.